### PR TITLE
Refactor DFG analysis to match cfg/fcg/liveness structure

### DIFF
--- a/venom/analysis/Holmakefile
+++ b/venom/analysis/Holmakefile
@@ -1,2 +1,2 @@
 # Venom analysis passes
-INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec .. ../../syntax ../../semantics shared dataflow cfg fcg liveness
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec .. ../../syntax ../../semantics shared dataflow cfg dfg fcg liveness

--- a/venom/analysis/dfg/Holmakefile
+++ b/venom/analysis/dfg/Holmakefile
@@ -1,0 +1,3 @@
+# DFG analysis: public API
+# defs/ = definitions, proofs/ = correctness proofs
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../.. ../../../syntax ../../../semantics defs proofs

--- a/venom/analysis/dfg/defs/Holmakefile
+++ b/venom/analysis/dfg/defs/Holmakefile
@@ -1,0 +1,2 @@
+# DFG analysis definitions
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../../.. ../../../../syntax ../../../../semantics

--- a/venom/analysis/dfg/defs/dfgDefsScript.sml
+++ b/venom/analysis/dfg/defs/dfgDefsScript.sml
@@ -1,14 +1,30 @@
 (*
- * Data-Flow Graph Analysis
+ * Data-Flow Graph Analysis — Definitions
  *
  * Reusable DFG helpers for Venom passes.
  * Tracks:
  *  - Uses: variable -> instructions that read it (in program order)
  *  - Defs: variable -> producing instruction
  *  - IDs: instruction id -> instruction
+ *
+ * TOP-LEVEL:
+ *   dfg_analysis          — record type
+ *   dfg_build_function    — build DFG from a function
+ *   dfg_get_def           — query: producing instruction for a variable
+ *   dfg_get_uses          — query: instructions that read a variable
+ *   dfg_get_inst_by_id    — query: instruction by ID
+ *   well_formed_dfg       — well-formedness predicate
+ *   dfg_def_ids           — set of instruction IDs in DFG def range
+ *
+ * Helper:
+ *   operand_var/operand_vars — extract variable names from operands
+ *   dfg_add_use/dfg_add_uses — use-tracking mutations
+ *   dfg_add_defs            — def-tracking mutations
+ *   dfg_add_inst            — add a full instruction to DFG
+ *   dfg_build_insts         — build DFG from instruction list
  *)
 
-Theory dfgAnalysis
+Theory dfgDefs
 Ancestors
   list finite_map
   venomState venomInst
@@ -136,4 +152,16 @@ Definition dfg_build_function_def:
   dfg_build_function fn = dfg_build_insts (fn_insts fn)
 End
 
-val _ = export_theory();
+(* ==========================================================================
+   Well-formedness and ID sets
+   ========================================================================== *)
+
+Definition well_formed_dfg_def:
+  well_formed_dfg dfg <=>
+    !v inst. dfg_get_def dfg v = SOME inst ==> MEM v inst.inst_outputs
+End
+
+Definition dfg_def_ids_def:
+  dfg_def_ids dfg = IMAGE (\inst. inst.inst_id) (FRANGE dfg.dfg_defs)
+End
+

