### PR TITLE
Import contract bytecode from test JSON into accounts

### DIFF
--- a/tests/vyperTestLib.sml
+++ b/tests/vyperTestLib.sml
@@ -436,7 +436,7 @@ val deployment : term decoder =
   check (field "source_code" string)
         (fn src => not (has_unsupported_patterns src))
         "has unsupported_pattern" $
-  JSONDecode.map (fn ((c,(i,h,bh),(s,m,a,g),(d,bn,bf,v)),e) =>
+  JSONDecode.map (fn (((c,(i,h,bh),(s,m,a,g),(d,bn,bf,v)),e),bc) =>
              TypeBase.mk_record (deployment_trace_ty, [
                ("sourceAst", c),
                ("contractAbi", mk_list(i, abi_entry_ty)),
@@ -450,9 +450,10 @@ val deployment : term decoder =
                ("blobHashes", bh),
                ("blobBaseFee", bf),
                ("gasPrice", g),
-               ("callData", d)
+               ("callData", d),
+               ("runtimeBytecode", bc)
              ]))
-          (tuple2 (tuple4 (toplevels_via_jsonast,
+          (tuple2 (tuple2 (tuple4 (toplevels_via_jsonast,
                            tuple3 (
                              field "contract_abi" (array abiEntry),
                              field "env" $ field "block" $
@@ -469,7 +470,8 @@ val deployment : term decoder =
                                    field "env" $ field "block" $ field "number" numtm,
                                    field "env" $ field "block" $ field "blob_basefee" numtm,
                                    field "value" numtm)),
-                   field "deployment_succeeded" booltm))
+                   field "deployment_succeeded" booltm),
+                  field "runtime_bytecode" bytes))
 
 val trace : term decoder =
   achoose "trace" [


### PR DESCRIPTION
Parse runtime_bytecode from deployment traces and store it in accounts[deployedAddress].code after successful deployment.

This enables external calls to work via verifereum, since the callee's code is now available in the account state.

Fixes #71