### PR TITLE
Fix MCE: clear load facts for all affected address spaces in volatile case

### DIFF
--- a/venom/passes/memory_copy_elision/defs/memoryCopyElisionDefsScript.sml
+++ b/venom/passes/memory_copy_elision/defs/memoryCopyElisionDefsScript.sml
@@ -466,13 +466,19 @@ Definition load_store_step_def:
       let write_loc = bp_get_write_location bp inst AddrSp_Memory in
       let lf' = invalidate_loads aliases lf write_loc AddrSp_Memory in
       (lf', inst)
-    (* 4. Volatile memory writers: clear MEMORY loads only.
-       Python: _volatile_memory → self.loads[Effects.MEMORY].clear()
-       Storage and transient load facts survive. *)
+    (* 4. Volatile writers: clear loads for every address space whose
+       effect is in the instruction's write_effects.
+       DIVERGENCE from Python: upstream only clears MEMORY loads here
+       (vyper/venom/passes/memory_copy_elision.py L276-280), keeping
+       STORAGE and TRANSIENT facts alive across INVOKE/CALL/etc.
+       That is unsound — see https://github.com/vyperlang/vyper/pull/4914 *)
     else if Eff_MEMORY IN write_effects inst.inst_opcode then
+      let weffs = write_effects inst.inst_opcode in
       let lf' = DRESTRICT lf
-        { v | !lfact. FLOOKUP lf v = SOME lfact ==>
-              load_opcode_addr_space lfact.lf_opcode <> AddrSp_Memory } in
+        { v | !lfact eff. FLOOKUP lf v = SOME lfact /\
+              effect_of_addr_space
+                (load_opcode_addr_space lfact.lf_opcode) = SOME eff ==>
+              eff NOTIN weffs } in
       (lf', inst)
     else (lf, inst)
 End

--- a/venom/passes/memory_copy_elision/proofs/memoryCopyElisionProofsScript.sml
+++ b/venom/passes/memory_copy_elision/proofs/memoryCopyElisionProofsScript.sml
@@ -18,7 +18,7 @@ Ancestors
   passSimulationDefs passSimulationProps passSharedDefs passSharedProps
   stateEquiv stateEquivProps
   basePtrDefs basePtrProps basePtrProofs
-  venomWf venomInst venomInstProps venomExecSemantics venomExecProps
+  venomWf venomInst venomInstProps venomEffects venomExecSemantics venomExecProps
   venomState venomMemDefs venomMemProps
   dfgAnalysisProps dfgCorrectnessProof dfgDefs dfAnalyzeDefs
   dfIterateProps dfIterateProofs
@@ -3813,22 +3813,34 @@ QED
    accounts/transient/call_ctx/allocas/lookup_var are unchanged.
    Used for Branch 4 (Eff_MEMORY ∈ write_effects) where MLOAD entries are
    removed but SLOAD/TLOAD entries survive. *)
+(* DRESTRICT to entries whose address-space effect is not in weffs.
+   Requires that the surviving facts' state components are preserved.
+   Used for Branch 4 where volatile instructions clear affected loads. *)
 Triviality lf_sound_drestrict_non_memory[local]:
-  !lf s s'.
+  !lf weffs s s'.
     lf_sound lf s /\
+    Eff_MEMORY IN weffs /\
     s'.vs_accounts = s.vs_accounts /\
     s'.vs_transient = s.vs_transient /\
     s'.vs_call_ctx = s.vs_call_ctx /\
     s'.vs_allocas = s.vs_allocas /\
     (!v. lookup_var v s' = lookup_var v s) ==>
     lf_sound (DRESTRICT lf
-      {v | !lfact. FLOOKUP lf v = SOME lfact ==>
-           load_opcode_addr_space lfact.lf_opcode <> AddrSp_Memory}) s'
+      {v | !lfact eff. FLOOKUP lf v = SOME lfact /\
+           effect_of_addr_space
+             (load_opcode_addr_space lfact.lf_opcode) = SOME eff ==>
+           eff NOTIN weffs}) s'
 Proof
   simp[lf_sound_def, FLOOKUP_DRESTRICT] >>
   rpt strip_tac >>
   first_x_assum drule >> strip_tac >>
   first_x_assum drule >> strip_tac >>
+  (* The surviving entry has effect_of_addr_space ... = SOME eff
+     with eff NOTIN weffs, so in particular eff <> Eff_MEMORY,
+     meaning the load opcode is SLOAD or TLOAD, not MLOAD. *)
+  `load_opcode_addr_space lfact.lf_opcode <> AddrSp_Memory` by
+    (CCONTR_TAC >> gvs[load_opcode_addr_space_def,
+       effect_of_addr_space_def]) >>
   qexists `addr` >> rpt conj_tac
   >- gvs[resolve_memloc_offset_def]
   >- (qpat_x_assum `lookup_var _ _ = _` mp_tac >>
@@ -4175,7 +4187,7 @@ Resume lse_inv_preserved[branch4]:
        branch4_state_preserves >> simp[]) >>
   simp[load_store_step_def, LET_THM] >>
   irule lf_sound_drestrict_non_memory >>
-  qexists `s` >> simp[]
+  simp[] >> qexists_tac `s` >> simp[]
 QED
 
 Resume lse_inv_preserved[branch1_load]:


### PR DESCRIPTION
_co-authored by claude opus 4.6_

Fix a soundness bug in the memory copy elision load-store pass: the volatile memory handler (case 4 of `load_store_step`) only cleared MEMORY load facts, leaving STORAGE and TRANSIENT load facts alive across instructions like INVOKE, CALL, and DELEGATECALL that can modify storage and transient storage. This could cause incorrect load-store elision.

**Upstream Python bug**: The same issue exists in `_volatile_memory` in `vyper/venom/passes/memory_copy_elision.py` (L276-280), which only clears `self.loads[Effects.MEMORY]`. Reported as https://github.com/vyperlang/vyper/pull/4914.

### Changes

**Definitions** (`memoryCopyElisionDefsScript.sml`):
- `load_store_step_def` case 4: DRESTRICT predicate now uses `effect_of_addr_space` and `write_effects` to filter load facts by address space, instead of hardcoding `AddrSp_Memory`
- For INVOKE (`write_effects = all_effects`), all load facts are cleared
- For instructions that only write MEMORY (DLOAD, CALLDATACOPY, etc.), behavior is unchanged

**Proofs** (`memoryCopyElisionProofsScript.sml`):
- Updated `lf_sound_drestrict_non_memory` lemma to match new DRESTRICT predicate shape
- Added `venomEffects` to Ancestors for `effect_of_addr_space_def`
- Adapted branch4 call site

Build passes, no new cheats introduced.