--- a/venom/analysis/dfg/dfgAnalysisPropsScript.sml
+++ b/venom/analysis/dfg/dfgAnalysisPropsScript.sml
@@ -1,0 +1,226 @@
+(*
+ * DFG Analysis Correctness (Statements Only)
+ *
+ * Exported API for consumers of the DFG analysis.
+ *
+ * 1) Well-formedness — building a DFG preserves well_formed_dfg.
+ * 2) Correctness — if dfg_get_def returns an instruction, it comes from
+ *    the original instruction list.
+ * 3) Finiteness — dfg_def_ids is finite.
+ *
+ * Internal proof machinery lives in proofs/dfgCorrectnessProofScript.sml.
+ * Re-exported via ACCEPT_TAC.
+ *)
+
+Theory dfgAnalysisProps
+Ancestors
+  dfgCorrectnessProof
+
+(* ==========================================================================
+   1) Well-formedness preservation
+   ========================================================================== *)
+
+Theorem well_formed_dfg_update:
+  !dfg inst v.
+    well_formed_dfg dfg /\ MEM v inst.inst_outputs
+    ==> well_formed_dfg (dfg with dfg_defs := dfg.dfg_defs |+ (v, inst))
+Proof
+  ACCEPT_TAC well_formed_dfg_update_proof
+QED
+
+Theorem dfg_add_defs_well_formed:
+  !dfg vs inst.
+    well_formed_dfg dfg /\ EVERY (\v. MEM v inst.inst_outputs) vs
+    ==> well_formed_dfg (dfg_add_defs dfg vs inst)
+Proof
+  ACCEPT_TAC dfg_add_defs_well_formed_proof
+QED
+
+Theorem dfg_add_use_get_def:
+  !dfg v inst u.
+    dfg_get_def (dfg_add_use dfg u inst) v = dfg_get_def dfg v
+Proof
+  ACCEPT_TAC dfg_add_use_get_def_proof
+QED
+
+Theorem dfg_add_uses_get_def:
+  !dfg vs inst v.
+    dfg_get_def (dfg_add_uses dfg vs inst) v = dfg_get_def dfg v
+Proof
+  ACCEPT_TAC dfg_add_uses_get_def_proof
+QED
+
+Theorem dfg_add_uses_preserve_wf:
+  !dfg vs inst.
+    well_formed_dfg dfg ==> well_formed_dfg (dfg_add_uses dfg vs inst)
+Proof
+  ACCEPT_TAC dfg_add_uses_preserve_wf_proof
+QED
+
+Theorem well_formed_dfg_update_ids:
+  !dfg ids. well_formed_dfg dfg ==> well_formed_dfg (dfg with dfg_ids := ids)
+Proof
+  ACCEPT_TAC well_formed_dfg_update_ids_proof
+QED
+
+Theorem dfg_add_inst_well_formed:
+  !dfg inst.
+    well_formed_dfg dfg ==> well_formed_dfg (dfg_add_inst dfg inst)
+Proof
+  ACCEPT_TAC dfg_add_inst_well_formed_proof
+QED
+
+Theorem dfg_build_insts_rev_well_formed:
+  !dfg insts.
+    well_formed_dfg dfg ==> well_formed_dfg (dfg_build_insts_rev dfg insts)
+Proof
+  ACCEPT_TAC dfg_build_insts_rev_well_formed_proof
+QED
+
+Theorem dfg_build_insts_well_formed:
+  !insts. well_formed_dfg (dfg_build_insts insts)
+Proof
+  ACCEPT_TAC dfg_build_insts_well_formed_proof
+QED
+
+Theorem dfg_build_function_well_formed:
+  !fn. well_formed_dfg (dfg_build_function fn)
+Proof
+  ACCEPT_TAC dfg_build_function_well_formed_proof
+QED
+
+(* ==========================================================================
+   2) Def-source correctness
+   ========================================================================== *)
+
+Theorem dfg_add_defs_lookup:
+  !dfg vs inst v inst'.
+    dfg_get_def (dfg_add_defs dfg vs inst) v = SOME inst' ==>
+    dfg_get_def dfg v = SOME inst' \/ (inst' = inst /\ MEM v vs)
+Proof
+  ACCEPT_TAC dfg_add_defs_lookup_proof
+QED
+
+Theorem dfg_add_inst_get_def:
+  !dfg inst0 v.
+    dfg_get_def (dfg_add_inst dfg inst0) v =
+    dfg_get_def
+      (dfg_add_defs
+         (dfg_add_uses dfg (operand_vars inst0.inst_operands) inst0)
+         inst0.inst_outputs inst0) v
+Proof
+  ACCEPT_TAC dfg_add_inst_get_def_proof
+QED
+
+Theorem dfg_add_inst_lookup:
+  !dfg inst0 v inst.
+    dfg_get_def (dfg_add_inst dfg inst0) v = SOME inst ==>
+    dfg_get_def dfg v = SOME inst \/ (inst = inst0 /\ MEM v inst0.inst_outputs)
+Proof
+  ACCEPT_TAC dfg_add_inst_lookup_proof
+QED
+
+Theorem dfg_build_insts_rev_correct:
+  !insts dfg v inst.
+    dfg_get_def (dfg_build_insts_rev dfg insts) v = SOME inst ==>
+    dfg_get_def dfg v = SOME inst \/
+    (MEM inst insts /\ MEM v inst.inst_outputs)
+Proof
+  ACCEPT_TAC dfg_build_insts_rev_correct_proof
+QED
+
+Theorem dfg_build_insts_correct:
+  !insts v inst.
+    dfg_get_def (dfg_build_insts insts) v = SOME inst ==>
+    MEM inst insts /\ MEM v inst.inst_outputs
+Proof
+  ACCEPT_TAC dfg_build_insts_correct_proof
+QED
+
+Theorem dfg_build_function_correct:
+  !fn v inst.
+    dfg_get_def (dfg_build_function fn) v = SOME inst
+    ==>
+    MEM v inst.inst_outputs /\ MEM inst (fn_insts fn)
+Proof
+  ACCEPT_TAC dfg_build_function_correct_proof
+QED
+
+(* ==========================================================================
+   3) Finiteness / termination helpers
+   ========================================================================== *)
+
+Theorem dfg_def_ids_finite:
+  !dfg. FINITE (dfg_def_ids dfg)
+Proof
+  ACCEPT_TAC dfg_def_ids_finite_proof
+QED
+
+Theorem dfg_get_def_implies_dfg_def_ids:
+  !dfg v inst. dfg_get_def dfg v = SOME inst ==> inst.inst_id IN dfg_def_ids dfg
+Proof
+  ACCEPT_TAC dfg_get_def_implies_dfg_def_ids_proof
+QED
+
+(* ==========================================================================
+   4) Uses correctness
+   ========================================================================== *)
+
+(* If dfg_get_uses reports inst as a user of v, then inst is from the
+   function and v appears among its operand variables. *)
+Theorem dfg_build_function_uses_sound:
+  !fn v inst.
+    MEM inst (dfg_get_uses (dfg_build_function fn) v) ==>
+    MEM inst (fn_insts fn) /\ MEM v (operand_vars inst.inst_operands)
+Proof
+  ACCEPT_TAC dfg_build_function_uses_sound_proof
+QED
+
+(* Every instruction in the function that mentions v as an operand
+   variable appears in the uses list for v. *)
+Theorem dfg_build_function_uses_complete:
+  !fn v inst.
+    MEM inst (fn_insts fn) /\
+    MEM v (operand_vars inst.inst_operands) ==>
+    MEM inst (dfg_get_uses (dfg_build_function fn) v)
+Proof
+  ACCEPT_TAC dfg_build_function_uses_complete_proof
+QED
+
+(* ==========================================================================
+   5) Defs completeness
+   ========================================================================== *)
+
+(* If any instruction in the function lists v as an output, then
+   dfg_get_def returns some defining instruction for v. *)
+Theorem dfg_build_function_defs_complete:
+  !fn v inst.
+    MEM inst (fn_insts fn) /\
+    MEM v inst.inst_outputs ==>
+    ?inst'. dfg_get_def (dfg_build_function fn) v = SOME inst'
+Proof
+  ACCEPT_TAC dfg_build_function_defs_complete_proof
+QED
+
+(* ==========================================================================
+   6) ID map correctness
+   ========================================================================== *)
+
+(* If dfg_get_inst_by_id returns an instruction, it is from the function. *)
+Theorem dfg_build_function_ids_sound:
+  !fn id inst.
+    dfg_get_inst_by_id (dfg_build_function fn) id = SOME inst ==>
+    MEM inst (fn_insts fn)
+Proof
+  ACCEPT_TAC dfg_build_function_ids_sound_proof
+QED
+
+(* Every instruction in the function is retrievable by its ID. *)
+Theorem dfg_build_function_ids_complete:
+  !fn inst.
+    MEM inst (fn_insts fn) ==>
+    ?inst'. dfg_get_inst_by_id (dfg_build_function fn) inst.inst_id = SOME inst'
+Proof
+  ACCEPT_TAC dfg_build_function_ids_complete_proof
+QED
+

