### PR TITLE
Fix flag member translation to use FlagMember instead of Attribute

### DIFF
--- a/frontend/jsonASTLib.sig
+++ b/frontend/jsonASTLib.sig
@@ -124,7 +124,7 @@ signature jsonASTLib = sig
   val mk_JE_Hex : string -> term
   val mk_JE_Bool : bool -> term
   val mk_JE_Name : string * string option * term -> term
-  val mk_JE_Attribute : term * string -> term
+  val mk_JE_Attribute : term * string * string option * term -> term
   val mk_JE_Subscript : term * term -> term
   val mk_JE_BinOp : term * term * term -> term
   val mk_JE_BoolOp : term * term list -> term

--- a/frontend/jsonASTScript.sml
+++ b/frontend/jsonASTScript.sml
@@ -76,7 +76,7 @@ Datatype:
 
   (* Variables and access *)
   | JE_Name string (string option) (num option)        (* id, typeclass, source_id for modules *)
-  | JE_Attribute json_expr string                      (* value, attr *)
+  | JE_Attribute json_expr string (string option) (num option)  (* value, attr, result_typeclass, source_id *)
   | JE_Subscript json_expr json_expr                   (* value, slice *)
 
   (* Operators *)

--- a/semantics/vyperInterpreterScript.sml
+++ b/semantics/vyperInterpreterScript.sml
@@ -3030,13 +3030,7 @@ Definition initial_immutables_def:
    let key = string_to_num id in
    let iv = force_default_value env typ in
      update_immutable NONE key iv imms) ∧
-  (* TODO: prevent flag value being updated even in constructor *)
-  initial_immutables env (FlagDecl id ls :: ts) =
-  (let imms = initial_immutables env ts in
-   let key = string_to_num id in
-   let iv = flag_value (LENGTH ls) 1 [] ls in
-     update_immutable NONE key iv imms) ∧
-  (* TODO: handle Constants? or ignore since assuming folded into AST *)
+  (* Flags are accessed via FlagMember and lookup_flag_mem, not immutables *)
   (* HashMaps are not stored in immutables - they're constructed on-the-fly in lookup_global *)
   initial_immutables env (t :: ts) = initial_immutables env ts
 End


### PR DESCRIPTION
Previously, flag member access like `Action.BUY` was translated to `Attribute (Name "Action") "BUY"`. This worked for same-module flags because FlagDecl was stored in immutables as a struct, but failed for cross-module flags like `lib1.Action.BUY` which couldn't find the flag in the imported module's immutables.

The proper mechanism already exists: `FlagMember (src_id_opt, flag_name) member` which uses `lookup_flag_mem` to look up the FlagDecl in the appropriate module and compute the flag value.

Changes:
- jsonASTScript.sml: Add result typeclass and source_id to JE_Attribute constructor (now has 4 arguments: expr, attr, typeclass, source_id)
- jsonASTLib.sml: Extract type.typeclass and type.type_decl_node.source_id when parsing Attribute nodes; add source_id_opt_tm decoder helper and mk_num_from_largeint to reduce duplication
- jsonASTLib.sig: Update mk_JE_Attribute signature
- jsonToVyperScript.sml: Generate FlagMember for flag access patterns:
  - Same-module: Action.BUY (JE_Name with tc = SOME "flag")
  - Cross-module: lib1.Action.BUY (module chain with source_id)
  - Nested modules: lib1.lib2.Roles3.NOBODY (finds innermost module's source_id)
- vyperInterpreterScript.sml: Remove FlagDecl case from initial_immutables since flags are now accessed via lookup_flag_mem

This was motivated by test_access_flag_from_another_module which was failing with "lookup_global: var not found".