### PR TITLE
ci: cancel in-progress runs on new push to same PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,12 @@ on:
     - main
   pull_request:
 
+concurrency:
+  # Cancel older in-progress runs from same PR/workflow.
+  # Push-triggered runs use unique run_id so they never cancel each other.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this will help with build pressure.

Adapts concurrency pattern from https://github.com/vyperlang/vyper/blob/54cb28e1790f50487df1b6dfe75027d6bd9c16a0/.github/workflows/test.yml#L10. Groups by workflow+branch for PRs (cancels stale), by run_id for pushes (never cancels).