--- a/venom/analysis/dfg/dfgAnalysisScript.sml
+++ b/venom/analysis/dfg/dfgAnalysisScript.sml
@@ -1,0 +1,9 @@
+(*
+ * DFG Analysis — public API
+ *
+ * Consumers: just `Ancestors dfgAnalysis` to get defs + properties.
+ *)
+
+Theory dfgAnalysis
+Ancestors
+  dfgDefs dfgAnalysisProps

--- a/venom/analysis/dfg/proofs/Holmakefile
+++ b/venom/analysis/dfg/proofs/Holmakefile
@@ -1,0 +1,2 @@
+# DFG correctness proofs
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../../.. ../../../../syntax ../../../../semantics ../defs

--- a/venom/analysis/dfg/proofs/dfgCorrectnessProofScript.sml
+++ b/venom/analysis/dfg/proofs/dfgCorrectnessProofScript.sml
@@ -1,33 +1,19 @@
 (*
- * DFG Analysis Correctness
+ * DFG Analysis Correctness Proofs
  *
- * Proof-oriented lemmas over shared dfgAnalysis definitions.
- * This file provides reusable correctness infrastructure for passes that
- * consume the shared DFG.
+ * Internal proof machinery for DFG analysis.
+ * Re-exported via dfgAnalysisPropsScript.sml.
  *)
 
