### PR TITLE
refactor phi elimination to use shared dfg analysis

### DIFF
--- a/Holmakefile
+++ b/Holmakefile
@@ -1,4 +1,4 @@
 # Root Holmakefile - builds all theories including test infrastructure
 INCLUDES = $(HOLDIR)/examples/Crypto/Keccak $(VFMDIR)/util $(VFMDIR)/spec \
            syntax frontend semantics semantics/prop hoare hoare/examples tests \
-           venom venom/passes/phi_elimination venom/passes/revert_to_assert
+           venom venom/analysis venom/passes/phi_elimination venom/passes/revert_to_assert

--- a/venom/analysis/Holmakefile
+++ b/venom/analysis/Holmakefile
@@ -1,0 +1,2 @@
+# Venom analysis passes
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec .. ../../syntax ../../semantics

--- a/venom/analysis/dfgAnalysisCorrectnessScript.sml
+++ b/venom/analysis/dfgAnalysisCorrectnessScript.sml
@@ -1,0 +1,210 @@
+(*
+ * DFG Analysis Correctness
+ *
+ * Proof-oriented lemmas over shared dfgAnalysis definitions.
+ * This file provides reusable correctness infrastructure for passes that
+ * consume the shared DFG.
+ *)
+
+Theory dfgAnalysisCorrectness
+Ancestors
+  dfgAnalysis list finite_map pred_set
+
+(* --------------------------------------------------------------------------
+   Bridge-level predicates
+   -------------------------------------------------------------------------- *)
+
+Definition well_formed_dfg_def:
+  well_formed_dfg dfg <=>
+    !v inst. dfg_get_def dfg v = SOME inst ==> MEM v inst.inst_outputs
+End
+
+Definition dfg_def_ids_def:
+  dfg_def_ids dfg = IMAGE (\inst. inst.inst_id) (FRANGE dfg.dfg_defs)
+End
+
+(* --------------------------------------------------------------------------
+   Well-formedness preservation
+   -------------------------------------------------------------------------- *)
+
+Theorem well_formed_dfg_update:
+  !dfg inst v.
+    well_formed_dfg dfg /\ MEM v inst.inst_outputs
+    ==> well_formed_dfg (dfg with dfg_defs := dfg.dfg_defs |+ (v, inst))
+Proof
+  rw[well_formed_dfg_def, dfg_get_def_def, FLOOKUP_UPDATE] >>
+  Cases_on `v' = v` >> fs[]
+QED
+
+Theorem dfg_add_defs_well_formed:
+  !dfg vs inst.
+    well_formed_dfg dfg /\ EVERY (\v. MEM v inst.inst_outputs) vs
+    ==> well_formed_dfg (dfg_add_defs dfg vs inst)
+Proof
+  Induct_on `vs` >> rw[dfg_add_defs_def] >>
+  first_x_assum match_mp_tac >>
+  conj_tac >- (
+    match_mp_tac well_formed_dfg_update >>
+    simp[]
+  ) >>
+  simp[]
+QED
+
+Theorem dfg_add_use_get_def:
+  !dfg v inst u.
+    dfg_get_def (dfg_add_use dfg u inst) v = dfg_get_def dfg v
+Proof
+  rw[dfg_add_use_def, dfg_get_def_def]
+QED
+
+Theorem dfg_add_uses_get_def:
+  !dfg vs inst v.
+    dfg_get_def (dfg_add_uses dfg vs inst) v = dfg_get_def dfg v
+Proof
+  Induct_on `vs` >> rw[dfg_add_uses_def] >>
+  rw[dfg_add_use_get_def]
+QED
+
+Theorem dfg_add_uses_preserve_wf:
+  !dfg vs inst.
+    well_formed_dfg dfg ==> well_formed_dfg (dfg_add_uses dfg vs inst)
+Proof
+  rw[well_formed_dfg_def] >>
+  qpat_x_assum `dfg_get_def (dfg_add_uses dfg vs inst) v = SOME inst'` mp_tac >>
+  simp[dfg_add_uses_get_def] >>
+  metis_tac[well_formed_dfg_def]
+QED
+
+Theorem well_formed_dfg_update_ids:
+  !dfg ids. well_formed_dfg dfg ==> well_formed_dfg (dfg with dfg_ids := ids)
+Proof
+  rw[well_formed_dfg_def, dfg_get_def_def]
+QED
+
+Theorem dfg_add_inst_well_formed:
+  !dfg inst.
+    well_formed_dfg dfg ==> well_formed_dfg (dfg_add_inst dfg inst)
+Proof
+  rw[dfg_add_inst_def] >>
+  match_mp_tac well_formed_dfg_update_ids >>
+  match_mp_tac dfg_add_defs_well_formed >>
+  conj_tac >- (
+    match_mp_tac dfg_add_uses_preserve_wf >>
+    simp[]
+  ) >>
+  simp[EVERY_MEM]
+QED
+
+Theorem dfg_build_insts_rev_well_formed:
+  !dfg insts.
+    well_formed_dfg dfg ==> well_formed_dfg (dfg_build_insts_rev dfg insts)
+Proof
+  Induct_on `insts` >> rw[dfg_build_insts_rev_def] >>
+  first_x_assum match_mp_tac >>
+  metis_tac[dfg_add_inst_well_formed]
+QED
+
+Theorem dfg_build_insts_well_formed:
+  !insts. well_formed_dfg (dfg_build_insts insts)
+Proof
+  rw[dfg_build_insts_def, dfg_empty_def] >>
+  match_mp_tac dfg_build_insts_rev_well_formed >>
+  rw[well_formed_dfg_def, dfg_get_def_def, dfg_empty_def]
+QED
+
+Theorem dfg_build_function_well_formed:
+  !fn. well_formed_dfg (dfg_build_function fn)
+Proof
+  rw[dfg_build_function_def, dfg_build_insts_well_formed]
+QED
+
+(* --------------------------------------------------------------------------
+   Def-source correctness
+   -------------------------------------------------------------------------- *)
+
+Theorem dfg_add_defs_lookup:
+  !dfg vs inst v inst'.
+    dfg_get_def (dfg_add_defs dfg vs inst) v = SOME inst' ==>
+    dfg_get_def dfg v = SOME inst' \/ (inst' = inst /\ MEM v vs)
+Proof
+  Induct_on `vs` >> rw[dfg_add_defs_def] >>
+  first_x_assum (qspecl_then [`dfg with dfg_defs := dfg.dfg_defs |+ (h,inst)`,
+                              `inst`, `v`, `inst'`] mp_tac) >>
+  simp[dfg_get_def_def, FLOOKUP_UPDATE] >>
+  Cases_on `h = v` >> fs[] >>
+  metis_tac[]
+QED
+
+Theorem dfg_add_inst_get_def:
+  !dfg inst0 v.
+    dfg_get_def (dfg_add_inst dfg inst0) v =
+    dfg_get_def
+      (dfg_add_defs
+         (dfg_add_uses dfg (operand_vars inst0.inst_operands) inst0)
+         inst0.inst_outputs inst0) v
+Proof
+  rw[dfg_add_inst_def, dfg_get_def_def]
+QED
+
+Theorem dfg_add_inst_lookup:
+  !dfg inst0 v inst.
+    dfg_get_def (dfg_add_inst dfg inst0) v = SOME inst ==>
+    dfg_get_def dfg v = SOME inst \/ (inst = inst0 /\ MEM v inst0.inst_outputs)
+Proof
+  metis_tac[dfg_add_inst_get_def, dfg_add_defs_lookup, dfg_add_uses_get_def]
+QED
+
+Theorem dfg_build_insts_rev_correct:
+  !insts dfg v inst.
+    dfg_get_def (dfg_build_insts_rev dfg insts) v = SOME inst ==>
+    dfg_get_def dfg v = SOME inst \/
+    (MEM inst insts /\ MEM v inst.inst_outputs)
+Proof
+  Induct_on `insts` >> rw[dfg_build_insts_rev_def] >>
+  first_x_assum drule >>
+  disch_then strip_assume_tac >- (
+    drule dfg_add_inst_lookup >> simp[] >>
+    strip_tac >> metis_tac[]
+  ) >>
+  metis_tac[]
+QED
+
+Theorem dfg_build_insts_correct:
+  !insts v inst.
+    dfg_get_def (dfg_build_insts insts) v = SOME inst ==>
+    MEM inst insts /\ MEM v inst.inst_outputs
+Proof
+  rw[dfg_build_insts_def] >>
+  drule (Q.SPECL [`REVERSE insts`, `dfg_empty`, `v`, `inst`] dfg_build_insts_rev_correct) >>
+  simp[dfg_get_def_def, dfg_empty_def] >>
+  metis_tac[MEM_REVERSE]
+QED
+
+Theorem dfg_build_function_correct:
+  !fn v inst.
+    dfg_get_def (dfg_build_function fn) v = SOME inst
+    ==>
+    MEM v inst.inst_outputs /\ MEM inst (fn_insts fn)
+Proof
+  rw[dfg_build_function_def] >>
+  drule dfg_build_insts_correct >>
+  simp[]
+QED
+
+(* --------------------------------------------------------------------------
+   Finiteness/termination helpers
+   -------------------------------------------------------------------------- *)
+
+Theorem dfg_def_ids_finite:
+  !dfg. FINITE (dfg_def_ids dfg)
+Proof
+  rw[dfg_def_ids_def, IMAGE_FINITE, FINITE_FRANGE]
+QED
+
+Theorem dfg_get_def_implies_dfg_def_ids:
+  !dfg v inst. dfg_get_def dfg v = SOME inst ==> inst.inst_id IN dfg_def_ids dfg
+Proof
+  metis_tac[dfg_def_ids_def, IN_IMAGE, IN_FRANGE_FLOOKUP, dfg_get_def_def]
+QED
+
+val _ = export_theory();

