### PR TITLE
DRAFT: Enable modules on tests which makes sqrt technically working

### DIFF
--- a/tests/vyperTestLib.sml
+++ b/tests/vyperTestLib.sml
@@ -274,22 +274,8 @@ fun has_default_arg src =
     has_default_from 0
   end
 
-fun has_sqrt_call src =
-  let
-    val n = String.size src
-    fun loop i =
-      if i + 5 > n then false
-      else if String.substring (src, i, 5) = "sqrt(" andalso
-              (i = 0 orelse String.sub (src, i - 1) <> #"i")
-           then true
-           else loop (i + 1)
-  in
-    loop 0
-  end
-
 fun has_unsupported_patterns src =
   has_default_arg src orelse
-  has_sqrt_call src orelse
   List.exists (fn x => String.isSubstring x src) unsupported_patterns
 
 fun is_blank s =


### PR DESCRIPTION
We are not adding sqrt as a builtin to vyper-hol anymore since that approach was deprecated in vyper in favor for sqrt being a method on the math module.

So this PR just does a few changes to the frontend to ensure we work with negative source ids, which are the ones used by modules in the standard library, which in turn makes the sqrt tests pass, without working on anything directly related to sqrt.

Though apparently #99 works on something to the same extent so this could possibly be needless anymore. Just up for review so we can make sure.