-Theory dfgAnalysisCorrectness
+Theory dfgCorrectnessProof
 Ancestors
-  dfgAnalysis list finite_map pred_set
-
-(* --------------------------------------------------------------------------
-   Bridge-level predicates
-   -------------------------------------------------------------------------- *)
-
-Definition well_formed_dfg_def:
-  well_formed_dfg dfg <=>
-    !v inst. dfg_get_def dfg v = SOME inst ==> MEM v inst.inst_outputs
-End
-
-Definition dfg_def_ids_def:
-  dfg_def_ids dfg = IMAGE (\inst. inst.inst_id) (FRANGE dfg.dfg_defs)
-End
+  dfgDefs list finite_map pred_set
 
 (* --------------------------------------------------------------------------
    Well-formedness preservation
    -------------------------------------------------------------------------- *)
 
-Theorem well_formed_dfg_update:
+Theorem well_formed_dfg_update_proof:
   !dfg inst v.
     well_formed_dfg dfg /\ MEM v inst.inst_outputs
     ==> well_formed_dfg (dfg with dfg_defs := dfg.dfg_defs |+ (v, inst))
@@ -36,7 +22,7 @@ Proof
   Cases_on `v' = v` >> fs[]
 QED
 
-Theorem dfg_add_defs_well_formed:
+Theorem dfg_add_defs_well_formed_proof:
   !dfg vs inst.
     well_formed_dfg dfg /\ EVERY (\v. MEM v inst.inst_outputs) vs
     ==> well_formed_dfg (dfg_add_defs dfg vs inst)
@@ -44,85 +30,85 @@ Proof
   Induct_on `vs` >> rw[dfg_add_defs_def] >>
   first_x_assum match_mp_tac >>
   conj_tac >- (
-    match_mp_tac well_formed_dfg_update >>
+    match_mp_tac well_formed_dfg_update_proof >>
     simp[]
   ) >>
   simp[]
 QED
 
-Theorem dfg_add_use_get_def:
+Theorem dfg_add_use_get_def_proof:
   !dfg v inst u.
     dfg_get_def (dfg_add_use dfg u inst) v = dfg_get_def dfg v
 Proof
   rw[dfg_add_use_def, dfg_get_def_def]
 QED
 
-Theorem dfg_add_uses_get_def:
+Theorem dfg_add_uses_get_def_proof:
   !dfg vs inst v.
     dfg_get_def (dfg_add_uses dfg vs inst) v = dfg_get_def dfg v
 Proof
   Induct_on `vs` >> rw[dfg_add_uses_def] >>
-  rw[dfg_add_use_get_def]
+  rw[dfg_add_use_get_def_proof]
 QED
 
-Theorem dfg_add_uses_preserve_wf:
+Theorem dfg_add_uses_preserve_wf_proof:
   !dfg vs inst.
     well_formed_dfg dfg ==> well_formed_dfg (dfg_add_uses dfg vs inst)
 Proof
   rw[well_formed_dfg_def] >>
   qpat_x_assum `dfg_get_def (dfg_add_uses dfg vs inst) v = SOME inst'` mp_tac >>
-  simp[dfg_add_uses_get_def] >>
+  simp[dfg_add_uses_get_def_proof] >>
   metis_tac[well_formed_dfg_def]
 QED
 
