### PR TITLE
Update inst.output to inst.outputs to match Venom IR

### DIFF
--- a/venom/passes/phi_elimination/dfgOriginsScript.sml
+++ b/venom/passes/phi_elimination/dfgOriginsScript.sml
@@ -301,10 +301,10 @@ Definition phi_operands_direct_def:
     case phi_single_origin dfg inst of
       NONE => T
     | SOME origin =>
-        case origin.inst_output of
-          NONE => T
-        | SOME src_var =>
+        case origin.inst_outputs of
+          [src_var] =>
             EVERY (\v. v = src_var) (phi_var_operands inst.inst_operands)
+        | _ => T
 End
 
 (* Helper: Origins come from DFG lookups (or are the instruction itself) *)
@@ -366,8 +366,8 @@ Proof
   drule CHOICE_DEF >> strip_tac >> fs[IN_DELETE] >>
   (* Get FLOOKUP dfg v' = SOME origin *)
   drule_all compute_origins_non_self_in_dfg >> strip_tac >>
-  (* Get origin.inst_output = SOME v' *)
-  `origin.inst_output = SOME v'` by fs[well_formed_dfg_def] >>
+  (* Get origin.inst_outputs = [v'] *)
+  `origin.inst_outputs = [v']` by fs[well_formed_dfg_def] >>
   (* Get MEM v (phi_var_operands) *)
   drule_all resolve_phi_in_operands >> strip_tac >>
   (* Unfold phi_operands_direct and use EVERY_MEM to get v = v' *)

--- a/venom/passes/phi_elimination/phiTransformScript.sml
+++ b/venom/passes/phi_elimination/phiTransformScript.sml
@@ -39,13 +39,13 @@ Definition transform_inst_def:
   transform_inst dfg inst =
     case phi_single_origin dfg inst of
       SOME origin =>
-        (case origin.inst_output of
-           SOME src_var =>
+        (case origin.inst_outputs of
+           [src_var] =>
              inst with <|
                inst_opcode := ASSIGN;
                inst_operands := [Var src_var]
              |>
-         | NONE => inst)
+         | _ => inst)
     | NONE => inst
 End
 
@@ -147,7 +147,8 @@ Theorem transform_inst_preserves_terminator:
 Proof
   rw[transform_inst_def] >>
   Cases_on `phi_single_origin dfg inst` >> simp[] >>
-  Cases_on `x.inst_output` >> simp[is_terminator_def] >>
+  Cases_on `x.inst_outputs` >> simp[is_terminator_def] >>
+  Cases_on `t` >> simp[is_terminator_def] >>
   fs[phi_single_origin_def] >>
   Cases_on `is_phi_inst inst` >> fs[is_phi_inst_def, is_terminator_def]
 QED

--- a/venom/venomInstScript.sml
+++ b/venom/venomInstScript.sml
@@ -69,7 +69,10 @@ End
    - id: unique identifier (models object identity from Python)
    - opcode: the operation to perform
    - operands: list of input operands (rightmost = top of conceptual stack)
-   - output: optional output variable name (SSA)
+   - outputs: list of output variable names (SSA)
+
+   Most instructions have 0 or 1 output. The invoke opcode can have multiple
+   outputs for multi-return internal function calls.
 
    The inst_id is used to distinguish instructions that may have identical
    fields but are different objects. This is important for passes that
@@ -81,18 +84,31 @@ Datatype:
     inst_id : num;
     inst_opcode : opcode;
     inst_operands : operand list;
-    inst_output : string option
+    inst_outputs : string list
   |>
 End
 
 (* Construct an instruction with a given ID *)
 Definition mk_inst_def:
-  mk_inst id op ops out = <|
+  mk_inst id op ops outs = <|
     inst_id := id;
     inst_opcode := op;
     inst_operands := ops;
-    inst_output := out
+    inst_outputs := outs
   |>
+End
+
+(* Helper: get single output (for instructions with exactly one output) *)
+Definition inst_output_def:
+  inst_output inst =
+    case inst.inst_outputs of
+      [out] => SOME out
+    | _ => NONE
+End
+
+(* Helper: check if instruction has outputs *)
+Definition has_outputs_def:
+  has_outputs inst = ~NULL inst.inst_outputs
 End
 
 (* --------------------------------------------------------------------------

--- a/venom/venomSemScript.sml
+++ b/venom/venomSemScript.sml
@@ -184,9 +184,9 @@ Definition exec_binop_def:
       [op1; op2] =>
         (case (eval_operand op1 s, eval_operand op2 s) of
           (SOME v1, SOME v2) =>
-            (case inst.inst_output of
-              SOME out => OK (update_var out (f v1 v2) s)
-            | NONE => Error "binop requires output")
+            (case inst.inst_outputs of
+              [out] => OK (update_var out (f v1 v2) s)
+            | _ => Error "binop requires single output")
         | _ => Error "undefined operand")
     | _ => Error "binop requires 2 operands"
 End
@@ -198,9 +198,9 @@ Definition exec_unop_def:
       [op1] =>
         (case eval_operand op1 s of
           SOME v =>
-            (case inst.inst_output of
-              SOME out => OK (update_var out (f v) s)
-            | NONE => Error "unop requires output")
+            (case inst.inst_outputs of
+              [out] => OK (update_var out (f v) s)
+            | _ => Error "unop requires single output")
         | NONE => Error "undefined operand")
     | _ => Error "unop requires 1 operand"
 End
@@ -212,9 +212,9 @@ Definition exec_modop_def:
       [op1; op2; op3] =>
         (case (eval_operand op1 s, eval_operand op2 s, eval_operand op3 s) of
           (SOME v1, SOME v2, SOME v3) =>
-            (case inst.inst_output of
-              SOME out => OK (update_var out (f v1 v2 v3) s)
-            | NONE => Error "modop requires output")
+            (case inst.inst_outputs of
+              [out] => OK (update_var out (f v1 v2 v3) s)
+            | _ => Error "modop requires single output")
         | _ => Error "undefined operand")
     | _ => Error "modop requires 3 operands"
 End
@@ -257,9 +257,9 @@ Definition step_inst_def:
           [op1] =>
             (case eval_operand op1 s of
               SOME addr =>
-                (case inst.inst_output of
-                  SOME out => OK (update_var out (mload (w2n addr) s) s)
-                | NONE => Error "mload requires output")
+                (case inst.inst_outputs of
+                  [out] => OK (update_var out (mload (w2n addr) s) s)
+                | _ => Error "mload requires single output")
             | NONE => Error "undefined operand")
         | _ => Error "mload requires 1 operand")
 
@@ -277,9 +277,9 @@ Definition step_inst_def:
           [op1] =>
             (case eval_operand op1 s of
               SOME key =>
-                (case inst.inst_output of
-                  SOME out => OK (update_var out (sload key s) s)
-                | NONE => Error "sload requires output")
+                (case inst.inst_outputs of
+                  [out] => OK (update_var out (sload key s) s)
+                | _ => Error "sload requires single output")
             | NONE => Error "undefined operand")
         | _ => Error "sload requires 1 operand")
 
@@ -297,9 +297,9 @@ Definition step_inst_def:
           [op1] =>
             (case eval_operand op1 s of
               SOME key =>
-                (case inst.inst_output of
-                  SOME out => OK (update_var out (tload key s) s)
-                | NONE => Error "tload requires output")
+                (case inst.inst_outputs of
+                  [out] => OK (update_var out (tload key s) s)
+                | _ => Error "tload requires single output")
             | NONE => Error "undefined operand")
         | _ => Error "tload requires 1 operand")
 
@@ -336,8 +336,8 @@ Definition step_inst_def:
 
     (* SSA - PHI node *)
     | PHI =>
-        (case inst.inst_output of
-          SOME out =>
+        (case inst.inst_outputs of
+          [out] =>
             (case s.vs_prev_bb of
               NONE => Error "phi at entry block"
             | SOME prev =>
@@ -347,16 +347,16 @@ Definition step_inst_def:
                     (case eval_operand val_op s of
                       SOME v => OK (update_var out v s)
                     | NONE => Error "phi: undefined operand")))
-        | NONE => Error "phi requires output")
+        | _ => Error "phi requires single output")
 
     (* SSA - ASSIGN *)
     | ASSIGN =>
-        (case (inst.inst_operands, inst.inst_output) of
-          ([op1], SOME out) =>
+        (case (inst.inst_operands, inst.inst_outputs) of
+          ([op1], [out]) =>
             (case eval_operand op1 s of
               SOME v => OK (update_var out v s)
             | NONE => Error "undefined operand")
-        | _ => Error "assign requires 1 operand and output")
+        | _ => Error "assign requires 1 operand and single output")
 
     (* NOP *)
     | NOP => OK s


### PR DESCRIPTION
## Summary
- Align HOL4 semantics with recent Venom IR changes in Vyper compiler where instruction outputs changed from single optional to a list
- Update all affected theory files (venomInst, venomSem, dfgDefs, dfgOrigins, phiTransform, phiBlock, execEquiv, phiWellFormed)
- Fix transform_block_result_equiv proof with improved tactic structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)