### PR TITLE
Support multi-arg _abi_encode and chain.id; unexclude test

### DIFF
--- a/frontend/jsonToVyperScript.sml
+++ b/frontend/jsonToVyperScript.sml
@@ -45,7 +45,7 @@ Definition translate_type_def:
   (translate_type JT_None = NoneT) /\
   (translate_type (JT_Named name) =
      if name = "bool" then BaseT BoolT
-     else if name = "address" then BaseT AddressT
+     else if name = "address" ∨ name = "self" then BaseT AddressT
      else if name = "decimal" then BaseT DecimalT
      else StructT name) /\
   (translate_type_list [] = []) /\
@@ -574,6 +574,7 @@ Definition translate_expr_def:
     else if obj = "block" /\ attr = "prevhash" then Builtin (Env PrevHash) []
     else if obj = "block" /\ attr = "blobbasefee" then Builtin (Env BlobBaseFee) []
     else if obj = "tx" /\ attr = "gasprice" then Builtin (Env GasPrice) []
+    else if obj = "chain" /\ attr = "id" then Builtin (Env ChainId) []
     else if obj = "self" /\ attr = "balance" then
       Builtin (Acc Balance) [Builtin (Env SelfAddr) []]
     (* self.x: use attr_src_id_opt from variable_reads for cross-module storage access *)

--- a/syntax/vyperASTScript.sml
+++ b/syntax/vyperASTScript.sml
@@ -91,6 +91,7 @@ Datatype:
   | BlobBaseFee
   | GasPrice
   | PrevHash
+  | ChainId
 End
 
 Datatype:

--- a/tests/vyperTestLib.sml
+++ b/tests/vyperTestLib.sml
@@ -97,6 +97,7 @@ val call : term decoder =
                 ("blobBaseFee", bf),
                 ("gasLimit", g),
                 ("gasPrice", p),
+                ("chainId", numSyntax.term_of_int 1),
                 ("static", a),
                 ("expectedOutput", e)]))
           (tuple3 (
@@ -290,8 +291,7 @@ val allowed_test_names = [
 
 (* Tests excluded by name - require architectural changes *)
 val excluded_test_names = [
-  (* TODO: multi-arg abi_encode *)
-  "test_immutable_hashing_overlap_regression",
+
   (* TODO: external calls with default args *)
   "test_basic_default_param_*",
   "test_default_param_*",
@@ -411,6 +411,7 @@ val deployment : term decoder =
                ("blobHashes", bh),
                ("blobBaseFee", bf),
                ("gasPrice", g),
+               ("chainId", numSyntax.term_of_int 1),
                ("callData", d),
                ("runtimeBytecode", bc),
                ("storageLayout", sl)

--- a/tests/vyperTestRunnerScript.sml
+++ b/tests/vyperTestRunnerScript.sml
@@ -37,6 +37,7 @@ Datatype:
   ; blobHashes: bytes32 list
   ; blobBaseFee: num
   ; gasPrice: num
+  ; chainId: num
   ; callData: byte list
   ; runtimeBytecode: byte list
   ; storageLayout: json_storage_layout
@@ -98,6 +99,7 @@ Datatype:
   ; blobBaseFee: num
   ; gasLimit: num
   ; gasPrice: num
+  ; chainId: num
   ; static: bool
   ; expectedOutput: byte list option
   |>
@@ -154,6 +156,7 @@ Definition run_deployment_def:
           ; blob_hashes := dt.blobHashes
           ; blob_base_fee := dt.blobBaseFee
           ; gas_price := dt.gasPrice
+          ; chain_id := dt.chainId
           ; is_creation := T |>;
     in load_contract am tx dt.sourceAst dt.sourceExports
   in (sns, res)
@@ -194,6 +197,7 @@ Definition run_call_def:
           ; blob_hashes := ct.blobHashes
           ; blob_base_fee := ct.blobBaseFee
           ; gas_price := ct.gasPrice
+          ; chain_id := ct.chainId
           ; is_creation := F |>;
     (* TODO: set static based on ct.static *)
     (* TODO: set env data somewhere? *)


### PR DESCRIPTION
Add support for _abi_encode with multiple arguments, as used in EIP-712 domain separator computation: _abi_encode(typehash, name_hash, version_hash, chain.id, self).

Multi-arg _abi_encode:
- jsonASTLib: add a special decoder for abi_encode calls that extracts per-argument types as JT_Tuple, so the type information is available for ABI encoding
- jsonToVyperScript: translate_type maps "self" to AddressT since self appears as an abi_encode argument type
- vyperInterpreterScript: accept n >= 1 args for AbiEncode, wrap multiple values in ArrayV (TupleV vs) for encoding with the TupleT type. The existing vyper_to_abi/evaluate_abi_encode already handle TupleT/TupleV.

chain.id:
- vyperASTScript: add ChainId to env_item
- jsonToVyperScript: translate chain.id to Builtin (Env ChainId)
- vyperInterpreterScript: add chain_id field to call_txn, evaluate Env ChainId
- vyperTestRunnerScript: wire chainId through deployment_trace and call_trace to call_txn
- vyperTestLib: default chainId to 1 (not yet in test JSON exports)

Unexclude test_immutable_hashing_overlap_regression.