-Theorem well_formed_dfg_update_ids:
+Theorem well_formed_dfg_update_ids_proof:
   !dfg ids. well_formed_dfg dfg ==> well_formed_dfg (dfg with dfg_ids := ids)
 Proof
   rw[well_formed_dfg_def, dfg_get_def_def]
 QED
 
-Theorem dfg_add_inst_well_formed:
+Theorem dfg_add_inst_well_formed_proof:
   !dfg inst.
     well_formed_dfg dfg ==> well_formed_dfg (dfg_add_inst dfg inst)
 Proof
   rw[dfg_add_inst_def] >>
-  match_mp_tac well_formed_dfg_update_ids >>
-  match_mp_tac dfg_add_defs_well_formed >>
+  match_mp_tac well_formed_dfg_update_ids_proof >>
+  match_mp_tac dfg_add_defs_well_formed_proof >>
   conj_tac >- (
-    match_mp_tac dfg_add_uses_preserve_wf >>
+    match_mp_tac dfg_add_uses_preserve_wf_proof >>
     simp[]
   ) >>
   simp[EVERY_MEM]
 QED
 
-Theorem dfg_build_insts_rev_well_formed:
+Theorem dfg_build_insts_rev_well_formed_proof:
   !dfg insts.
     well_formed_dfg dfg ==> well_formed_dfg (dfg_build_insts_rev dfg insts)
 Proof
   Induct_on `insts` >> rw[dfg_build_insts_rev_def] >>
   first_x_assum match_mp_tac >>
-  metis_tac[dfg_add_inst_well_formed]
+  metis_tac[dfg_add_inst_well_formed_proof]
 QED
 
-Theorem dfg_build_insts_well_formed:
+Theorem dfg_build_insts_well_formed_proof:
   !insts. well_formed_dfg (dfg_build_insts insts)
 Proof
   rw[dfg_build_insts_def, dfg_empty_def] >>
-  match_mp_tac dfg_build_insts_rev_well_formed >>
+  match_mp_tac dfg_build_insts_rev_well_formed_proof >>
   rw[well_formed_dfg_def, dfg_get_def_def, dfg_empty_def]
 QED
 
-Theorem dfg_build_function_well_formed:
+Theorem dfg_build_function_well_formed_proof:
   !fn. well_formed_dfg (dfg_build_function fn)
 Proof
-  rw[dfg_build_function_def, dfg_build_insts_well_formed]
+  rw[dfg_build_function_def, dfg_build_insts_well_formed_proof]
 QED
 
 (* --------------------------------------------------------------------------
    Def-source correctness
    -------------------------------------------------------------------------- *)
 
-Theorem dfg_add_defs_lookup:
+Theorem dfg_add_defs_lookup_proof:
   !dfg vs inst v inst'.
     dfg_get_def (dfg_add_defs dfg vs inst) v = SOME inst' ==>
     dfg_get_def dfg v = SOME inst' \/ (inst' = inst /\ MEM v vs)
@@ -135,7 +121,7 @@ Proof
   metis_tac[]
 QED
 
-Theorem dfg_add_inst_get_def:
+Theorem dfg_add_inst_get_def_proof:
   !dfg inst0 v.
     dfg_get_def (dfg_add_inst dfg inst0) v =
     dfg_get_def
@@ -146,15 +132,15 @@ Proof
   rw[dfg_add_inst_def, dfg_get_def_def]
 QED
 
-Theorem dfg_add_inst_lookup:
+Theorem dfg_add_inst_lookup_proof:
   !dfg inst0 v inst.
     dfg_get_def (dfg_add_inst dfg inst0) v = SOME inst ==>
     dfg_get_def dfg v = SOME inst \/ (inst = inst0 /\ MEM v inst0.inst_outputs)
 Proof
-  metis_tac[dfg_add_inst_get_def, dfg_add_defs_lookup, dfg_add_uses_get_def]
+  metis_tac[dfg_add_inst_get_def_proof, dfg_add_defs_lookup_proof, dfg_add_uses_get_def_proof]
 QED
 
