### PR TITLE
add shared venom analysis cache

### DIFF
--- a/venom/analysis/analysisCacheScript.sml
+++ b/venom/analysis/analysisCacheScript.sml
@@ -1,0 +1,48 @@
+(*
+ * Analysis Cache (minimal shared cache)
+ *
+ * Shared cache helpers for reusable analyses.
+ *)
+
+Theory analysisCache
+Ancestors
+  dfgAnalysis
+
+Datatype:
+  analysis_cache = <|
+    ac_function : ir_function;
+    ac_dfg : dfg_analysis option
+  |>
+End
+
+Definition analysis_cache_init_def:
+  analysis_cache_init fn =
+    <| ac_function := fn; ac_dfg := NONE |>
+End
+
+Definition analysis_cache_set_function_def:
+  analysis_cache_set_function cache fn =
+    cache with <| ac_function := fn; ac_dfg := NONE |>
+End
+
+Definition analysis_cache_request_dfg_def:
+  analysis_cache_request_dfg cache =
+    case cache.ac_dfg of
+      SOME dfg => (dfg, cache)
+    | NONE =>
+        let dfg = dfg_build_function cache.ac_function in
+          (dfg, cache with ac_dfg := SOME dfg)
+End
+
+Definition analysis_cache_invalidate_dfg_def:
+  analysis_cache_invalidate_dfg cache = cache with ac_dfg := NONE
+End
+
+(* ===== Force Helpers ===== *)
+
+Definition analysis_cache_force_dfg_def:
+  analysis_cache_force_dfg cache =
+    analysis_cache_request_dfg (analysis_cache_invalidate_dfg cache)
+End
+
+val _ = export_theory();


### PR DESCRIPTION
for now it only has the dfg stuff (but on my subsequent branches i put more stuff here ofc). not sure if it makes sense to eventually state some correctness property for analysis cache?