### PR TITLE
ci: cache vyper-hol build across runs, remove unnecessary Vyper install

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -1,5 +1,10 @@
-name: 'Setup HOL Environment'
+name: 'Setup Dependencies'
 description: 'Sets up PolyML, HOL4, and Verifereum'
+
+outputs:
+  deps-hash:
+    description: 'Hash of PolyML+HOL4+Verifereum versions for cache keys'
+    value: ${{ steps.versions.outputs.deps-hash }}
 
 runs:
   using: 'composite'
@@ -13,31 +18,13 @@ runs:
       id: versions
       shell: bash
       run: |
-        echo "polyml=$(git ls-remote https://github.com/polyml/polyml.git refs/tags/${POLYML_TAG} | cut -f1)" >> $GITHUB_OUTPUT
-        echo "verifereum=$(git ls-remote https://github.com/verifereum/verifereum.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
-        echo "hol4=$(git ls-remote https://github.com/HOL-Theorem-Prover/HOL.git master | cut -f1)" >> $GITHUB_OUTPUT
-        echo "vyper=$(git ls-remote https://github.com/vyperlang/vyper.git master | cut -f1)" >> $GITHUB_OUTPUT
-
-    - name: Cache Vyper
-      uses: actions/cache@v4
-      id: cache-vyper
-      with:
-        path: ~/vyper-install
-        key: vyper-${{ runner.os }}-${{ steps.versions.outputs.vyper }}
-
-    - name: Build Vyper
-      if: steps.cache-vyper.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        git clone -b master https://github.com/vyperlang/vyper.git
-        cd vyper
-        python3 -m venv ~/vyper-install
-        source ~/vyper-install/bin/activate
-        pip install .
-
-    - name: Add Vyper to PATH
-      shell: bash
-      run: echo "$HOME/vyper-install/bin" >> "$GITHUB_PATH"
+        polyml=$(git ls-remote https://github.com/polyml/polyml.git refs/tags/${POLYML_TAG} | cut -f1)
+        verifereum=$(git ls-remote https://github.com/verifereum/verifereum.git HEAD | cut -f1)
+        hol4=$(git ls-remote https://github.com/HOL-Theorem-Prover/HOL.git master | cut -f1)
+        echo "polyml=$polyml" >> $GITHUB_OUTPUT
+        echo "verifereum=$verifereum" >> $GITHUB_OUTPUT
+        echo "hol4=$hol4" >> $GITHUB_OUTPUT
+        echo "deps-hash=$(echo "${polyml}${hol4}${verifereum}" | sha256sum | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
     - name: Cache PolyML
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Vyper-HOL Theories Build
+name: CI
 
 on:
   workflow_dispatch:
@@ -16,17 +16,26 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      build-cache-key: ${{ steps.build-key.outputs.key }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-hol
-      - run: Holmake
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/deps
+        id: deps
+      - name: Compute build cache key
+        id: build-key
+        run: |
+          echo "key=vyper-hol-${{ runner.os }}-${{ steps.deps.outputs.deps-hash }}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache@v4
         with:
-          name: hol-build
           path: '**/.hol'
-          include-hidden-files: true
-          retention-days: 1
+          key: ${{ steps.build-key.outputs.key }}
+      - name: Fix restored timestamps
+        if: steps.build-cache.outputs.cache-hit == 'true'
+        run: find . -path '*/.hol/*' -type f -exec touch {} +
+      - run: Holmake
 
   export-vyper-tests:
     runs-on: ubuntu-latest
@@ -66,12 +75,14 @@ jobs:
         group: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-hol
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/deps
+      - name: Restore build cache
+        uses: actions/cache/restore@v4
         with:
-          name: hol-build
-      - name: Fix artifact timestamps
+          path: '**/.hol'
+          key: ${{ needs.build.outputs.build-cache-key }}
+          fail-on-cache-miss: true
+      - name: Fix restored timestamps
         run: find . -path '*/.hol/*' -type f -exec touch {} +
       - name: Restore Vyper test exports
         uses: actions/cache/restore@v4


### PR DESCRIPTION
The vyper-hol build was using upload-artifact/download-artifact to transfer build products from the build job to the 10 test runners. Artifacts are ephemeral (scoped to a single workflow run), so the project was rebuilt from scratch on every push even when nothing changed.

Switch to actions/cache with a key based on the dependency versions and commit sha. On cache hit, the build job restores .hol directories, touches them to fix timestamps (so Holmake sees targets as newer than sources), and Holmake completes as a no-op. The test runners restore the same cache entry.

Also remove the Vyper compiler from the deps action. No SML code invokes the compiler — it's only needed by the export-vyper-tests job, which has its own Python/pip setup. This was being installed (or cache- restored) 11 times per workflow run for no reason.

Rename files for clarity:
  .github/actions/setup-hol/ -> .github/actions/deps/
  .github/workflows/build.yml -> .github/workflows/ci.yml