### PR TITLE
Add 8 scoping/lookup lemmas to vyperLookupTheory

### DIFF
--- a/semantics/prop/vyperLookupScript.sml
+++ b/semantics/prop/vyperLookupScript.sml
@@ -979,7 +979,7 @@ Proof
   simp[valid_lookups_def, var_in_scope_fempty_prepend]
 QED
 
-Theorem fcs_fempty:
+Theorem fcs_fempty[local]:
   ∀ni rest.
     find_containing_scope ni (FEMPTY :: rest) =
     OPTION_MAP (λ(pre,env,a,post). (FEMPTY::pre,env,a,post))


### PR DESCRIPTION
General-purpose lemmas needed by vyper-automation WP theory:

- update_scoped_var_frame: other variables preserved across update
- lookup_scoped_var_fempty_prepend: FEMPTY prepend is transparent
- var_in_scope_fempty_prepend: ditto for var_in_scope
- valid_lookups_fempty_prepend: ditto for valid_lookups
- fcs_fempty: find_containing_scope through FEMPTY
- update_scoped_var_fempty: update distributes over FEMPTY prepend
- lookup_scopes_none_fcs_none: no lookup implies no containing scope
- new_variable_eq_update: new_variable = update when var absent