-Theorem dfg_build_insts_rev_correct:
+Theorem dfg_build_insts_rev_correct_proof:
   !insts dfg v inst.
     dfg_get_def (dfg_build_insts_rev dfg insts) v = SOME inst ==>
     dfg_get_def dfg v = SOME inst \/
@@ -163,31 +149,31 @@ Proof
   Induct_on `insts` >> rw[dfg_build_insts_rev_def] >>
   first_x_assum drule >>
   disch_then strip_assume_tac >- (
-    drule dfg_add_inst_lookup >> simp[] >>
+    drule dfg_add_inst_lookup_proof >> simp[] >>
     strip_tac >> metis_tac[]
   ) >>
   metis_tac[]
 QED
 
-Theorem dfg_build_insts_correct:
+Theorem dfg_build_insts_correct_proof:
   !insts v inst.
     dfg_get_def (dfg_build_insts insts) v = SOME inst ==>
     MEM inst insts /\ MEM v inst.inst_outputs
 Proof
   rw[dfg_build_insts_def] >>
-  drule (Q.SPECL [`REVERSE insts`, `dfg_empty`, `v`, `inst`] dfg_build_insts_rev_correct) >>
+  drule (Q.SPECL [`REVERSE insts`, `dfg_empty`, `v`, `inst`] dfg_build_insts_rev_correct_proof) >>
   simp[dfg_get_def_def, dfg_empty_def] >>
   metis_tac[MEM_REVERSE]
 QED
 
-Theorem dfg_build_function_correct:
+Theorem dfg_build_function_correct_proof:
   !fn v inst.
     dfg_get_def (dfg_build_function fn) v = SOME inst
     ==>
     MEM v inst.inst_outputs /\ MEM inst (fn_insts fn)
 Proof
   rw[dfg_build_function_def] >>
-  drule dfg_build_insts_correct >>
+  drule dfg_build_insts_correct_proof >>
   simp[]
 QED
 
@@ -195,16 +181,77 @@ QED
    Finiteness/termination helpers
    -------------------------------------------------------------------------- *)
 
-Theorem dfg_def_ids_finite:
+Theorem dfg_def_ids_finite_proof:
   !dfg. FINITE (dfg_def_ids dfg)
 Proof
   rw[dfg_def_ids_def, IMAGE_FINITE, FINITE_FRANGE]
 QED
 
-Theorem dfg_get_def_implies_dfg_def_ids:
+Theorem dfg_get_def_implies_dfg_def_ids_proof:
   !dfg v inst. dfg_get_def dfg v = SOME inst ==> inst.inst_id IN dfg_def_ids dfg
 Proof
   metis_tac[dfg_def_ids_def, IN_IMAGE, IN_FRANGE_FLOOKUP, dfg_get_def_def]
 QED
 
-val _ = export_theory();
+(* --------------------------------------------------------------------------
+   Uses correctness
+   -------------------------------------------------------------------------- *)
+
+(* If dfg_get_uses reports inst as a user of v, then inst is from the
+   function and v appears among its operand variables. *)
+Theorem dfg_build_function_uses_sound_proof:
+  !fn v inst.
+    MEM inst (dfg_get_uses (dfg_build_function fn) v) ==>
+    MEM inst (fn_insts fn) /\ MEM v (operand_vars inst.inst_operands)
+Proof
+  cheat
+QED
+
+(* Every instruction in the function that mentions v as an operand
+   variable appears in the uses list for v. *)
+Theorem dfg_build_function_uses_complete_proof:
+  !fn v inst.
+    MEM inst (fn_insts fn) /\
+    MEM v (operand_vars inst.inst_operands) ==>
+    MEM inst (dfg_get_uses (dfg_build_function fn) v)
+Proof
+  cheat
+QED
+
+(* --------------------------------------------------------------------------
+   Defs completeness
+   -------------------------------------------------------------------------- *)
+
+(* If any instruction in the function lists v as an output, then
+   dfg_get_def returns some defining instruction for v. *)
+Theorem dfg_build_function_defs_complete_proof:
+  !fn v inst.
+    MEM inst (fn_insts fn) /\
+    MEM v inst.inst_outputs ==>
+    ?inst'. dfg_get_def (dfg_build_function fn) v = SOME inst'
+Proof
+  cheat
+QED
+
+(* --------------------------------------------------------------------------
+   ID map correctness
+   -------------------------------------------------------------------------- *)
+
+(* If dfg_get_inst_by_id returns an instruction, it is from the function. *)
+Theorem dfg_build_function_ids_sound_proof:
+  !fn id inst.
+    dfg_get_inst_by_id (dfg_build_function fn) id = SOME inst ==>
+    MEM inst (fn_insts fn)
+Proof
+  cheat
+QED
+
+(* Every instruction in the function is retrievable by its ID. *)
+Theorem dfg_build_function_ids_complete_proof:
+  !fn inst.
+    MEM inst (fn_insts fn) ==>
+    ?inst'. dfg_get_inst_by_id (dfg_build_function fn) inst.inst_id = SOME inst'
+Proof
+  cheat
+QED
+

