### PR TITLE
CI: Parallelize Vyper tests across 10 runners with build caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: hol-build
+      - name: Fix artifact timestamps
+        run: find . -path '*/.hol/*' -type f -exec touch {} +
       - name: Restore Vyper test exports
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
## Summary
- Split `export-vyper-tests` into separate job that runs parallel with `build`
- Add run-scoped cache (`build-{run_id}-{attempt}`) to share `.hol/` build outputs between jobs
- Use matrix strategy to split ~87 tests across 10 parallel runners
- Separate system prompts for Claude and Codex agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)