### PR TITLE
mem_alias: defs + cheated property statements

### DIFF
--- a/venom/analysis/Holmakefile
+++ b/venom/analysis/Holmakefile
@@ -14,4 +14,5 @@ INCLUDES = \
   dominators \
   base_ptr \
   available_expression \
-  stack_order
+  stack_order \
+  mem_alias

--- a/venom/analysis/mem_alias/Holmakefile
+++ b/venom/analysis/mem_alias/Holmakefile
@@ -1,0 +1,2 @@
+# Memory alias analysis: public API (props + analysis)
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../.. ../../../syntax ../../../semantics ../shared ../cfg/defs ../dataflow/defs ../base_ptr defs proofs

--- a/venom/analysis/mem_alias/defs/Holmakefile
+++ b/venom/analysis/mem_alias/defs/Holmakefile
@@ -1,0 +1,2 @@
+# Memory alias analysis definitions
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../../.. ../../../../syntax ../../../../semantics ../../shared ../../cfg/defs ../../dataflow/defs ../../base_ptr

--- a/venom/analysis/mem_alias/defs/memAliasDefsScript.sml
+++ b/venom/analysis/mem_alias/defs/memAliasDefsScript.sml
@@ -1,0 +1,171 @@
+(*
+ * Memory Alias Analysis — Definitions
+ *
+ * Ported from vyper/venom/analysis/mem_alias.py.
+ * Coarse memory alias analysis: determines which memory locations may alias.
+ * For each instruction, computes read/write locations via base pointer analysis,
+ * then builds pairwise alias sets using may_overlap.
+ *
+ * TOP-LEVEL:
+ *   alias_sets (type), wf_alias_sets,
+ *   ma_analyze_inst, ma_analyze_block, ma_analyze,
+ *   ma_may_alias, ma_mark_volatile,
+ *   memory_alias_analyze, storage_alias_analyze, transient_alias_analyze
+ *
+ * Helper:
+ *   ma_add_location, ma_analyze_blocks
+ *
+ * Divergences from Python:
+ *   - alias_sets is (mem_loc, mem_loc list) fmap instead of dict[MemoryLocation, OrderedSet]
+ *   - Three instantiations (Memory/Storage/Transient) via addr_space parameter
+ *   - ma_may_alias is pure (Python version lazily mutates alias_sets for unknown locs)
+ *)
+
+Theory memAliasDefs
+Ancestors
+  basePtrDefs
+
+(* ===== Alias Set Type ===== *)
+
+(* Map from memory locations to lists of potentially aliasing locations.
+ * Each location maps to the set of known locations that may_overlap with it. *)
+Type alias_sets = ``:(mem_loc, mem_loc list) fmap``
+
+(* ===== Well-Formedness Invariant ===== *)
+
+(* An alias set is well-formed when:
+ *   1. Correctness: every entry in an alias list actually overlaps its key
+ *   2. Completeness: if two tracked locations overlap, each appears in the
+ *      other's alias list
+ * Symmetry of alias lists follows from (1) + (2). *)
+Definition wf_alias_sets_def:
+  wf_alias_sets (sets : alias_sets) ⇔
+    (* Correctness: listed aliases actually overlap *)
+    (∀loc als a.
+       FLOOKUP sets loc = SOME als ∧ MEM a als ⇒
+       may_overlap loc a) ∧
+    (* Completeness: overlapping tracked locations are cross-listed *)
+    (∀l1 l2 als1.
+       FLOOKUP sets l1 = SOME als1 ∧ l2 ∈ FDOM sets ∧ may_overlap l1 l2 ⇒
+       MEM l2 als1)
+End
+
+(* ===== Core: Add a Location to Alias Sets ===== *)
+
+(* Add a memory location to alias sets, updating pairwise relationships.
+ * For each existing location that may_overlap with loc, add loc to its alias
+ * list and add it to loc's alias list.
+ * Matches Python _analyze_mem_location. *)
+Definition ma_add_location_def:
+  ma_add_location (sets : alias_sets) loc =
+    let current = case FLOOKUP sets loc of SOME l => l | NONE => [] in
+    (* Find all existing locations that overlap with loc *)
+    let keys = MAP FST (fmap_to_alist sets) in
+    let overlapping = FILTER (λk. may_overlap loc k) keys in
+    (* Add loc as alias of each overlapping location *)
+    let sets1 = FOLDL (λs k.
+      let old = case FLOOKUP s k of SOME l => l | NONE => [] in
+      if MEM loc old then s else s |+ (k, loc :: old)) sets overlapping in
+    (* Set loc's alias list to all overlapping locations *)
+    sets1 |+ (loc, overlapping ++ current)
+End
+
+(* ===== Instruction-Level Analysis ===== *)
+
+(* Analyze one instruction: add its read and write locations to alias sets.
+ * Matches Python _analyze_instruction. *)
+Definition ma_analyze_inst_def:
+  ma_analyze_inst bp_result addr_sp (sets : alias_sets) inst =
+    let rloc = bp_get_read_location bp_result inst addr_sp in
+    let wloc = bp_get_write_location bp_result inst addr_sp in
+    let sets1 = if rloc = ml_empty ∨ rloc = ml_undefined then sets
+                else ma_add_location sets rloc in
+    let sets2 = if wloc = ml_empty ∨ wloc = ml_undefined then sets1
+                else ma_add_location sets1 wloc in
+    sets2
+End
+
+(* ===== Block-Level Analysis ===== *)
+
+(* Process all instructions in a block. *)
+Definition ma_analyze_block_def:
+  ma_analyze_block bp_result addr_sp sets [] = sets ∧
+  ma_analyze_block bp_result addr_sp sets (inst::insts) =
+    ma_analyze_block bp_result addr_sp
+      (ma_analyze_inst bp_result addr_sp sets inst) insts
+End
+
+(* ===== Function-Level Analysis ===== *)
+
+(* Analyze all blocks in a function.
+ * Matches Python analyze. *)
+Definition ma_analyze_blocks_def:
+  ma_analyze_blocks bp_result addr_sp sets [] = sets ∧
+  ma_analyze_blocks bp_result addr_sp sets (bb::bbs) =
+    ma_analyze_blocks bp_result addr_sp
+      (ma_analyze_block bp_result addr_sp sets bb.bb_instructions) bbs
+End
+
+(* Top-level entry point.
+ * bp_result comes from bp_analyze (base pointer analysis). *)
+Definition ma_analyze_def:
+  ma_analyze bp_result fn addr_sp =
+    ma_analyze_blocks bp_result addr_sp FEMPTY fn.fn_blocks
+End
+
+(* ===== Query: May-Alias ===== *)
+
+(* Check if two locations may alias according to the analysis result.
+ * Volatile locations fall through to direct may_overlap check.
+ * For non-volatile, checks the precomputed alias sets.
+ * Falls back to may_overlap if location was not seen during analysis.
+ * Matches Python may_alias. *)
+Definition ma_may_alias_def:
+  ma_may_alias (sets : alias_sets) loc1 loc2 =
+    if loc1.ml_volatile ∨ loc2.ml_volatile then
+      may_overlap loc1 loc2
+    else
+      case (FLOOKUP sets loc1, FLOOKUP sets loc2) of
+        (SOME aliases1, SOME _) => MEM loc2 aliases1
+      | _ => may_overlap loc1 loc2
+End
+
+(* ===== Mark Volatile ===== *)
+
+(* Mark a location as volatile and propagate alias info.
+ * Volatile locations conservatively alias with everything that overlaps.
+ * Matches Python mark_volatile. *)
+Definition ma_mark_volatile_def:
+  ma_mark_volatile (sets : alias_sets) loc =
+    let vloc = mk_volatile loc in
+    case FLOOKUP sets loc of
+      NONE => (vloc, sets)
+    | SOME aliases =>
+        (* vloc aliases itself, loc, and everything loc aliases *)
+        let vloc_aliases = vloc :: loc :: FILTER (λa. a ≠ loc ∧ a ≠ vloc) aliases in
+        let sets1 = sets |+ (vloc, vloc_aliases) in
+        (* Add vloc to loc's alias list *)
+        let sets2 = sets1 |+ (loc, vloc :: aliases) in
+        (* Add vloc to all of loc's existing aliases *)
+        let sets3 = FOLDL (λs a.
+          if a = loc ∨ a = vloc then s
+          else case FLOOKUP s a of
+                 SOME alist => s |+ (a, vloc :: alist)
+               | NONE => s) sets2 (FILTER (λa. a ≠ loc ∧ a ≠ vloc) aliases) in
+        (vloc, sets3)
+End
+
+(* ===== Three Address-Space Instantiations ===== *)
+
+Definition memory_alias_analyze_def:
+  memory_alias_analyze bp_result fn = ma_analyze bp_result fn AddrSp_Memory
+End
+
+Definition storage_alias_analyze_def:
+  storage_alias_analyze bp_result fn = ma_analyze bp_result fn AddrSp_Storage
+End
+
+Definition transient_alias_analyze_def:
+  transient_alias_analyze bp_result fn = ma_analyze bp_result fn AddrSp_Transient
+End
+

--- a/venom/analysis/mem_alias/memAliasPropsScript.sml
+++ b/venom/analysis/mem_alias/memAliasPropsScript.sml
@@ -1,0 +1,76 @@
+(*
+ * Memory Alias Analysis — Properties (public API)
+ *
+ * Re-exports proven properties from proofs/ via ACCEPT_TAC.
+ * Consumers: just `Ancestors memAliasProps` to get defs + properties.
+ *
+ * TOP-LEVEL PROPERTIES:
+ *   ma_analyze_wf                 — analysis output satisfies wf_alias_sets
+ *   ma_may_alias_iff              — alias query ⟺ may_overlap (the key theorem)
+ *   ma_different_alloca_no_alias  — different base allocations ⟹ no alias
+ *   ma_empty_no_alias             — ml_empty never aliases with anything
+ *   ma_mark_volatile_is_volatile  — returned location has volatile flag set
+ *   ma_mark_volatile_preserves_wf — marking volatile preserves well-formedness
+ *)
+
+Theory memAliasProps
+Ancestors
+  memAliasDefs memAliasProofs
+
+(* ===== Core ===== *)
+
+(* The top-level analysis produces well-formed alias sets *)
+Theorem ma_analyze_wf:
+  ∀bp_result fn addr_sp.
+    wf_alias_sets (ma_analyze bp_result fn addr_sp)
+Proof ACCEPT_TAC memAliasProofsTheory.ma_analyze_wf
+QED
+
+(* For well-formed alias sets, the alias query is equivalent to may_overlap.
+ * The analysis is a precomputation of pairwise may_overlap, not an
+ * approximation — so consumers can reason purely about may_overlap. *)
+Theorem ma_may_alias_iff:
+  ∀sets loc1 loc2.
+    wf_alias_sets sets ⇒
+    (ma_may_alias sets loc1 loc2 ⇔ may_overlap loc1 loc2)
+Proof ACCEPT_TAC memAliasProofsTheory.ma_may_alias_iff
+QED
+
+(* ===== Convenience corollaries ===== *)
+
+(* Locations backed by different base allocations never alias *)
+Theorem ma_different_alloca_no_alias:
+  ∀sets loc1 loc2 a1 a2.
+    wf_alias_sets sets ∧
+    loc1.ml_alloca = SOME a1 ∧ loc2.ml_alloca = SOME a2 ∧ a1 ≠ a2 ⇒
+    ¬ma_may_alias sets loc1 loc2
+Proof ACCEPT_TAC memAliasProofsTheory.ma_different_alloca_no_alias
+QED
+
+(* The empty memory location (zero size at offset 0) never aliases *)
+Theorem ma_empty_no_alias:
+  ∀sets loc.
+    wf_alias_sets sets ⇒
+    ¬ma_may_alias sets ml_empty loc
+Proof ACCEPT_TAC memAliasProofsTheory.ma_empty_no_alias
+QED
+
+(* ===== ma_mark_volatile ===== *)
+
+(* The returned location has the volatile flag set *)
+Theorem ma_mark_volatile_is_volatile:
+  ∀sets loc vloc sets'.
+    ma_mark_volatile sets loc = (vloc, sets') ⇒
+    vloc.ml_volatile
+Proof ACCEPT_TAC memAliasProofsTheory.ma_mark_volatile_is_volatile
+QED
+
+(* Marking a location volatile preserves well-formedness *)
+Theorem ma_mark_volatile_preserves_wf:
+  ∀sets loc vloc sets'.
+    wf_alias_sets sets ∧
+    ma_mark_volatile sets loc = (vloc, sets') ⇒
+    wf_alias_sets sets'
+Proof ACCEPT_TAC memAliasProofsTheory.ma_mark_volatile_preserves_wf
+QED
+

--- a/venom/analysis/mem_alias/proofs/Holmakefile
+++ b/venom/analysis/mem_alias/proofs/Holmakefile
@@ -1,0 +1,2 @@
+# Memory alias analysis proofs
+INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../../.. ../../../../syntax ../../../../semantics ../../shared ../../cfg/defs ../../dataflow/defs ../../base_ptr ../defs

--- a/venom/analysis/mem_alias/proofs/memAliasProofsScript.sml
+++ b/venom/analysis/mem_alias/proofs/memAliasProofsScript.sml
@@ -1,0 +1,164 @@
+(*
+ * Memory Alias Analysis — Proofs (internal)
+ *
+ * Cheated proofs for safety properties. The externally-facing API
+ * is in memAliasPropsScript.sml (ACCEPT_TAC wrappers).
+ *)
+
+Theory memAliasProofs
+Ancestors
+  memAliasDefs memLocProps
+Libs
+  finite_mapTheory
+
+(* ===== ma_add_location (internal stepping stones) ===== *)
+
+Theorem ma_add_location_loc_in_domain[local]:
+  ∀sets loc. loc ∈ FDOM (ma_add_location sets loc)
+Proof
+  rw[ma_add_location_def, LET_THM, FDOM_FUPDATE]
+QED
+
+Theorem ma_add_location_preserves_domain[local]:
+  ∀sets loc k. k ∈ FDOM sets ⇒ k ∈ FDOM (ma_add_location sets loc)
+Proof cheat
+QED
+
+Theorem ma_add_location_aliases_overlap[local]:
+  ∀sets loc aliases.
+    FLOOKUP (ma_add_location sets loc) loc = SOME aliases ⇒
+    ∀a. MEM a aliases ⇒
+      a ∈ FDOM sets ∧ may_overlap loc a ∨
+      MEM a (case FLOOKUP sets loc of NONE => [] | SOME l => l)
+Proof cheat
+QED
+
+Theorem ma_add_location_overlap_recorded[local]:
+  ∀sets loc k.
+    k ∈ FDOM sets ∧ may_overlap loc k ⇒
+    ∃aliases. FLOOKUP (ma_add_location sets loc) k = SOME aliases ∧
+              MEM loc aliases
+Proof cheat
+QED
+
+Theorem ma_add_location_preserves_wf[local]:
+  ∀sets loc.
+    wf_alias_sets sets ⇒
+    wf_alias_sets (ma_add_location sets loc)
+Proof cheat
+QED
+
+(* ===== domain monotonicity (internal stepping stones) ===== *)
+
+Theorem ma_analyze_block_domain_mono[local]:
+  ∀bp addr sets insts k.
+    k ∈ FDOM sets ⇒
+    k ∈ FDOM (ma_analyze_block bp addr sets insts)
+Proof cheat
+QED
+
+Theorem ma_analyze_blocks_domain_mono[local]:
+  ∀bp addr sets bbs k.
+    k ∈ FDOM sets ⇒
+    k ∈ FDOM (ma_analyze_blocks bp addr sets bbs)
+Proof cheat
+QED
+
+(* ===== wf_alias_sets: analysis output is well-formed ===== *)
+
+(* The analysis produces well-formed alias sets.
+ * Proof sketch: FEMPTY is trivially wf, ma_add_location preserves wf,
+ * ma_analyze_inst/block/blocks preserve wf by induction. *)
+Theorem ma_analyze_wf:
+  ∀bp_result fn addr_sp.
+    wf_alias_sets (ma_analyze bp_result fn addr_sp)
+Proof cheat
+QED
+
+(* ===== ma_may_alias ===== *)
+
+(* ma_may_alias is equivalent to may_overlap for well-formed alias sets.
+ * This is THE key theorem — the alias query is a precomputation of
+ * pairwise may_overlap, not an approximation.
+ *
+ * Proof sketch, by cases on ma_may_alias_def:
+ *   volatile: ma_may_alias = may_overlap by definition.
+ *   (SOME als1, SOME _): MEM loc2 als1 ⟺ may_overlap loc1 loc2
+ *     Forward: wf correctness.  Backward: wf completeness (loc2 ∈ FDOM).
+ *   fallback: ma_may_alias = may_overlap by definition. *)
+Theorem ma_may_alias_iff:
+  ∀sets loc1 loc2.
+    wf_alias_sets sets ⇒
+    (ma_may_alias sets loc1 loc2 ⇔ may_overlap loc1 loc2)
+Proof cheat
+QED
+
+(* Locations backed by different base allocations never alias.
+ * Convenience corollary: ma_may_alias_iff + different_alloca_no_overlap. *)
+Theorem ma_different_alloca_no_alias:
+  ∀sets loc1 loc2 a1 a2.
+    wf_alias_sets sets ∧
+    loc1.ml_alloca = SOME a1 ∧ loc2.ml_alloca = SOME a2 ∧ a1 ≠ a2 ⇒
+    ¬ma_may_alias sets loc1 loc2
+Proof cheat
+QED
+
+(* The empty memory location never aliases with anything.
+ * Convenience corollary: ma_may_alias_iff + empty_no_overlap_l. *)
+Theorem ma_empty_no_alias:
+  ∀sets loc.
+    wf_alias_sets sets ⇒
+    ¬ma_may_alias sets ml_empty loc
+Proof cheat
+QED
+
+(* Empty function produces empty alias sets *)
+Theorem ma_analyze_empty[local]:
+  ∀bp addr_sp fn.
+    fn.fn_blocks = [] ⇒
+    ma_analyze bp fn addr_sp = FEMPTY
+Proof
+  rw[ma_analyze_def, ma_analyze_blocks_def]
+QED
+
+(* ===== ma_may_alias characterization (local, subsumed by iff) ===== *)
+
+Theorem ma_may_alias_volatile[local]:
+  ∀sets loc1 loc2.
+    loc1.ml_volatile ∨ loc2.ml_volatile ⇒
+    (ma_may_alias sets loc1 loc2 ⇔ may_overlap loc1 loc2)
+Proof
+  rw[ma_may_alias_def]
+QED
+
+Theorem ma_may_alias_unknown[local]:
+  ∀sets loc1 loc2.
+    ¬loc1.ml_volatile ∧ ¬loc2.ml_volatile ∧
+    (FLOOKUP sets loc1 = NONE ∨ FLOOKUP sets loc2 = NONE) ⇒
+    (ma_may_alias sets loc1 loc2 ⇔ may_overlap loc1 loc2)
+Proof
+  rw[ma_may_alias_def] >>
+  BasicProvers.EVERY_CASE_TAC >> gvs[]
+QED
+
+(* ===== ma_mark_volatile ===== *)
+
+(* The returned location is volatile *)
+Theorem ma_mark_volatile_is_volatile:
+  ∀sets loc vloc sets'.
+    ma_mark_volatile sets loc = (vloc, sets') ⇒
+    vloc.ml_volatile
+Proof
+  rw[ma_mark_volatile_def, memLocDefsTheory.mk_volatile_def, LET_THM] >>
+  BasicProvers.EVERY_CASE_TAC >> gvs[]
+QED
+
+(* mark_volatile preserves well-formedness of alias sets *)
+Theorem ma_mark_volatile_preserves_wf:
+  ∀sets loc vloc sets'.
+    wf_alias_sets sets ∧
+    ma_mark_volatile sets loc = (vloc, sets') ⇒
+    wf_alias_sets sets'
+Proof cheat
+QED
+

--- a/venom/analysis/venomAnalysisHolScript.sml
+++ b/venom/analysis/venomAnalysisHolScript.sml
@@ -23,3 +23,5 @@ Ancestors
   availExprAnalysis
   (* stack order *)
   stackOrderProps
+  (* memory alias *)
+  memAliasProps


### PR DESCRIPTION
_co-authored by claude opus 4.6_

## Memory Alias Analysis — Scaffolding

Ported from `vyper/venom/analysis/mem_alias.py`. Coarse memory alias analysis: determines which memory locations may alias by precomputing pairwise `may_overlap` relationships.

### Files (8 files, ~420 LOC)

- `venom/analysis/mem_alias/defs/memAliasDefsScript.sml` — definitions: `alias_sets` type, `wf_alias_sets` invariant, `ma_add_location`, `ma_analyze_inst/block/blocks/analyze`, `ma_may_alias`, `ma_mark_volatile`, three addr-space instantiations
- `venom/analysis/mem_alias/proofs/memAliasProofsScript.sml` — 17 theorems (5 proved, 12 cheated)
- `venom/analysis/mem_alias/memAliasPropsScript.sml` — public API (6 theorems via ACCEPT_TAC)
- Holmakefiles ×3, updated `venom/analysis/Holmakefile` and `venomAnalysisHolScript.sml`

### Key design

- `wf_alias_sets` (correctness + completeness invariant) as the central predicate
- `ma_may_alias_iff`: for well-formed sets, `ma_may_alias sets loc1 loc2 ⟺ may_overlap loc1 loc2`
- This single theorem subsumes soundness, symmetry, and domain-specific corollaries
- Internal stepping stones (add_location helpers, domain monotonicity) are `[local]`

### Public API (6 theorems)

| theorem | description |
|---------|-------------|
| `ma_analyze_wf` | The top-level analysis always produces well-formed alias sets (correctness + completeness of pairwise overlap tracking) |
| `ma_may_alias_iff` | For well-formed alias sets, the alias query is equivalent to `may_overlap` — the analysis is a faithful precomputation, not an approximation |
| `ma_different_alloca_no_alias` | Locations backed by distinct base allocations (`alloca = SOME a1`, `alloca = SOME a2`, `a1 ≠ a2`) are guaranteed non-aliasing |
| `ma_empty_no_alias` | The zero-size empty location `ml_empty` never aliases with any location |
| `ma_mark_volatile_is_volatile` | `ma_mark_volatile` returns a location with the `ml_volatile` flag set |
| `ma_mark_volatile_preserves_wf` | Marking a tracked location as volatile preserves the well-formedness invariant of the alias sets |

### Status

Scaffolding PR — 12 cheats remaining, to be filled in separately. Builds clean. Unblocks `mem_ssa` worktree.