--- a/venom/analysis/venomAnalysisHolScript.sml
+++ b/venom/analysis/venomAnalysisHolScript.sml
@@ -13,4 +13,4 @@ Ancestors
   (* liveness *)
   livenessAnalysis
   (* dfg *)
-  dfgAnalysisCorrectness
+  dfgAnalysis

--- a/venom/passes/phi_elimination/Holmakefile
+++ b/venom/passes/phi_elimination/Holmakefile
@@ -1,2 +1,2 @@
 # PHI elimination pass for Venom IR
-INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../.. ../../analysis ../../../syntax ../../../semantics
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../.. ../../analysis ../../analysis/dfg ../../analysis/dfg/defs ../../analysis/dfg/proofs ../../../syntax ../../../semantics

--- a/venom/passes/phi_elimination/dfgOriginsScript.sml
+++ b/venom/passes/phi_elimination/dfgOriginsScript.sml
@@ -27,7 +27,7 @@
 
 Theory dfgOrigins
 Ancestors
-  dfgDefs pred_set list
+  phiDefs pred_set list
 
 (* ==========================================================================
    Origin Computation

--- a/venom/passes/phi_elimination/phiBlockScript.sml
+++ b/venom/passes/phi_elimination/phiBlockScript.sml
@@ -24,7 +24,7 @@
 
 Theory phiBlock
 Ancestors
-  phiWellFormed execEquiv venomSem venomState venomInst dfgDefs dfgOrigins phiTransform stateEquiv list
+  phiWellFormed execEquiv venomSem venomState venomInst phiDefs dfgOrigins phiTransform stateEquiv list
 
 (* ==========================================================================
    Instruction Step Lemmas

--- a/venom/passes/phi_elimination/phiDefsScript.sml
+++ b/venom/passes/phi_elimination/phiDefsScript.sml
@@ -1,14 +1,17 @@
 (*
- * Data-Flow Graph (DFG) Definitions for PHI Elimination
+ * PHI Elimination — Definitions
  *
- * This theory is a PHI-local compatibility layer over the shared DFG analysis.
- * The shared analysis keeps multi-output definitions; PHI elimination uses a
- * lookup view that treats non-singleton outputs as absent.
+ * PHI-specific definitions for the elimination pass:
+ *   - dfg_lookup: singleton-output filtered DFG lookup
+ *   - ssa_form: SSA well-formedness predicate
+ *   - dfg_ids: instruction IDs visible through dfg_lookup
+ *   - phi_var_operands, phi_well_formed: PHI operand helpers
+ *   - assign_var_operand, is_phi_inst: instruction classification
  *)
 
-Theory dfgDefs
+Theory phiDefs
 Ancestors
-  dfgAnalysisCorrectness pred_set list finite_map
+  dfgDefs dfgAnalysisProps pred_set list finite_map
   venomState venomInst venomSem
 
 (* ==========================================================================

--- a/venom/passes/phi_elimination/phiFunctionScript.sml
+++ b/venom/passes/phi_elimination/phiFunctionScript.sml
@@ -20,7 +20,7 @@
 
 Theory phiFunction
 Ancestors
-  phiBlock execEquiv venomSem venomInst stateEquiv phiWellFormed phiTransform dfgDefs list
+  phiBlock execEquiv venomSem venomInst stateEquiv phiWellFormed phiTransform phiDefs list
 
 (* ==========================================================================
    Function Execution Helpers

--- a/venom/passes/phi_elimination/phiTransformScript.sml
+++ b/venom/passes/phi_elimination/phiTransformScript.sml
@@ -27,7 +27,7 @@
 Theory phiTransform
 Ancestors
   list finite_map pred_set
-  venomState venomInst venomSem dfgDefs dfgOrigins
+  venomState venomInst venomSem phiDefs dfgOrigins
 
 (* ==========================================================================
    PHI Elimination Transformation

--- a/venom/passes/phi_elimination/phiWellFormedScript.sml
+++ b/venom/passes/phi_elimination/phiWellFormedScript.sml
@@ -21,7 +21,7 @@
 
 Theory phiWellFormed
 Ancestors
-  phiTransform stateEquiv venomSem venomState dfgDefs dfgOrigins list
+  phiTransform stateEquiv venomSem venomState phiDefs dfgOrigins list
 
 (* ==========================================================================
    Well-Formedness Definitions
@@ -110,7 +110,7 @@ End
    PHI Resolution Lemmas
    ========================================================================== *)
 
-(* Note: resolve_phi_in_operands is in dfgDefsTheory *)
+(* Note: resolve_phi_in_operands is in phiDefsTheory *)
 
 Theorem resolve_phi_well_formed:
   !prev_bb ops v.


### PR DESCRIPTION
_co-authored by claude opus 4.6_

Refactor DFG analysis to follow the same `defs/` `proofs/` `*Props` `*Script` structure used by cfg, fcg, and liveness.

## Changes

**DFG restructured** (`analysis/dfgAnalysis*.sml` → `analysis/dfg/`):
- `defs/dfgDefsScript.sml` — all definitions (type, build functions, query API, `well_formed_dfg`, `dfg_def_ids`)
- `proofs/dfgCorrectnessProofScript.sml` — all proofs with `_proof` suffix
- `dfgAnalysisPropsScript.sml` — safety properties (ACCEPT_TAC re-exports only)
- `dfgAnalysisScript.sml` — public API roll-up

**PHI elimination rename** (resolves theory name collision):
- `dfgDefsScript.sml` (Theory `dfgDefs`) → `phiDefsScript.sml` (Theory `phiDefs`)
- All phi_elimination ancestors updated

**Style**: removed `export_theory()` per modern HOL4 convention.

## Safety properties

| # | Property | Map | Description | Formal |
|---|----------|-----|-------------|--------|
| 1 | Well-formedness | defs | Building a DFG preserves the invariant that every def maps a variable to an instruction that outputs it | `dfg_get_def v = SOME inst ⇒ MEM v inst.inst_outputs` |
| 2 | Defs soundness | defs | Every variable-to-instruction entry in the def map corresponds to an actual instruction in the function | `dfg_get_def v = SOME inst ⇒ MEM inst (fn_insts fn) ∧ MEM v inst.inst_outputs` |
| 3 | Defs completeness | defs | Every variable defined by some instruction in the function has an entry in the def map | `MEM inst (fn_insts fn) ∧ MEM v inst.inst_outputs ⇒ ∃inst'. dfg_get_def v = SOME inst'` |
| 4 | Uses soundness | uses | Every instruction in a variable's use list actually appears in the function and uses that variable | `MEM inst (dfg_get_uses dfg v) ⇒ MEM inst (fn_insts fn) ∧ MEM v (operand_vars inst.inst_operands)` |
| 5 | Uses completeness | uses | Every instruction in the function that reads a variable appears in that variable's use list | `MEM inst (fn_insts fn) ∧ MEM v (operand_vars inst.inst_operands) ⇒ MEM inst (dfg_get_uses dfg v)` |
| 6 | ID soundness | ids | Every instruction retrievable by ID is from the original function | `dfg_get_inst_by_id dfg id = SOME inst ⇒ MEM inst (fn_insts fn)` |
| 7 | ID completeness | ids | Every instruction in the function is retrievable by its ID | `MEM inst (fn_insts fn) ⇒ ∃inst'. dfg_get_inst_by_id dfg inst.inst_id = SOME inst'` |
| 8 | Finiteness | defs | The set of instruction IDs in the def map is finite (used for termination of origin computation) | `FINITE (dfg_def_ids dfg)` |

## Build

All analyses and passes build clean. Only CHEATED warnings are from stubs 3–7.