--- a/venom/analysis/dfgAnalysisScript.sml
+++ b/venom/analysis/dfgAnalysisScript.sml
@@ -1,0 +1,149 @@
+(*
+ * Data-Flow Graph Analysis
+ *
+ * Reusable DFG helpers for Venom passes.
+ * Tracks:
+ *  - Uses: variable -> instructions that read it (in program order)
+ *  - Defs: variable -> producing instruction
+ *  - IDs: instruction id -> instruction
+ *)
+
+Theory dfgAnalysis
+Ancestors
+  list finite_map
+  venomState venomInst
+
+(* ==========================================================================
+   Core DFG Type
+   ========================================================================== *)
+
+Datatype:
+  dfg_analysis = <|
+    dfg_uses : (string, instruction list) fmap;
+    dfg_defs : (string, instruction) fmap;
+    dfg_ids : (num, instruction) fmap
+  |>
+End
+
+Definition dfg_empty_def:
+  dfg_empty = <| dfg_uses := FEMPTY; dfg_defs := FEMPTY; dfg_ids := FEMPTY |>
+End
+
+Definition dfg_get_uses_def:
+  dfg_get_uses dfg v =
+    case FLOOKUP dfg.dfg_uses v of
+      NONE => []
+    | SOME uses => uses
+End
+
+Definition dfg_get_def_def:
+  dfg_get_def dfg v = FLOOKUP dfg.dfg_defs v
+End
+
+Definition dfg_get_inst_by_id_def:
+  dfg_get_inst_by_id dfg id = FLOOKUP dfg.dfg_ids id
+End
+
+(* ==========================================================================
+   Variable/Instruction Helpers
+   ========================================================================== *)
+
+Definition operand_var_def:
+  operand_var op =
+    case op of
+      Var v => SOME v
+    | _ => NONE
+End
+
+Definition operand_vars_def:
+  operand_vars [] = [] /\
+  operand_vars (op::ops) =
+    case operand_var op of
+      NONE => operand_vars ops
+    | SOME v => v :: operand_vars ops
+End
+
+Definition dfg_add_use_def:
+  dfg_add_use dfg v inst =
+    let uses = dfg_get_uses dfg v in
+      if MEM inst uses then dfg
+      else dfg with dfg_uses := dfg.dfg_uses |+ (v, inst :: uses)
+End
+
+Definition dfg_remove_use_def:
+  dfg_remove_use dfg v inst_id =
+    let uses = dfg_get_uses dfg v in
+    let uses' = FILTER (λinst. inst.inst_id <> inst_id) uses in
+      dfg with dfg_uses := dfg.dfg_uses |+ (v, uses')
+End
+
+Definition dfg_add_uses_def:
+  dfg_add_uses dfg [] inst = dfg /\
+  dfg_add_uses dfg (v::vs) inst =
+    dfg_add_uses (dfg_add_use dfg v inst) vs inst
+End
+
+Definition dfg_add_defs_def:
+  dfg_add_defs dfg [] inst = dfg /\
+  dfg_add_defs dfg (v::vs) inst =
+    dfg_add_defs (dfg with dfg_defs := dfg.dfg_defs |+ (v, inst)) vs inst
+End
+
+Definition dfg_set_def_def:
+  dfg_set_def dfg v inst =
+    dfg with dfg_defs := dfg.dfg_defs |+ (v, inst)
+End
+
+Definition dfg_remove_def_def:
+  dfg_remove_def dfg v =
+    dfg with dfg_defs := FDIFF dfg.dfg_defs {v}
+End
+
+Definition dfg_set_inst_by_id_def:
+  dfg_set_inst_by_id dfg inst =
+    dfg with dfg_ids := dfg.dfg_ids |+ (inst.inst_id, inst)
+End
+
+Definition dfg_remove_inst_by_id_def:
+  dfg_remove_inst_by_id dfg id =
+    dfg with dfg_ids := FDIFF dfg.dfg_ids {id}
+End
+
+Definition dfg_add_inst_def:
+  dfg_add_inst dfg inst =
+    let in_vars = operand_vars inst.inst_operands in
+    let dfg1 = dfg_add_uses dfg in_vars inst in
+    let dfg2 = dfg_add_defs dfg1 inst.inst_outputs inst in
+      dfg2 with dfg_ids := dfg2.dfg_ids |+ (inst.inst_id, inst)
+End
+
+(* ==========================================================================
+   Build DFG from Instruction Lists / Functions
+   ========================================================================== *)
+
+Definition fn_insts_blocks_def:
+  fn_insts_blocks [] = [] /\
+  fn_insts_blocks (bb::bbs) =
+    bb.bb_instructions ++ fn_insts_blocks bbs
+End
+
+Definition fn_insts_def:
+  fn_insts fn = fn_insts_blocks fn.fn_blocks
+End
+
+Definition dfg_build_insts_rev_def:
+  dfg_build_insts_rev dfg [] = dfg /\
+  dfg_build_insts_rev dfg (inst::rest) =
+    dfg_build_insts_rev (dfg_add_inst dfg inst) rest
+End
+
+Definition dfg_build_insts_def:
+  dfg_build_insts insts =
+    dfg_build_insts_rev dfg_empty (REVERSE insts)
+End
+
+Definition dfg_build_function_def:
+  dfg_build_function fn = dfg_build_insts (fn_insts fn)
+End
+
+val _ = export_theory();

--- a/venom/passes/phi_elimination/Holmakefile
+++ b/venom/passes/phi_elimination/Holmakefile
@@ -1,2 +1,2 @@
 # PHI elimination pass for Venom IR
-INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../.. ../../../syntax ../../../semantics
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../.. ../../analysis ../../../syntax ../../../semantics

--- a/venom/passes/phi_elimination/phiFunctionScript.sml
+++ b/venom/passes/phi_elimination/phiFunctionScript.sml
@@ -95,17 +95,16 @@ Proof
     Cases_on `lookup_block s.vs_current_bb func.fn_blocks` >> gvs[result_equiv_def] >>
     rename1 `lookup_block _ _ = SOME bb` >>
     (* Normalize to use transform_function for IH *)
-    `(func with fn_blocks := MAP (transform_block (build_dfg_fn func)) func.fn_blocks) =
+    `(func with fn_blocks := MAP (transform_block (dfg_build_function func)) func.fn_blocks) =
      transform_function func` by simp[transform_function_def, LET_DEF] >>
     pop_assum (fn th => RULE_ASSUM_TAC (REWRITE_RULE [th]) >> REWRITE_TAC [th]) >>
     `MEM bb func.fn_blocks` by metis_tac[lookup_block_MEM] >>
-    `result_equiv (run_block bb s) (run_block (transform_block (build_dfg_fn func) bb) s)` by (
+    `result_equiv (run_block bb s) (run_block (transform_block (dfg_build_function func) bb) s)` by (
       irule transform_block_result_equiv >> simp[] >>
       fs[phi_wf_fn_def, LET_DEF] >> rpt conj_tac >>
-      rpt strip_tac >> TRY (first_x_assum drule_all >> simp[]) >>
-      simp[build_dfg_fn_well_formed]
+      rpt strip_tac >> first_x_assum drule_all >> simp[]
     ) >>
-    Cases_on `run_block bb s` >> Cases_on `run_block (transform_block (build_dfg_fn func) bb) s` >>
+    Cases_on `run_block bb s` >> Cases_on `run_block (transform_block (dfg_build_function func) bb) s` >>
     gvs[result_equiv_def] >>
     TRY (`v.vs_halted <=> v'.vs_halted` by fs[state_equiv_def]) >>
     Cases_on `v.vs_halted` >> gvs[result_equiv_def] >>
@@ -135,13 +134,13 @@ Proof
   Cases_on `lookup_block s.vs_current_bb func.fn_blocks` >> gvs[result_equiv_def] >>
   rename1 `lookup_block _ _ = SOME bb` >>
   (* Normalize to use transform_function for IH *)
-  `(func with fn_blocks := MAP (transform_block (build_dfg_fn func)) func.fn_blocks) =
+  `(func with fn_blocks := MAP (transform_block (dfg_build_function func)) func.fn_blocks) =
    transform_function func` by simp[transform_function_def, LET_DEF] >>
   pop_assum (fn th => RULE_ASSUM_TAC (REWRITE_RULE [th]) >> REWRITE_TAC [th]) >>
   (* At entry block: use run_block_transform_identity since entry block has no PHI with single origin *)
   (* Since s.vs_current_bb = (HD func.fn_blocks).bb_label and lookup succeeded, bb = HD func.fn_blocks *)
   (* From phi_wf_fn, entry block has no PHI with single origin, so transform is identity *)
-  `run_block (transform_block (build_dfg_fn func) bb) s = run_block bb s` by (
+  `run_block (transform_block (dfg_build_function func) bb) s = run_block bb s` by (
     irule run_block_transform_identity >>
     rpt strip_tac >>
     (* First prove bb = HD func.fn_blocks *)
@@ -222,4 +221,3 @@ Proof
   simp[transform_context_def, transform_function_def, MEM_MAP] >>
   qexists_tac `func` >> simp[]
 QED
-

--- a/venom/passes/phi_elimination/phiTransformScript.sml
+++ b/venom/passes/phi_elimination/phiTransformScript.sml
@@ -58,7 +58,7 @@ End
 (* TOP-LEVEL: Transform a function - builds DFG and transforms all blocks *)
 Definition transform_function_def:
   transform_function fn =
-    let dfg = build_dfg_fn fn in
+    let dfg = dfg_build_function fn in
     fn with fn_blocks := MAP (transform_block dfg) fn.fn_blocks
 End
 
@@ -192,4 +192,3 @@ Proof
   ) >>
   simp[]
 QED
-


### PR DESCRIPTION
- added `analysis` directory
- added a shared DFG analysis with support for multi-output instructions
- ported the phi-elimination DFG analysis from the previous definition to the new
- added adaptation proofs specific for phi-elimination pass so it gets the extra assumption of instruction-output lookup being bijective (`lookup v = inst => inst.inst_outputs = [v]` instead of just` lookup v = inst => v ∈ inst.inst_outputs`)