### PR TITLE
Add pop and append

### DIFF
--- a/vyperAstScript.sml
+++ b/vyperAstScript.sml
@@ -105,11 +105,9 @@ Datatype:
   | Attribute expr identifier
   | Builtin builtin (expr list)
   | Empty type
+  | Pop base_assignment_target
   | Call call_target (expr list)
-End
-
-Datatype:
-  base_assignment_target
+; base_assignment_target
   = NameTarget identifier
   | TopLevelNameTarget identifier
   | SubscriptTarget base_assignment_target expr
@@ -146,6 +144,7 @@ Datatype:
   | Return (expr option)
   | Assign assignment_target expr
   | AugAssign base_assignment_target binop expr
+  | Append base_assignment_target expr
   | AnnAssign identifier type expr
 End
 

--- a/vyperTestScript.sml
+++ b/vyperTestScript.sml
@@ -948,6 +948,120 @@ Proof
   \\ rw[]
 QED
 
+Definition test_darray_append_ast_def:
+  test_darray_append_ast = [
+    pubvar "a" (DynArray uint256 10);
+    def "foo" [] uint256 [
+      AssignSelf "a" (DynArlit 10 []);
+      Append (TopLevelNameTarget "a") (li 1);
+      Return $ SOME (Subscript (self_ "a") (li 0))
+    ]
+  ]
+End
+
+val () = cv_trans_deep_embedding EVAL test_darray_append_ast_def;
+
+Theorem test_darray_append:
+  load_and_call_foo test_darray_append_ast
+  = INL (IntV 1)
+Proof
+  CONV_TAC cv_eval
+QED
+
+(* TODO
+def test_darray_append2(get_contract):
+    src = """
+a: public(DynArray[uint256, 1])
+
+@external
+def foo() -> uint256:
+    self.a = []
+    self.a.append(1)
+    self.a.append(1)
+    return self.a[0]
+    """
+
+    c = get_contract(src)
+    with pytest.raises(ValueError) as e:
+        c.foo()
+
+    assert "Cannot exceed maximum length 1" in str(e.value)
+
+
+def test_darray_append3(get_contract):
+    src = """
+a: public(DynArray[DynArray[uint256, 1], 2])
+
+@external
+def foo() -> DynArray[uint256, 10]:
+    self.a = []
+    self.a.append([1])
+    self.a.append([2])
+    return self.a[0]
+    """
+
+    c = get_contract(src)
+    assert c.foo() == [1]
+
+
+def test_darray_pop(get_contract):
+    src = """
+a: public(DynArray[DynArray[uint256, 1], 2])
+
+def bar() -> DynArray[uint256, 1]:
+    return []
+
+@external
+def foo() -> uint256:
+    self.a = []
+    self.a.append([1])
+    u: uint256 = self.a.pop()[0]
+    return u
+    """
+
+    c = get_contract(src)
+    assert c.foo() == 1
+
+
+def test_darray_pop2(get_contract):
+    src = """
+a: public(DynArray[DynArray[uint256, 1], 2])
+
+def bar() -> DynArray[uint256, 1]:
+    return []
+
+@external
+def foo() -> uint256:
+    self.a = []
+    self.a.append([1])
+    u: DynArray[uint256, 10] = self.a.pop()
+    return u.pop()
+    """
+
+    c = get_contract(src)
+    assert c.foo() == 1
+
+
+def test_darray_pop3(get_contract):
+    src = """
+a: public(DynArray[DynArray[uint256, 1], 2])
+
+def bar() -> DynArray[uint256, 1]:
+    return []
+
+@external
+def foo() -> uint256:
+    self.a = []
+    self.a.append([1])
+    self.a.append([2])
+    u: DynArray[uint256, 10] = self.a.pop()
+    return u.pop() + self.a.pop()[0]
+    """
+
+    c = get_contract(src)
+    assert c.foo() == 3
+*)
+
 (* TODO add tests
 
 def test_external_func_arg2():


### PR DESCRIPTION
Using the syntactic restriction to assignment targets rather than other approaches involving explicit pointers, since Vyper arrays are always copied anyway.