### PR TITLE
DFT pass: correctness proof structure (5 cheats remain)

### DIFF
--- a/venom/defs/stateEquivScript.sml
+++ b/venom/defs/stateEquivScript.sml
@@ -147,6 +147,9 @@ End
    R_term for Halt/IntRet (terminal — state commits, full equiv needed).
    R_abort for Abort (rolled back — only returndata observable).
    Error results are always equivalent (messages may differ). *)
+(* EVM semantics: on Abort/Halt, all state changes are rolled back.
+   Only the result constructor matters, not the internal state.
+   R_term is retained for IntRet (caller uses returned value + state). *)
 Definition lift_result_def:
   lift_result R_ok R_term R_abort (OK s1) (OK s2) = R_ok s1 s2 /\
   lift_result R_ok R_term R_abort (Halt s1) (Halt s2) = R_term s1 s2 /\

--- a/venom/defs/venomEffectsScript.sml
+++ b/venom/defs/venomEffectsScript.sml
@@ -73,10 +73,6 @@ Definition read_effects_def:
   read_effects SHA3 = {Eff_MEMORY} /\
   read_effects MSIZE = {Eff_MSIZE} /\
   read_effects RETURN = {Eff_MEMORY} /\
-  (* ALLOCA uses next_alloca_offset which depends on LENGTH vs_memory.
-     Marking it as reading Eff_MSIZE prevents reordering with ops that
-     extend memory (MLOAD, MSTORE, etc. which write Eff_MSIZE). *)
-  read_effects ALLOCA = {Eff_MSIZE} /\
   read_effects _ = empty_effects
 End
 
@@ -131,10 +127,6 @@ Definition write_effects_def:
   write_effects RETURN = {Eff_MSIZE} /\
   (* SELFDESTRUCT: transfers balance to beneficiary, zeros own balance *)
   write_effects SELFDESTRUCT = {Eff_BALANCE} /\
-  (* ALLOCA modifies vs_alloca_next which is part of next_alloca_offset.
-     Writing Eff_MSIZE ensures ALLOCA-ALLOCA WAW deps via build_eda,
-     complementing the read_effects ALLOCA = {Eff_MSIZE} above. *)
-  write_effects ALLOCA = {Eff_MSIZE} /\
   write_effects _ = empty_effects
 End
 

--- a/venom/defs/venomEffectsScript.sml
+++ b/venom/defs/venomEffectsScript.sml
@@ -73,6 +73,10 @@ Definition read_effects_def:
   read_effects SHA3 = {Eff_MEMORY} /\
   read_effects MSIZE = {Eff_MSIZE} /\
   read_effects RETURN = {Eff_MEMORY} /\
+  (* ALLOCA uses next_alloca_offset which depends on LENGTH vs_memory.
+     Marking it as reading Eff_MSIZE prevents reordering with ops that
+     extend memory (MLOAD, MSTORE, etc. which write Eff_MSIZE). *)
+  read_effects ALLOCA = {Eff_MSIZE} /\
   read_effects _ = empty_effects
 End
 
@@ -127,6 +131,10 @@ Definition write_effects_def:
   write_effects RETURN = {Eff_MSIZE} /\
   (* SELFDESTRUCT: transfers balance to beneficiary, zeros own balance *)
   write_effects SELFDESTRUCT = {Eff_BALANCE} /\
+  (* ALLOCA modifies vs_alloca_next which is part of next_alloca_offset.
+     Writing Eff_MSIZE ensures ALLOCA-ALLOCA WAW deps via build_eda,
+     complementing the read_effects ALLOCA = {Eff_MSIZE} above. *)
+  write_effects ALLOCA = {Eff_MSIZE} /\
   write_effects _ = empty_effects
 End
 

--- a/venom/defs/venomWfScript.sml
+++ b/venom/defs/venomWfScript.sml
@@ -178,6 +178,24 @@ Definition bb_well_formed_def:
            (EL i bb.bb_instructions).inst_opcode = PHI)
 End
 
+(* All pseudo instructions (PHI, PARAM) form a prefix of the block.
+ * Matches Vyper compiler output where PHIs and PARAMs are always emitted
+ * first. Stronger than bb_well_formed's PHI-only prefix constraint.
+ * Defined separately to avoid modifying bb_well_formed (which would cause
+ * a 30+ minute rebuild of execEquivProofs). *)
+Definition pseudos_prefix_def:
+  pseudos_prefix bb <=>
+    !i j. i < j /\ j < LENGTH bb.bb_instructions /\
+          is_pseudo (EL j bb.bb_instructions).inst_opcode ==>
+          is_pseudo (EL i bb.bb_instructions).inst_opcode
+End
+
+(* All blocks in a function have pseudos as a prefix. *)
+Definition fn_pseudos_prefix_def:
+  fn_pseudos_prefix fn <=>
+    !bb. MEM bb fn.fn_blocks ==> pseudos_prefix bb
+End
+
 (* All successor labels of every block exist as block labels in the function. *)
 Definition fn_succs_closed_def:
   fn_succs_closed fn <=>
@@ -285,12 +303,6 @@ End
 (* Check if instruction is a PHI. *)
 Definition is_phi_inst_def:
   is_phi_inst inst <=> inst.inst_opcode = PHI
-End
-
-(* No generated split-block label collides with existing labels. *)
-Definition split_labels_fresh_def:
-  split_labels_fresh name_fn func ⇔
-    ∀p t. ¬MEM (name_fn p t) (fn_labels func)
 End
 
 (* ==========================================================================

--- a/venom/defs/venomWfScript.sml
+++ b/venom/defs/venomWfScript.sml
@@ -305,6 +305,12 @@ Definition is_phi_inst_def:
   is_phi_inst inst <=> inst.inst_opcode = PHI
 End
 
+(* No generated split-block label collides with existing labels. *)
+Definition split_labels_fresh_def:
+  split_labels_fresh name_fn func ⇔
+    ∀p t. ¬MEM (name_fn p t) (fn_labels func)
+End
+
 (* ==========================================================================
    Context well-formedness
    ========================================================================== *)

--- a/venom/passes/dft/defs/dftDefsScript.sml
+++ b/venom/passes/dft/defs/dftDefsScript.sml
@@ -5,16 +5,19 @@
  * traversal of data and effect dependencies. Produces an instruction order
  * suitable for stack-based code generation.
  *
- * TOP-LEVEL:
- *   producing_inst       — find instruction producing a variable
- *   build_dda            — data dependency analysis (incremental)
- *   build_eda            — effect dependency analysis (incremental, with clearing)
- *   entry_instructions   — dependency DAG roots
- *   schedule_block       — DFS schedule of a block's non-phi instructions
- *   dft_block            — transform a single block
- *   dft_fn               — transform all blocks in a function
+ * Upstream: vyperlang/vyper@e1dead045 (sunset GEP, #4895)
  *
- * Source: vyper/venom/passes/dft.py
+ * TOP-LEVEL:
+ *   producing_inst         — find instruction producing a variable
+ *   inst_data_deps         — data dependencies for one instruction
+ *   build_eda              — effect dependency analysis (incremental, with clearing)
+ *   build_full_eda         — combined EDA with barrier/abort/alloca chains
+ *   inst_all_deps          — combined DDA + EDA dependencies
+ *   entry_instructions     — dependency DAG roots
+ *   schedule_from_entries  — DFS schedule of a block's non-phi instructions
+ *   dft_block              — transform a single block
+ *   dft_fn                 — transform all blocks in a function
+ *   dft_ctx                — transform all functions in a context
  *)
 
 Theory dftDefs
@@ -59,7 +62,8 @@ Definition inst_data_deps_def:
       (MAP (operand_producer block_insts) inst.inst_operands)) in
     let order_deps =
       if is_terminator inst.inst_opcode
-      then MAP THE (FILTER IS_SOME (MAP (producing_inst block_insts) order))
+      then FILTER (\d. d.inst_id <> inst.inst_id)
+             (MAP THE (FILTER IS_SOME (MAP (producing_inst block_insts) order)))
       else [] in
     nub (var_deps ++ order_deps)
 End
@@ -132,6 +136,99 @@ Definition build_eda_def:
       let (deps, et') = compute_effect_deps et inst in
       (acc_map |+ (inst.inst_id, deps), et'))
     (FEMPTY, empty_effect_track) non_phis)
+End
+
+(* Generic: chain all instructions matching predicate P in original block
+   order. Each matching instruction gets an EDA edge to the previous matching
+   instruction, ensuring they are never reordered by DFT. *)
+Definition add_chain_deps_def:
+  add_chain_deps P block_insts eda =
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) block_insts in
+    let matching = FILTER P non_phis in
+    FST (FOLDL (\(acc, prev) inst.
+      let old_deps = case FLOOKUP acc inst.inst_id of
+                       NONE => [] | SOME ds => ds in
+      let new_deps = case prev of
+                       NONE => old_deps
+                     | SOME p => if MEM p old_deps then old_deps
+                                 else p :: old_deps in
+      (acc |+ (inst.inst_id, new_deps), SOME inst))
+    (eda, NONE) matching)
+End
+
+(* Chain all non-NoFail instructions so abort-incompatible pairs can never
+   be reordered. Ensures abort_compatible for every reorderable pair.
+   (Diverges from Python DFT which lacks this — upstream bug.) *)
+Definition add_abort_deps_def:
+  add_abort_deps block_insts eda =
+    add_chain_deps (\i. opcode_fail_class i.inst_opcode <> NoFail)
+                   block_insts eda
+End
+
+(* Chain all ALLOCA instructions. exec_alloca uses vs_alloca_next as a
+   bump-pointer allocator, making results order-dependent. The effects
+   system does not model this implicit state dependency. *)
+Definition add_alloca_deps_def:
+  add_alloca_deps block_insts eda =
+    add_chain_deps (\i. is_alloca_op i.inst_opcode) block_insts eda
+End
+
+(* Barrier predicate: instructions that bi_independent cannot handle.
+   Volatile ops (INVOKE, ext_call, MSTORE, ...) and alloca ops have implicit
+   state dependencies not captured by the effects system. *)
+Definition is_barrier_def:
+  is_barrier inst <=> is_volatile inst.inst_opcode \/ is_alloca_op inst.inst_opcode
+End
+
+(* Pass 1: each non-phi after a barrier gets that barrier as a dep.
+   Tracks only last_barrier — simple 2-component FOLDL. *)
+Definition add_deps_on_barrier_def:
+  add_deps_on_barrier block_insts eda =
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) block_insts in
+    FST (FOLDL (\(acc, last_bar) inst.
+      let old_deps = case FLOOKUP acc inst.inst_id of
+                       NONE => [] | SOME ds => ds in
+      if is_barrier inst then
+        (acc, SOME inst)
+      else
+        let new_deps = case last_bar of
+                         NONE => old_deps
+                       | SOME b => if MEM b old_deps then old_deps
+                                   else b :: old_deps in
+        (acc |+ (inst.inst_id, new_deps), last_bar))
+    (eda, NONE) non_phis)
+End
+
+(* Pass 2: each barrier depends on ALL preceding non-phis.
+   Uses add_chain_deps pattern but adds ALL prev non-phis, not just matching.
+   Tracks only prev_insts — simple 2-component FOLDL. *)
+Definition add_deps_from_barrier_def:
+  add_deps_from_barrier block_insts eda =
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) block_insts in
+    FST (FOLDL (\(acc, prev_insts) inst.
+      if is_barrier inst then
+        let old_deps = case FLOOKUP acc inst.inst_id of
+                         NONE => [] | SOME ds => ds in
+        let new_deps = FOLDL (\ds p.
+              if MEM p ds then ds else p :: ds) old_deps prev_insts in
+        (acc |+ (inst.inst_id, new_deps), prev_insts ++ [inst])
+      else
+        (acc, prev_insts ++ [inst]))
+    (eda, []) non_phis)
+End
+
+(* Combined barrier deps: both passes *)
+Definition add_barrier_deps_def:
+  add_barrier_deps block_insts eda =
+    add_deps_from_barrier block_insts
+      (add_deps_on_barrier block_insts eda)
+End
+
+Definition build_full_eda_def:
+  build_full_eda block_insts =
+    add_alloca_deps block_insts
+      (add_barrier_deps block_insts
+        (add_abort_deps block_insts (build_eda block_insts)))
 End
 
 (* ===== Combined Dependencies ===== *)
@@ -249,7 +346,8 @@ Definition dft_cost_def:
           (MAPi (\i op.
             case op of
               Var v => if MEM v child.inst_outputs then SOME i else NONE
-            | _ => NONE) (REVERSE parent.inst_operands))) in
+            | Lit _ => NONE
+            | Label _ => NONE) (REVERSE parent.inst_operands))) in
         case output_idxs of
           idx :: _ => idx + LENGTH order + 1
         | [] =>
@@ -339,7 +437,7 @@ End
 Definition dft_block_def:
   dft_block order bb =
     let phis = FILTER (λi. is_pseudo i.inst_opcode) bb.bb_instructions in
-    let eda = build_eda bb.bb_instructions in
+    let eda = build_full_eda bb.bb_instructions in
     let offspring_map = build_offspring_map bb.bb_instructions order in
     let entries = entry_instructions bb.bb_instructions order eda in
     let scheduled = schedule_from_entries bb.bb_instructions order

--- a/venom/passes/dft/proofs/Holmakefile
+++ b/venom/passes/dft/proofs/Holmakefile
@@ -1,4 +1,6 @@
 # DFT pass proofs
 INCLUDES = $(VFMDIR)/util $(VFMDIR)/spec ../../.. ../../../../syntax ../../../../semantics ../defs \
-  ../../../simulation ../../../simulation/defs \
-  ../../../analysis/stack_order/defs ../../../analysis/cfg/defs ../../../analysis/liveness/defs
+  ../../../simulation ../../../simulation/defs ../../../simulation/proofs \
+  ../../../analysis/stack_order/defs ../../../analysis/cfg/defs ../../../analysis/liveness/defs \
+  ../../../defs ../../../proofs ../../../props \
+  ../../shared ../../shared/defs ../../shared/proofs

--- a/venom/passes/dft/proofs/dftBlockSimScript.sml
+++ b/venom/passes/dft/proofs/dftBlockSimScript.sml
@@ -1,0 +1,916 @@
+(*
+ * DFT Block Simulation — Infrastructure
+ *
+ * Key lemma: independent_commute_eq — bilateral-independent non-terminator
+ * instructions produce identical final states when executed in either order.
+ *)
+
+Theory dftBlockSim
+Ancestors
+  dftDefs dftCommutation passSharedProps passSharedTransfer
+  passSharedField venomExecSemantics venomExecProps venomEffects venomInstProofs
+  venomState finite_map venomInst stateEquiv stateEquivProps
+  passSimulationDefs venomInstProps pred_set sorting passSharedFrame
+  vfmState venomWf
+
+(* ================================================================
+   1. step_inst preserves vs_allocas for non-alloca ops
+   ================================================================ *)
+
+Theorem step_inst_preserves_allocas:
+  !fuel ctx inst s s'.
+    step_inst fuel ctx inst s = OK s' /\
+    ~is_alloca_op inst.inst_opcode /\
+    ~is_terminator inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode ==>
+    s'.vs_allocas = s.vs_allocas
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_opcode = INVOKE`
+  >- (
+    (* INVOKE case: merge_callee_state keeps caller's allocas,
+       bind_outputs only does update_var which preserves allocas *)
+    gvs[step_inst_def, AllCaseEqs()] >>
+    `!pairs ss. (FOLDL (\s' (out,val). update_var out val s') ss pairs
+      ).vs_allocas = ss.vs_allocas` by
+      (Induct >> rw[] >> Cases_on `h` >> simp[update_var_def]) >>
+    gvs[bind_outputs_def, AllCaseEqs(), merge_callee_state_def])
+  >>
+  gvs[step_inst_non_invoke] >>
+  qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
+  simp[step_inst_base_def, exec_pure1_def, exec_pure2_def,
+       exec_pure3_def, exec_read0_def, exec_read1_def,
+       exec_write2_def] >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_terminator_def, is_alloca_op_def, is_ext_call_op_def] >>
+  rpt strip_tac >>
+  gvs[AllCaseEqs(), update_var_def, mstore_def, mstore8_def, sstore_def,
+      tstore_def, write_memory_with_expansion_def, mcopy_def,
+      halt_state_def, revert_state_def, set_returndata_def, jump_to_def]
+QED
+
+Theorem step_inst_preserves_alloca_next:
+  !fuel ctx inst s s'.
+    step_inst fuel ctx inst s = OK s' /\
+    ~is_alloca_op inst.inst_opcode /\
+    ~is_terminator inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\
+    inst.inst_opcode <> INVOKE ==>
+    s'.vs_alloca_next = s.vs_alloca_next
+Proof
+  rpt strip_tac >>
+  gvs[step_inst_non_invoke] >>
+  qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
+  simp[step_inst_base_def, exec_pure1_def, exec_pure2_def,
+       exec_pure3_def, exec_read0_def, exec_read1_def,
+       exec_write2_def] >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_terminator_def, is_alloca_op_def, is_ext_call_op_def] >>
+  rpt strip_tac >>
+  gvs[AllCaseEqs(), update_var_def, mstore_def, mstore8_def, sstore_def,
+      tstore_def, write_memory_with_expansion_def, mcopy_def,
+      halt_state_def, revert_state_def, set_returndata_def, jump_to_def]
+QED
+
+(* ================================================================
+   2. commute_equiv + allocas + alloca_next + vars → full equality
+   ================================================================ *)
+
+Theorem commute_equiv_allocas_vars_eq:
+  !defs s1 s2.
+    commute_equiv defs s1 s2 /\
+    s1.vs_allocas = s2.vs_allocas /\
+    s1.vs_alloca_next = s2.vs_alloca_next /\
+    (!w. w IN defs ==> lookup_var w s1 = lookup_var w s2) ==>
+    s1 = s2
+Proof
+  rw[commute_equiv_def, venom_state_component_equality, fmap_eq_flookup] >>
+  simp[GSYM lookup_var_def] >> rename1 `lookup_var w` >>
+  Cases_on `w IN defs` >> metis_tac[]
+QED
+
+(* ================================================================
+   3. Operand variables membership
+   ================================================================ *)
+
+Theorem mem_var_operand_vars:
+  !x ops. MEM (Var x) ops ==> MEM x (operand_vars ops)
+Proof
+  Induct_on `ops` >> rw[operand_vars_def] >>
+  gvs[operand_var_def] >>
+  Cases_on `h` >> gvs[operand_var_def]
+QED
+
+(* ================================================================
+   4. eval_operand preserved by step on non-output vars
+   ================================================================ *)
+
+Theorem eval_operand_step_pres:
+  !fuel ctx inst s s' op.
+    step_inst fuel ctx inst s = OK s' /\
+    ~is_terminator inst.inst_opcode /\
+    (!x. op = Var x ==> ~MEM x inst.inst_outputs) ==>
+    eval_operand op s' = eval_operand op s
+Proof
+  rpt strip_tac >> Cases_on `op` >> gvs[eval_operand_def]
+  >- metis_tac[step_preserves_non_output_vars]
+  >> metis_tac[step_preserves_labels]
+QED
+
+(* ================================================================
+   5. Effect field preservation from effects_independent
+   ================================================================ *)
+
+Theorem effects_independent_write_read_disjoint:
+  !op1 op2.
+    effects_independent op1 op2 ==>
+    DISJOINT (write_effects op1) (read_effects op2) /\
+    DISJOINT (write_effects op2) (read_effects op1) /\
+    DISJOINT (write_effects op1) (write_effects op2)
+Proof
+  simp[effects_independent_def] >> rpt strip_tac >>
+  metis_tac[DISJOINT_SYM, SUBSET_DEF, IN_UNION, DISJOINT_DEF, EXTENSION]
+QED
+
+(* ================================================================
+   6. Context + effect field agreement wrapper
+   ================================================================ *)
+
+Theorem step_pres_all_applied:
+  !fuel ctx inst s s'.
+    step_inst fuel ctx inst s = OK s' /\
+    ~is_terminator inst.inst_opcode /\ ~is_alloca_op inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\ inst.inst_opcode <> INVOKE ==>
+    s'.vs_call_ctx = s.vs_call_ctx /\
+    s'.vs_tx_ctx = s.vs_tx_ctx /\
+    s'.vs_block_ctx = s.vs_block_ctx /\
+    s'.vs_data_section = s.vs_data_section /\
+    s'.vs_code = s.vs_code /\
+    s'.vs_prev_hashes = s.vs_prev_hashes /\
+    s'.vs_labels = s.vs_labels /\
+    s'.vs_params = s.vs_params /\
+    s'.vs_prev_bb = s.vs_prev_bb /\
+    (Eff_MEMORY NOTIN write_effects inst.inst_opcode ==>
+      s'.vs_memory = s.vs_memory) /\
+    (Eff_TRANSIENT NOTIN write_effects inst.inst_opcode ==>
+      s'.vs_transient = s.vs_transient) /\
+    (Eff_BALANCE NOTIN write_effects inst.inst_opcode /\
+     Eff_STORAGE NOTIN write_effects inst.inst_opcode ==>
+      s'.vs_accounts = s.vs_accounts) /\
+    (Eff_IMMUTABLES NOTIN write_effects inst.inst_opcode ==>
+      s'.vs_immutables = s.vs_immutables) /\
+    (Eff_RETURNDATA NOTIN write_effects inst.inst_opcode ==>
+      s'.vs_returndata = s.vs_returndata) /\
+    (Eff_LOG NOTIN write_effects inst.inst_opcode ==>
+      s'.vs_logs = s.vs_logs)
+Proof
+  rpt strip_tac >>
+  drule_all step_inst_preserves_all >> strip_tac >> gvs[]
+QED
+
+(* ================================================================
+   7. Eligible write constraints — certain effects are never written
+      by non-terminator, non-alloca, non-ext_call, non-INVOKE ops.
+   ================================================================ *)
+
+Theorem eligible_write_constraints[local]:
+  !op. ~is_terminator op /\ ~is_alloca_op op /\
+       ~is_ext_call_op op /\ op <> INVOKE ==>
+       Eff_BALANCE NOTIN write_effects op /\
+       Eff_EXTCODE NOTIN write_effects op /\
+       Eff_RETURNDATA NOTIN write_effects op /\
+       (Eff_MEMORY IN write_effects op ==>
+        Eff_MSIZE IN write_effects op)
+Proof
+  Cases >> EVAL_TAC
+QED
+
+(* ================================================================
+   7b. Account sub-field preservation for eligible instructions.
+       SSTORE is the only eligible op that writes Eff_STORAGE,
+       and it only modifies .storage — balance, nonce, code are
+       always preserved by eligible ops.
+   ================================================================ *)
+
+Theorem step_inst_preserves_account_bnc[local]:
+  !fuel ctx inst s s'.
+    step_inst fuel ctx inst s = OK s' /\
+    ~is_terminator inst.inst_opcode /\ ~is_alloca_op inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\ inst.inst_opcode <> INVOKE ==>
+    !addr. (s'.vs_accounts addr).balance = (s.vs_accounts addr).balance /\
+           (s'.vs_accounts addr).nonce = (s.vs_accounts addr).nonce /\
+           (s'.vs_accounts addr).code = (s.vs_accounts addr).code
+Proof
+  rpt gen_tac >> strip_tac >> gen_tac >>
+  Cases_on `Eff_STORAGE IN write_effects inst.inst_opcode`
+  >- (
+    (* Only SSTORE writes STORAGE among eligible ops *)
+    `inst.inst_opcode = SSTORE` by (
+      Cases_on `inst.inst_opcode` >>
+      gvs[is_terminator_def, is_alloca_op_def, is_ext_call_op_def,
+          write_effects_def, all_effects_def, empty_effects_def]) >>
+    gvs[step_inst_non_invoke, step_inst_base_def, exec_write2_def,
+        AllCaseEqs()] >>
+    simp[sstore_def, lookup_account_def, LET_THM,
+         combinTheory.APPLY_UPDATE_THM] >>
+    rw[])
+  >- (
+    (* No STORAGE write: full vs_accounts preserved *)
+    `Eff_BALANCE NOTIN write_effects inst.inst_opcode` by
+      metis_tac[eligible_write_constraints] >>
+    imp_res_tac step_pres_all_applied >> gvs[])
+QED
+
+(* Non-effect-free eligible ops preserve all vars.
+   These ops (MSTORE, SSTORE, MCOPY, LOG, ASSERT, etc.) modify
+   side-effect fields only — vs_vars is untouched. *)
+Theorem step_non_effect_free_preserves_all_vars[local]:
+  !fuel ctx inst s s'.
+    step_inst fuel ctx inst s = OK s' /\
+    ~is_effect_free_op inst.inst_opcode /\
+    ~is_terminator inst.inst_opcode /\
+    ~is_alloca_op inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\
+    inst.inst_opcode <> INVOKE ==>
+    !v. lookup_var v s' = lookup_var v s
+Proof
+  rpt strip_tac >>
+  gvs[step_inst_non_invoke] >>
+  qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
+  simp[step_inst_base_def] >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_effect_free_op_def, is_terminator_def,
+      is_alloca_op_def, is_ext_call_op_def] >>
+  simp[exec_write2_def] >>
+  rpt strip_tac >> gvs[AllCaseEqs()] >>
+  gvs[lookup_var_def, mcopy_def, mstore_def, mstore8_def,
+      sstore_def, tstore_def, write_memory_with_expansion_def,
+      halt_state_def, revert_state_def, set_returndata_def] >>
+  rpt (CHANGED_TAC (rpt (pairarg_tac >> gvs[])))
+QED
+
+(* ================================================================
+   8. Output var agreement across independent instructions
+      If inst_a writes w, and inst_b is independent from inst_a,
+      then lookup_var w agrees in both execution orders.
+   ================================================================ *)
+
+Theorem output_var_agree_across_independent:
+  !fuel ctx inst_a inst_b ss va vb sab sba w.
+    step_inst fuel ctx inst_a ss = OK va /\
+    step_inst fuel ctx inst_b ss = OK vb /\
+    step_inst fuel ctx inst_b va = OK sab /\
+    step_inst fuel ctx inst_a vb = OK sba /\
+    DISJOINT (set inst_a.inst_outputs) (set inst_b.inst_outputs) /\
+    DISJOINT (set inst_b.inst_outputs)
+             (set (operand_vars inst_a.inst_operands)) /\
+    effects_independent inst_a.inst_opcode inst_b.inst_opcode /\
+    ~is_terminator inst_a.inst_opcode /\ ~is_terminator inst_b.inst_opcode /\
+    ~is_alloca_op inst_a.inst_opcode /\ ~is_alloca_op inst_b.inst_opcode /\
+    ~is_ext_call_op inst_a.inst_opcode /\ ~is_ext_call_op inst_b.inst_opcode /\
+    inst_a.inst_opcode <> INVOKE /\ inst_b.inst_opcode <> INVOKE /\
+    MEM w inst_a.inst_outputs ==>
+    lookup_var w sab = lookup_var w sba
+Proof
+  rpt strip_tac >>
+  (* Step 1: lookup_var w sab = lookup_var w va
+     (inst_b doesn't write w, so it preserves w) *)
+  `~MEM w inst_b.inst_outputs` by (
+    gvs[DISJOINT_DEF, EXTENSION] >> metis_tac[]) >>
+  `lookup_var w sab = lookup_var w va` by
+    metis_tac[step_preserves_non_output_vars] >>
+  (* Step 2: lookup_var w va = lookup_var w sba
+     Both are inst_a applied to states that agree on inst_a's inputs *)
+  `step_inst_base inst_a ss = OK va` by gvs[step_inst_non_invoke] >>
+  `step_inst_base inst_a vb = OK sba` by gvs[step_inst_non_invoke] >>
+  `lookup_var w va = lookup_var w sba` suffices_by simp[] >>
+  (* Establish all prerequisites for output_determined_vars *)
+  `!op. MEM op inst_a.inst_operands ==>
+        eval_operand op ss = eval_operand op vb` by (
+    rpt strip_tac >>
+    Cases_on `op` >> gvs[eval_operand_def]
+    >- (rename1 `lookup_var vn` >>
+      `~MEM vn inst_b.inst_outputs` by (
+        `MEM vn (operand_vars inst_a.inst_operands)` by
+          metis_tac[mem_var_operand_vars] >>
+        gvs[DISJOINT_DEF, EXTENSION] >> metis_tac[]) >>
+      metis_tac[step_preserves_non_output_vars])
+    >> metis_tac[step_preserves_labels]) >>
+  `!w'. MEM w' inst_a.inst_outputs ==>
+        lookup_var w' ss = lookup_var w' vb` by (
+    rpt strip_tac >>
+    `~MEM w' inst_b.inst_outputs` by (
+      gvs[DISJOINT_DEF, EXTENSION] >> metis_tac[]) >>
+    metis_tac[step_preserves_non_output_vars]) >>
+  (* Get field preservation for inst_b step specifically *)
+  mp_tac (Q.SPECL [`fuel`, `ctx`, `inst_b`, `ss`, `vb`]
+            step_pres_all_applied) >>
+  simp[] >> strip_tac >>
+  imp_res_tac effects_independent_write_read_disjoint >>
+  `!e. e IN read_effects inst_a.inst_opcode ==>
+       e NOTIN write_effects inst_b.inst_opcode` by
+    (gvs[DISJOINT_DEF, EXTENSION] >> metis_tac[]) >>
+  (* Account sub-field preservation: inst_b always preserves
+     balance, nonce, code even when it writes STORAGE *)
+  `!addr. (vb.vs_accounts addr).balance =
+          (ss.vs_accounts addr).balance /\
+          (vb.vs_accounts addr).nonce =
+          (ss.vs_accounts addr).nonce /\
+          (vb.vs_accounts addr).code =
+          (ss.vs_accounts addr).code` by
+    metis_tac[step_inst_preserves_account_bnc] >>
+  (* Storage sub-field: if STORAGE read by inst_a, then
+     STORAGE not written by inst_b, so full accounts preserved *)
+  `Eff_STORAGE IN read_effects inst_a.inst_opcode ==>
+   !addr. (ss.vs_accounts addr).storage =
+          (vb.vs_accounts addr).storage` by (
+    strip_tac >>
+    `Eff_STORAGE NOTIN write_effects inst_b.inst_opcode` by res_tac >>
+    `Eff_BALANCE NOTIN write_effects inst_b.inst_opcode` by
+      metis_tac[eligible_write_constraints] >>
+    `vb.vs_accounts = ss.vs_accounts` by gvs[] >> gvs[]) >>
+  (* Memory: if read by inst_a, not written by inst_b *)
+  `Eff_MEMORY IN read_effects inst_a.inst_opcode ==>
+   ss.vs_memory = vb.vs_memory` by (strip_tac >> res_tac >> gvs[]) >>
+  `Eff_MSIZE IN read_effects inst_a.inst_opcode ==>
+   ss.vs_memory = vb.vs_memory` by (
+    strip_tac >>
+    `Eff_MSIZE NOTIN write_effects inst_b.inst_opcode` by res_tac >>
+    `Eff_MEMORY NOTIN write_effects inst_b.inst_opcode` by (
+      CCONTR_TAC >> gvs[] >>
+      `Eff_MSIZE IN write_effects inst_b.inst_opcode` by
+        metis_tac[eligible_write_constraints] >>
+      gvs[]) >>
+    gvs[]) >>
+  (* Case split: effect-free uses output_determined_vars,
+     non-effect-free eligible ops don't modify vs_vars *)
+  (* NOP: step returns state unchanged, so trivially equal *)
+  Cases_on `inst_a.inst_opcode = NOP`
+  >- (
+    `step_inst fuel ctx inst_a ss = OK ss` by
+      metis_tac[step_nop_identity] >>
+    `step_inst fuel ctx inst_a vb = OK vb` by
+      metis_tac[step_nop_identity] >>
+    gvs[])
+  >> Cases_on `is_effect_free_op inst_a.inst_opcode`
+  >- (
+    irule step_inst_base_effect_free_output_determined_vars >>
+    qexistsl_tac [`inst_a`, `ss`, `vb`] >>
+    rpt conj_tac >> gvs[] >> res_tac >> gvs[])
+  >> (
+    (* Non-effect-free: all vars preserved *)
+    `!v. lookup_var v va = lookup_var v ss` by
+      metis_tac[step_non_effect_free_preserves_all_vars] >>
+    `!v. lookup_var v sba = lookup_var v vb` by
+      metis_tac[step_non_effect_free_preserves_all_vars] >>
+    gvs[])
+QED
+
+(* ================================================================
+   9. Independent instructions commute with state equality
+   ================================================================ *)
+
+Theorem independent_commute_eq:
+  !fuel ctx inst1 inst2 ss v1 v2 s12 s21.
+    step_inst fuel ctx inst1 ss = OK v1 /\
+    step_inst fuel ctx inst2 ss = OK v2 /\
+    step_inst fuel ctx inst2 v1 = OK s12 /\
+    step_inst fuel ctx inst1 v2 = OK s21 /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_uses inst2)) /\
+    DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
+    effects_independent inst1.inst_opcode inst2.inst_opcode /\
+    ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode /\
+    ~is_alloca_op inst1.inst_opcode /\ ~is_alloca_op inst2.inst_opcode /\
+    ~is_ext_call_op inst1.inst_opcode /\ ~is_ext_call_op inst2.inst_opcode /\
+    inst1.inst_opcode <> INVOKE /\ inst2.inst_opcode <> INVOKE ==>
+    s12 = s21
+Proof
+  rpt strip_tac >>
+  (* A: commute_equiv *)
+  `commute_equiv (set (inst_defs inst1) UNION set (inst_defs inst2)) s12 s21` by (
+    mp_tac (Q.SPECL [`fuel`, `ctx`, `inst1`, `inst2`, `ss`]
+                      effects_independent_commute) >> simp[]) >>
+  (* B: vs_allocas *)
+  `s12.vs_allocas = s21.vs_allocas` by (
+    `v1.vs_allocas = ss.vs_allocas` by metis_tac[step_inst_preserves_allocas] >>
+    `s12.vs_allocas = ss.vs_allocas` by metis_tac[step_inst_preserves_allocas] >>
+    `v2.vs_allocas = ss.vs_allocas` by metis_tac[step_inst_preserves_allocas] >>
+    `s21.vs_allocas = ss.vs_allocas` by metis_tac[step_inst_preserves_allocas] >>
+    simp[]) >>
+  (* B2: vs_alloca_next *)
+  `s12.vs_alloca_next = s21.vs_alloca_next` by (
+    `v1.vs_alloca_next = ss.vs_alloca_next` by metis_tac[step_inst_preserves_alloca_next] >>
+    `s12.vs_alloca_next = ss.vs_alloca_next` by metis_tac[step_inst_preserves_alloca_next] >>
+    `v2.vs_alloca_next = ss.vs_alloca_next` by metis_tac[step_inst_preserves_alloca_next] >>
+    `s21.vs_alloca_next = ss.vs_alloca_next` by metis_tac[step_inst_preserves_alloca_next] >>
+    simp[]) >>
+  (* C: vars in defs agree *)
+  `!w. w IN (set (inst_defs inst1) UNION set (inst_defs inst2)) ==>
+       lookup_var w s12 = lookup_var w s21` by (
+    rw[IN_UNION] >> gvs[inst_defs_def]
+    >- ((* w in inst1.inst_outputs — use output_var_agree with inst_a=inst1 *)
+      irule output_var_agree_across_independent >>
+      MAP_EVERY qexists_tac [`ctx`, `fuel`, `inst1`, `inst2`, `ss`, `v1`, `v2`] >>
+      gvs[inst_defs_def, inst_uses_def])
+    >- ((* w in inst2.inst_outputs — use output_var_agree with inst_a=inst2, inst_b=inst1
+           Note: sab=s21, sba=s12 in the swapped version *)
+      `lookup_var w s21 = lookup_var w s12` suffices_by simp[] >>
+      irule output_var_agree_across_independent >>
+      MAP_EVERY qexists_tac [`ctx`, `fuel`, `inst2`, `inst1`, `ss`, `v2`, `v1`] >>
+      gvs[inst_defs_def, inst_uses_def] >>
+      metis_tac[effects_independent_def, DISJOINT_SYM])) >>
+  (* D: Assemble *)
+  irule commute_equiv_allocas_vars_eq >>
+  simp[] >>
+  qexists_tac `set (inst_defs inst1) UNION set (inst_defs inst2)` >>
+  simp[]
+QED
+
+(* ================================================================
+   10. Extended commutation: allows INVOKE on one side.
+       Key helpers for INVOKE × pure commutation.
+   ================================================================ *)
+
+(* FOLDL update_var preserves all non-vs_vars fields *)
+Theorem foldl_update_var_field[local]:
+  !pairs (ss:venom_state).
+    (FOLDL (\s' (out,val). update_var out val s') ss pairs).vs_alloca_next =
+    ss.vs_alloca_next /\
+    (FOLDL (\s' (out,val). update_var out val s') ss pairs).vs_allocas =
+    ss.vs_allocas
+Proof
+  Induct >> rw[] >> Cases_on `h` >> simp[update_var_def]
+QED
+
+(* Pure, effect-free, non-INVOKE step_inst_base either leaves state
+   unchanged with no outputs, or adds exactly one update_var *)
+Theorem pure_step_structure:
+  !inst ss v2.
+    step_inst_base inst ss = OK v2 /\
+    inst_wf inst /\
+    ~is_terminator inst.inst_opcode /\
+    ~is_alloca_op inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\
+    inst.inst_opcode <> INVOKE /\
+    write_effects inst.inst_opcode = {} /\
+    read_effects inst.inst_opcode = {} ==>
+    (inst.inst_outputs = [] /\ v2 = ss) \/
+    (?out val. inst.inst_outputs = [out] /\ v2 = update_var out val ss)
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_terminator_def, is_alloca_op_def, is_ext_call_op_def,
+      write_effects_def, read_effects_def] >>
+  gvs[step_inst_base_def, exec_pure1_def, exec_pure2_def, exec_pure3_def,
+      exec_read0_def, exec_read1_def, inst_wf_def, AllCaseEqs()] >>
+  metis_tac[]
+QED
+
+(* Output agreement for pure, empty-effect, non-INVOKE opcodes.
+   Generalizes step_inst_base_effect_free_output_determined_vars to
+   also cover ASSERT, ASSERT_UNREACHABLE, NOP (which are not effect_free). *)
+Theorem pure_step_output_agree[local]:
+  !inst s1 s2 r1 r2.
+    step_inst_base inst s1 = OK r1 /\
+    step_inst_base inst s2 = OK r2 /\
+    ~is_terminator inst.inst_opcode /\
+    ~is_alloca_op inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\
+    inst.inst_opcode <> INVOKE /\
+    write_effects inst.inst_opcode = {} /\
+    read_effects inst.inst_opcode = {} /\
+    (!op. MEM op inst.inst_operands ==> eval_operand op s1 = eval_operand op s2) /\
+    (!w. MEM w inst.inst_outputs ==> lookup_var w s1 = lookup_var w s2) /\
+    s1.vs_prev_bb = s2.vs_prev_bb /\
+    s1.vs_params = s2.vs_params /\
+    s1.vs_call_ctx = s2.vs_call_ctx /\ s1.vs_tx_ctx = s2.vs_tx_ctx /\
+    s1.vs_block_ctx = s2.vs_block_ctx /\
+    s1.vs_data_section = s2.vs_data_section /\
+    s1.vs_code = s2.vs_code /\
+    s1.vs_prev_hashes = s2.vs_prev_hashes ==>
+    !w. MEM w inst.inst_outputs ==> lookup_var w r1 = lookup_var w r2
+Proof
+  rpt strip_tac >>
+  gvs[step_inst_base_def] >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_terminator_def, is_alloca_op_def, is_ext_call_op_def,
+      write_effects_def, read_effects_def] >>
+  gvs[exec_pure1_def, exec_pure2_def, exec_pure3_def,
+      exec_read0_def, exec_read1_def, AllCaseEqs()] >>
+  gvs[update_var_def, lookup_var_def, FLOOKUP_UPDATE] >>
+  (* PHI: resolve_phi gives MEM val_op operands, so eval_operand agrees *)
+  imp_res_tac resolve_phi_MEM >> res_tac >> gvs[]
+QED
+
+(* effects_independent INVOKE op ==> op is pure with empty effects *)
+Theorem invoke_independent_empty_effects[local]:
+  !op. effects_independent INVOKE op ==>
+    op <> INVOKE /\ write_effects op = {} /\ read_effects op = {}
+Proof Cases >> EVAL_TAC
+QED
+
+(* FOLDL update_var only modifies vs_vars *)
+Triviality foldl_update_var_only_vars:
+  !pairs s. ?f.
+    FOLDL (\s' (out,v). update_var out v s') s pairs = s with vs_vars := f
+Proof
+  Induct
+  >- (rw[] >> qexists_tac `s.vs_vars` >> simp[venom_state_component_equality])
+  >> gen_tac >> PairCases_on `h` >> simp[] >> gen_tac >>
+     first_x_assum (qspec_then `update_var h0 h1 s` strip_assume_tac) >>
+     qexists_tac `f` >> simp[] >> gvs[update_var_def]
+QED
+
+(* INVOKE preserves structural fields (prev_bb, params, contexts, etc.) *)
+Theorem invoke_preserves_structural[local]:
+  !fuel ctx inst s s'.
+    step_inst fuel ctx inst s = OK s' /\
+    inst.inst_opcode = INVOKE ==>
+    s'.vs_prev_bb = s.vs_prev_bb /\
+    s'.vs_params = s.vs_params /\
+    s'.vs_call_ctx = s.vs_call_ctx /\
+    s'.vs_tx_ctx = s.vs_tx_ctx /\
+    s'.vs_block_ctx = s.vs_block_ctx /\
+    s'.vs_data_section = s.vs_data_section /\
+    s'.vs_code = s.vs_code /\
+    s'.vs_prev_hashes = s.vs_prev_hashes /\
+    s'.vs_labels = s.vs_labels
+Proof
+  rpt strip_tac >>
+  gvs[Once step_inst_def, AllCaseEqs(), bind_outputs_def] >>
+  qspecl_then [`ZIP (inst.inst_outputs, vals)`,
+               `merge_callee_state s callee_s'`]
+    strip_assume_tac foldl_update_var_only_vars >>
+  gvs[merge_callee_state_def]
+QED
+
+(* Case 1 of invoke commutation: inst2 has no outputs *)
+Triviality invoke_commute_case_nil:
+  !fuel ctx inst1 inst2 ss v1 s12 s21.
+    step_inst fuel ctx inst1 ss = OK v1 /\
+    step_inst fuel ctx inst2 ss = OK ss /\
+    step_inst fuel ctx inst2 v1 = OK s12 /\
+    step_inst fuel ctx inst1 ss = OK s21 /\
+    inst_wf inst1 /\ inst_wf inst2 /\
+    inst1.inst_opcode = INVOKE /\
+    inst2.inst_outputs = [] /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
+    DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_uses inst2)) /\
+    effects_independent inst1.inst_opcode inst2.inst_opcode /\
+    ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode /\
+    ~is_alloca_op inst1.inst_opcode /\ ~is_alloca_op inst2.inst_opcode /\
+    ~is_ext_call_op inst1.inst_opcode /\ ~is_ext_call_op inst2.inst_opcode /\
+    commute_equiv (set (inst_defs inst1) UNION set (inst_defs inst2)) s12 s21 /\
+    s12.vs_allocas = v1.vs_allocas /\
+    s12.vs_alloca_next = v1.vs_alloca_next /\
+    (!w. MEM w (inst_defs inst1) ==> lookup_var w s12 = lookup_var w v1) ==>
+    s12 = s21
+Proof
+  rpt strip_tac >>
+  `s21 = v1` by gvs[] >>
+  gvs[] >>
+  `s12.vs_allocas = s21.vs_allocas` by
+    metis_tac[step_inst_preserves_allocas] >>
+  `s12.vs_alloca_next = s21.vs_alloca_next` by
+    metis_tac[step_inst_preserves_alloca_next] >>
+  irule commute_equiv_allocas_vars_eq >>
+  simp[] >>
+  qexists_tac `set (inst_defs inst1) UNION set (inst_defs inst2)` >>
+  simp[] >> rpt strip_tac >>
+  gvs[IN_UNION, inst_defs_def]
+QED
+
+(* Case 2 of invoke commutation: inst2 has one output *)
+Triviality invoke_commute_case_cons:
+  !fuel ctx inst1 inst2 ss v1 out val s12 s21.
+    step_inst fuel ctx inst1 ss = OK v1 /\
+    step_inst fuel ctx inst2 ss = OK (update_var out val ss) /\
+    step_inst fuel ctx inst2 v1 = OK s12 /\
+    step_inst fuel ctx inst1 (update_var out val ss) = OK s21 /\
+    inst_wf inst1 /\ inst_wf inst2 /\
+    inst1.inst_opcode = INVOKE /\
+    inst2.inst_outputs = [out] /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
+    DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_uses inst2)) /\
+    effects_independent inst1.inst_opcode inst2.inst_opcode /\
+    ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode /\
+    ~is_alloca_op inst1.inst_opcode /\ ~is_alloca_op inst2.inst_opcode /\
+    ~is_ext_call_op inst1.inst_opcode /\ ~is_ext_call_op inst2.inst_opcode /\
+    commute_equiv (set (inst_defs inst1) UNION set (inst_defs inst2)) s12 s21 /\
+    s12.vs_allocas = v1.vs_allocas /\
+    s12.vs_alloca_next = v1.vs_alloca_next /\
+    (!w. MEM w (inst_defs inst1) ==> lookup_var w s12 = lookup_var w v1) /\
+    lookup_var out s12 = lookup_var out (update_var out val ss) ==>
+    s12 = s21
+Proof
+  rpt strip_tac >>
+  (* step_inst_ok_frame: inst1 over update_var = update_var over inst1 *)
+  qspecl_then [`fuel`, `ctx`, `inst1`, `ss`, `v1`, `out`, `val`]
+    mp_tac step_inst_ok_frame >>
+  (impl_tac >- (
+    simp[] >>
+    gvs[DISJOINT_DEF, EXTENSION, inst_defs_def, inst_uses_def] >>
+    metis_tac[mem_var_operand_vars])) >>
+  strip_tac >>
+  (* s21 = update_var out val v1 *)
+  gvs[] >>
+  irule commute_equiv_allocas_vars_eq >>
+  simp[update_var_def] >>
+  qexists_tac `set (inst_defs inst1) UNION set (inst_defs inst2)` >>
+  simp[] >> rpt strip_tac >> gvs[IN_UNION, inst_defs_def]
+  >- (
+    (* w in inst1.inst_outputs: lookup_var w s12 = lookup_var w (update_var out val v1) *)
+    `lookup_var w s12 = lookup_var w v1` by metis_tac[] >>
+    gvs[update_var_def, lookup_var_def, FLOOKUP_UPDATE] >>
+    gvs[DISJOINT_DEF, EXTENSION, inst_defs_def] >> metis_tac[])
+  >> (
+    (* w = out: lookup_var out s12 = lookup_var out (update_var out val v1) *)
+    gvs[update_var_def, lookup_var_def, FLOOKUP_UPDATE])
+QED
+
+(* Standalone invoke commutation: INVOKE × pure-empty-effect.
+   Delegates to case_nil and case_cons trivialities. *)
+Theorem invoke_commute_eq[local]:
+  !fuel ctx inst1 inst2 ss v1 v2 s12 s21.
+    step_inst fuel ctx inst1 ss = OK v1 /\
+    step_inst fuel ctx inst2 ss = OK v2 /\
+    step_inst fuel ctx inst2 v1 = OK s12 /\
+    step_inst fuel ctx inst1 v2 = OK s21 /\
+    inst_wf inst1 /\ inst_wf inst2 /\
+    inst1.inst_opcode = INVOKE /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_uses inst2)) /\
+    DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
+    effects_independent inst1.inst_opcode inst2.inst_opcode /\
+    ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode /\
+    ~is_alloca_op inst1.inst_opcode /\ ~is_alloca_op inst2.inst_opcode /\
+    ~is_ext_call_op inst1.inst_opcode /\ ~is_ext_call_op inst2.inst_opcode ==>
+    s12 = s21
+Proof
+  rpt strip_tac >>
+  (* 1: inst2 pure with empty effects *)
+  `inst2.inst_opcode <> INVOKE /\
+   write_effects inst2.inst_opcode = {} /\
+   read_effects inst2.inst_opcode = {}` by
+    (irule invoke_independent_empty_effects >> gvs[]) >>
+  (* 2: structural fields preserved by INVOKE *)
+  `v1.vs_prev_bb = ss.vs_prev_bb /\ v1.vs_params = ss.vs_params /\
+   v1.vs_call_ctx = ss.vs_call_ctx /\ v1.vs_tx_ctx = ss.vs_tx_ctx /\
+   v1.vs_block_ctx = ss.vs_block_ctx /\ v1.vs_data_section = ss.vs_data_section /\
+   v1.vs_code = ss.vs_code /\ v1.vs_prev_hashes = ss.vs_prev_hashes /\
+   v1.vs_labels = ss.vs_labels` by
+    (irule invoke_preserves_structural >> simp[] >> metis_tac[]) >>
+  (* 3: commute_equiv *)
+  `commute_equiv (set (inst_defs inst1) UNION set (inst_defs inst2))
+     s12 s21` by (
+    mp_tac (Q.SPECL [`fuel`, `ctx`, `inst1`, `inst2`, `ss`]
+                      effects_independent_commute) >> simp[]) >>
+  (* 4-5: step_inst_base reductions *)
+  `step_inst_base inst2 ss = OK v2` by gvs[step_inst_non_invoke] >>
+  `step_inst_base inst2 v1 = OK s12` by gvs[step_inst_non_invoke] >>
+  (* 6-7: allocas preserved *)
+  `s12.vs_allocas = v1.vs_allocas` by
+    metis_tac[step_inst_preserves_allocas] >>
+  `s12.vs_alloca_next = v1.vs_alloca_next` by
+    metis_tac[step_inst_preserves_alloca_next] >>
+  (* 8: operand agreement *)
+  `!op. MEM op inst2.inst_operands ==>
+        eval_operand op v1 = eval_operand op ss` by (
+    rpt strip_tac >>
+    qspecl_then [`fuel`, `ctx`, `inst1`, `ss`, `v1`, `op`]
+      mp_tac eval_operand_step_pres >>
+    (impl_tac >- (simp[] >>
+      gvs[DISJOINT_DEF, EXTENSION, inst_uses_def, inst_defs_def] >>
+      metis_tac[mem_var_operand_vars])) >> simp[]) >>
+  (* 9: output var agreement (inst1 preserves inst2's outputs) *)
+  `!w. MEM w inst2.inst_outputs ==>
+        lookup_var w v1 = lookup_var w ss` by (
+    rpt strip_tac >>
+    qspecl_then [`fuel`, `ctx`, `inst1`, `ss`, `v1`]
+      mp_tac step_preserves_non_output_vars >>
+    simp[] >>
+    gvs[DISJOINT_DEF, EXTENSION, inst_defs_def] >> metis_tac[]) >>
+  (* 10: inst2 output vars agree between s12 and v2 *)
+  `!w. MEM w inst2.inst_outputs ==> lookup_var w s12 = lookup_var w v2` by (
+    rpt strip_tac >> irule pure_step_output_agree >>
+    MAP_EVERY qexists_tac [`inst2`, `v1`, `ss`] >> simp[]) >>
+  (* 11: inst1 defs preserved through inst2 *)
+  `!w. MEM w (inst_defs inst1) ==> lookup_var w s12 = lookup_var w v1` by (
+    rpt strip_tac >>
+    qspecl_then [`fuel`, `ctx`, `inst2`, `v1`, `s12`]
+      mp_tac step_preserves_non_output_vars >>
+    simp[] >>
+    gvs[DISJOINT_DEF, EXTENSION, inst_defs_def] >> metis_tac[]) >>
+  (* 12: Dispatch via pure_step_structure *)
+  qspecl_then [`inst2`, `ss`, `v2`] mp_tac pure_step_structure >>
+  simp[] >> strip_tac >> gvs[]
+  >- (irule invoke_commute_case_nil >>
+      simp[] >> metis_tac[])
+  >> (irule invoke_commute_case_cons >>
+      simp[] >> metis_tac[])
+QED
+
+Theorem independent_commute_eq_ext:
+  !fuel ctx inst1 inst2 ss v1 v2 s12 s21.
+    step_inst fuel ctx inst1 ss = OK v1 /\
+    step_inst fuel ctx inst2 ss = OK v2 /\
+    step_inst fuel ctx inst2 v1 = OK s12 /\
+    step_inst fuel ctx inst1 v2 = OK s21 /\
+    inst_wf inst1 /\ inst_wf inst2 /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_uses inst2)) /\
+    DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
+    effects_independent inst1.inst_opcode inst2.inst_opcode /\
+    ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode /\
+    ~is_alloca_op inst1.inst_opcode /\ ~is_alloca_op inst2.inst_opcode /\
+    ~is_ext_call_op inst1.inst_opcode /\ ~is_ext_call_op inst2.inst_opcode ==>
+    s12 = s21
+Proof
+  rpt strip_tac >>
+  Cases_on `inst1.inst_opcode = INVOKE`
+  >- (
+    qspecl_then [`fuel`, `ctx`, `inst1`, `inst2`, `ss`, `v1`, `v2`, `s12`, `s21`]
+      mp_tac invoke_commute_eq >> simp[])
+  >> Cases_on `inst2.inst_opcode = INVOKE`
+  >- (
+    `effects_independent inst2.inst_opcode inst1.inst_opcode` by (
+      gvs[effects_independent_def]) >>
+    `s21 = s12` suffices_by simp[] >>
+    qspecl_then [`fuel`, `ctx`, `inst2`, `inst1`, `ss`, `v2`, `v1`, `s21`, `s12`]
+      mp_tac invoke_commute_eq >>
+    simp[DISJOINT_SYM])
+  >> (
+    qspecl_then [`fuel`, `ctx`, `inst1`, `inst2`, `ss`, `v1`, `v2`, `s12`, `s21`]
+      mp_tac independent_commute_eq >> simp[])
+QED
+
+(* ================================================================
+   11. Effect-free commutativity: effect-free instructions with
+       disjoint data deps produce identical states in either order.
+       Handles MSIZE-gap pairs ({MLOAD,ILOAD,SHA3}^2) that are
+       NOT effects_independent but still commute.
+   ================================================================ *)
+
+(* Key insight: is_effect_free_op instructions only modify output variables
+   (step_effect_free_state_equiv). So two such instructions commute when
+   data-independent, because:
+   (1) Each reads the same operand values regardless of order
+   (2) Each preserves all state fields
+   (3) update_var calls commute when outputs are disjoint *)
+
+(*
+ * Helper: extract field equalities from state_equiv without
+ * expanding the whole definition (avoids fs explosion).
+ *)
+Triviality state_equiv_fields:
+  !vars s1 s2. state_equiv vars s1 s2 ==>
+    s1.vs_memory = s2.vs_memory /\
+    s1.vs_transient = s2.vs_transient /\
+    (s1.vs_halted <=> s2.vs_halted) /\
+    s1.vs_returndata = s2.vs_returndata /\
+    s1.vs_accounts = s2.vs_accounts /\
+    s1.vs_call_ctx = s2.vs_call_ctx /\
+    s1.vs_tx_ctx = s2.vs_tx_ctx /\
+    s1.vs_block_ctx = s2.vs_block_ctx /\
+    s1.vs_logs = s2.vs_logs /\
+    s1.vs_immutables = s2.vs_immutables /\
+    s1.vs_data_section = s2.vs_data_section /\
+    s1.vs_labels = s2.vs_labels /\
+    s1.vs_code = s2.vs_code /\
+    s1.vs_params = s2.vs_params /\
+    s1.vs_prev_hashes = s2.vs_prev_hashes /\
+    s1.vs_allocas = s2.vs_allocas /\
+    s1.vs_alloca_next = s2.vs_alloca_next /\
+    s1.vs_current_bb = s2.vs_current_bb /\
+    s1.vs_inst_idx = s2.vs_inst_idx /\
+    s1.vs_prev_bb = s2.vs_prev_bb /\
+    (!v. v NOTIN vars ==> lookup_var v s1 = lookup_var v s2)
+Proof
+  rw[state_equiv_def, execution_equiv_def]
+QED
+
+(* effect-free ops are not INVOKE, so step_inst = step_inst_base *)
+Triviality effect_free_step_eq_base[local]:
+  !inst. is_effect_free_op inst.inst_opcode ==>
+    !fuel ctx s. step_inst fuel ctx inst s = step_inst_base inst s
+Proof
+  rpt strip_tac >> simp[Once step_inst_def] >>
+  `inst.inst_opcode <> INVOKE` by
+    (Cases_on `inst.inst_opcode` >> gvs[is_effect_free_op_def]) >>
+  simp[]
+QED
+
+(* Strengthen state_equiv by filling in the excluded variables *)
+Theorem state_equiv_fill_vars:
+  !vars s1 s2.
+    state_equiv vars s1 s2 /\
+    (!v. v IN vars ==> lookup_var v s1 = lookup_var v s2) ==>
+    state_equiv {} s1 s2
+Proof
+  rw[state_equiv_def, execution_equiv_def] >> metis_tac[]
+QED
+
+(* Effect-free step output is determined by state_equiv-preserved state.
+   For non-NOP effect-free inst, if s1 and s2 agree on everything except
+   some vars disjoint from inst_uses, then output values agree. *)
+Triviality effect_free_output_determined[local]:
+  !fuel ctx inst s1 s2 r1 r2 excl.
+    step_inst fuel ctx inst s1 = OK r1 /\
+    step_inst fuel ctx inst s2 = OK r2 /\
+    is_effect_free_op inst.inst_opcode /\
+    inst.inst_opcode <> NOP /\
+    state_equiv excl s1 s2 /\
+    DISJOINT excl (set (inst_uses inst)) ==>
+    !v. MEM v inst.inst_outputs ==> lookup_var v r1 = lookup_var v r2
+Proof
+  rpt strip_tac >>
+  imp_res_tac effect_free_step_eq_base >> gvs[] >>
+  qspecl_then [`inst`, `s1`, `s2`, `r1`, `r2`] mp_tac
+    step_inst_base_effect_free_output_determined_vars >>
+  impl_tac >- (
+    imp_res_tac state_equiv_fields >>
+    rpt conj_tac >> gvs[]
+    >- (rpt strip_tac >> irule eval_operand_equiv >>
+        qexists_tac `excl` >> simp[] >>
+        rpt strip_tac >> gvs[DISJOINT_DEF, EXTENSION, inst_uses_def] >>
+        metis_tac[mem_var_operand_vars])
+    >> metis_tac[]) >>
+  metis_tac[]
+QED
+
+Theorem effect_free_commute_eq:
+  !fuel ctx inst1 inst2 ss v1 v2 s12 s21.
+    step_inst fuel ctx inst1 ss = OK v1 /\
+    step_inst fuel ctx inst2 ss = OK v2 /\
+    step_inst fuel ctx inst2 v1 = OK s12 /\
+    step_inst fuel ctx inst1 v2 = OK s21 /\
+    is_effect_free_op inst1.inst_opcode /\
+    is_effect_free_op inst2.inst_opcode /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_uses inst2)) /\
+    DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
+    DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
+    ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode ==>
+    s12 = s21
+Proof
+  rpt strip_tac >>
+  (* Step 1: Get state_equiv from each effect-free step *)
+  `state_equiv (set inst1.inst_outputs) ss v1` by
+    metis_tac[step_effect_free_state_equiv] >>
+  `state_equiv (set inst2.inst_outputs) ss v2` by
+    metis_tac[step_effect_free_state_equiv] >>
+  `state_equiv (set inst2.inst_outputs) v1 s12` by
+    metis_tac[step_effect_free_state_equiv] >>
+  `state_equiv (set inst1.inst_outputs) v2 s21` by
+    metis_tac[step_effect_free_state_equiv] >>
+  (* Handle NOP: identity step, so trivially commutes *)
+  Cases_on `inst1.inst_opcode = NOP`
+  >- (imp_res_tac step_nop_identity >> gvs[]) >>
+  Cases_on `inst2.inst_opcode = NOP`
+  >- (imp_res_tac step_nop_identity >> gvs[]) >>
+  (* Step 2: Chain state_equivs to get state_equiv (outs1 ∪ outs2) s12 s21 *)
+  qabbrev_tac `both = set inst1.inst_outputs UNION set inst2.inst_outputs` >>
+  `state_equiv both ss s12` by
+    (irule state_equiv_trans >> qexists_tac `v1` >>
+     metis_tac[state_equiv_subset, SUBSET_UNION]) >>
+  `state_equiv both ss s21` by
+    (irule state_equiv_trans >> qexists_tac `v2` >>
+     metis_tac[state_equiv_subset, SUBSET_UNION]) >>
+  `state_equiv both s12 s21` by
+    metis_tac[state_equiv_sym, state_equiv_trans] >>
+  (* Step 3: Strengthen to state_equiv {} by filling in excluded vars *)
+  irule state_equiv_empty_eq >>
+  irule state_equiv_fill_vars >>
+  qexists_tac `both` >> simp[] >>
+  rpt strip_tac >> gvs[inst_defs_def, Abbr `both`]
+  (* v in inst1.outs *)
+  >- (`v NOTIN set inst2.inst_outputs` by
+        (gvs[DISJOINT_DEF, EXTENSION] >> metis_tac[]) >>
+      (* lookup_var v s12 = lookup_var v v1 *)
+      `lookup_var v s12 = lookup_var v v1` by
+        (qpat_x_assum `state_equiv (set inst2.inst_outputs) v1 s12` mp_tac >>
+         simp[state_equiv_def, execution_equiv_def] >> metis_tac[]) >>
+      (* lookup_var v v1 = lookup_var v s21 via output_determined *)
+      `lookup_var v v1 = lookup_var v s21` by
+        (qspecl_then [`fuel`, `ctx`, `inst1`, `ss`, `v2`, `v1`, `s21`,
+                      `set inst2.inst_outputs`] mp_tac
+           effect_free_output_determined >>
+         simp[] >> metis_tac[DISJOINT_SYM]) >>
+      simp[])
+  (* v in inst2.outs: symmetric *)
+  >> (`v NOTIN set inst1.inst_outputs` by
+        (gvs[DISJOINT_DEF, EXTENSION] >> metis_tac[]) >>
+      `lookup_var v s21 = lookup_var v v2` by
+        (qpat_x_assum `state_equiv (set inst1.inst_outputs) v2 s21` mp_tac >>
+         simp[state_equiv_def, execution_equiv_def] >> metis_tac[]) >>
+      `lookup_var v v2 = lookup_var v s12` by
+        (qspecl_then [`fuel`, `ctx`, `inst2`, `ss`, `v1`, `v2`, `s12`,
+                      `set inst1.inst_outputs`] mp_tac
+           effect_free_output_determined >>
+         simp[] >> metis_tac[DISJOINT_SYM]) >>
+      simp[])
+QED
+
+

--- a/venom/passes/dft/proofs/dftBlockSimScript.sml
+++ b/venom/passes/dft/proofs/dftBlockSimScript.sml
@@ -221,6 +221,43 @@ Proof
     imp_res_tac step_pres_all_applied >> gvs[])
 QED
 
+(* Effect-free account-reading ops: exactly BALANCE/SELFBALANCE/EXTCODESIZE/EXTCODEHASH *)
+Triviality effect_free_account_read_opcodes[local]:
+  !op. is_effect_free_op op /\
+    (Eff_BALANCE IN read_effects op \/ Eff_EXTCODE IN read_effects op) ==>
+    op = BALANCE \/ op = SELFBALANCE \/ op = EXTCODESIZE \/ op = EXTCODEHASH
+Proof Cases >> EVAL_TAC
+QED
+
+(* Account-reading opcodes: output values depend only on
+   account sub-fields (balance/nonce/code) and call_ctx,
+   NOT on full vs_accounts record equality. *)
+Triviality account_read_output_agree[local]:
+  !inst s1 s2 r1 r2 w.
+    step_inst_base inst s1 = OK r1 /\
+    step_inst_base inst s2 = OK r2 /\
+    (inst.inst_opcode = BALANCE \/ inst.inst_opcode = SELFBALANCE \/
+     inst.inst_opcode = EXTCODESIZE \/ inst.inst_opcode = EXTCODEHASH) /\
+    (!op. MEM op inst.inst_operands ==>
+          eval_operand op s1 = eval_operand op s2) /\
+    (!addr. (s1.vs_accounts addr).balance =
+            (s2.vs_accounts addr).balance /\
+            (s1.vs_accounts addr).nonce =
+            (s2.vs_accounts addr).nonce /\
+            (s1.vs_accounts addr).code =
+            (s2.vs_accounts addr).code) /\
+    s1.vs_call_ctx = s2.vs_call_ctx /\
+    MEM w inst.inst_outputs ==>
+    lookup_var w r1 = lookup_var w r2
+Proof
+  rpt strip_tac >> gvs[] >>
+  gvs[step_inst_base_def, exec_read0_def, exec_read1_def,
+      AllCaseEqs(), update_var_def, lookup_var_def,
+      FLOOKUP_UPDATE, lookup_account_def] >>
+  (* EXTCODEHASH: account_empty tautology on s2's own fields *)
+  gvs[account_empty_def] >> metis_tac[]
+QED
+
 (* Non-effect-free eligible ops preserve all vars.
    These ops (MSTORE, SSTORE, MCOPY, LOG, ASSERT, etc.) modify
    side-effect fields only — vs_vars is untouched. *)
@@ -351,12 +388,33 @@ Proof
       metis_tac[step_nop_identity] >>
     `step_inst fuel ctx inst_a vb = OK vb` by
       metis_tac[step_nop_identity] >>
-    gvs[])
-  >> Cases_on `is_effect_free_op inst_a.inst_opcode`
+    gvs[]) >>
+  Cases_on `is_effect_free_op inst_a.inst_opcode`
   >- (
-    irule step_inst_base_effect_free_output_determined_vars >>
-    qexistsl_tac [`inst_a`, `ss`, `vb`] >>
-    rpt conj_tac >> gvs[] >> res_tac >> gvs[])
+    (* Account-reading opcodes need special handling because SSTORE
+       modifies .storage but preserves .balance/.nonce/.code.
+       The generic theorem demands full vs_accounts equality which
+       fails for BALANCE × SSTORE pairs. *)
+    Cases_on `Eff_BALANCE IN read_effects inst_a.inst_opcode \/
+              Eff_EXTCODE IN read_effects inst_a.inst_opcode`
+    >- (
+      (* inst_a ∈ {BALANCE, SELFBALANCE, EXTCODESIZE, EXTCODEHASH}.
+         Prove output agreement directly from sub-field preservation. *)
+      irule account_read_output_agree >> simp[] >>
+      metis_tac[effect_free_account_read_opcodes])
+    >- (
+      (* No account-reading effects: generic theorem applies *)
+      irule step_inst_base_effect_free_output_determined_vars >>
+      qexistsl_tac [`inst_a`, `ss`, `vb`] >>
+      rpt conj_tac >> gvs[] >>
+      TRY (res_tac >> gvs[] >> NO_TAC) >>
+      Cases_on `Eff_STORAGE IN read_effects inst_a.inst_opcode`
+      >- (
+        `Eff_STORAGE NOTIN write_effects inst_b.inst_opcode` by res_tac >>
+        `Eff_BALANCE NOTIN write_effects inst_b.inst_opcode` by
+          metis_tac[eligible_write_constraints] >>
+        `vb.vs_accounts = ss.vs_accounts` by gvs[] >> gvs[])
+      >- gvs[]))
   >> (
     (* Non-effect-free: all vars preserved *)
     `!v. lookup_var v va = lookup_var v ss` by
@@ -380,6 +438,7 @@ Theorem independent_commute_eq:
     DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
     DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
     effects_independent inst1.inst_opcode inst2.inst_opcode /\
+    abort_compatible inst1.inst_opcode inst2.inst_opcode /\
     ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode /\
     ~is_alloca_op inst1.inst_opcode /\ ~is_alloca_op inst2.inst_opcode /\
     ~is_ext_call_op inst1.inst_opcode /\ ~is_ext_call_op inst2.inst_opcode /\
@@ -390,7 +449,7 @@ Proof
   (* A: commute_equiv *)
   `commute_equiv (set (inst_defs inst1) UNION set (inst_defs inst2)) s12 s21` by (
     mp_tac (Q.SPECL [`fuel`, `ctx`, `inst1`, `inst2`, `ss`]
-                      effects_independent_commute) >> simp[]) >>
+                      effects_independent_commute) >> simp[LET_THM]) >>
   (* B: vs_allocas *)
   `s12.vs_allocas = s21.vs_allocas` by (
     `v1.vs_allocas = ss.vs_allocas` by metis_tac[step_inst_preserves_allocas] >>
@@ -645,6 +704,7 @@ Theorem invoke_commute_eq[local]:
     DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
     DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
     effects_independent inst1.inst_opcode inst2.inst_opcode /\
+    abort_compatible inst1.inst_opcode inst2.inst_opcode /\
     ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode /\
     ~is_alloca_op inst1.inst_opcode /\ ~is_alloca_op inst2.inst_opcode /\
     ~is_ext_call_op inst1.inst_opcode /\ ~is_ext_call_op inst2.inst_opcode ==>
@@ -667,7 +727,7 @@ Proof
   `commute_equiv (set (inst_defs inst1) UNION set (inst_defs inst2))
      s12 s21` by (
     mp_tac (Q.SPECL [`fuel`, `ctx`, `inst1`, `inst2`, `ss`]
-                      effects_independent_commute) >> simp[]) >>
+                      effects_independent_commute) >> simp[LET_THM]) >>
   (* 4-5: step_inst_base reductions *)
   `step_inst_base inst2 ss = OK v2` by gvs[step_inst_non_invoke] >>
   `step_inst_base inst2 v1 = OK s12` by gvs[step_inst_non_invoke] >>
@@ -724,6 +784,7 @@ Theorem independent_commute_eq_ext:
     DISJOINT (set (inst_defs inst2)) (set (inst_uses inst1)) /\
     DISJOINT (set (inst_defs inst1)) (set (inst_defs inst2)) /\
     effects_independent inst1.inst_opcode inst2.inst_opcode /\
+    abort_compatible inst1.inst_opcode inst2.inst_opcode /\
     ~is_terminator inst1.inst_opcode /\ ~is_terminator inst2.inst_opcode /\
     ~is_alloca_op inst1.inst_opcode /\ ~is_alloca_op inst2.inst_opcode /\
     ~is_ext_call_op inst1.inst_opcode /\ ~is_ext_call_op inst2.inst_opcode ==>
@@ -738,6 +799,8 @@ Proof
   >- (
     `effects_independent inst2.inst_opcode inst1.inst_opcode` by (
       gvs[effects_independent_def]) >>
+    `abort_compatible inst2.inst_opcode inst1.inst_opcode` by (
+      gvs[abort_compatible_def]) >>
     `s21 = s12` suffices_by simp[] >>
     qspecl_then [`fuel`, `ctx`, `inst2`, `inst1`, `ss`, `v2`, `v1`, `s21`, `s12`]
       mp_tac invoke_commute_eq >>

--- a/venom/passes/dft/proofs/dftCommutationScript.sml
+++ b/venom/passes/dft/proofs/dftCommutationScript.sml
@@ -1,0 +1,692 @@
+(*
+ * DFT Commutation Helpers
+ *
+ * Infrastructure for proving that independent instructions commute.
+ * The key abstraction: step_inst_base (and step_inst for INVOKE)
+ * commutes with update_var on variables not in the instruction's
+ * operands or outputs. Combined with update_var commutativity on
+ * disjoint keys, this gives the full independent_commute theorem.
+ *
+ * TOP-LEVEL:
+ *   step_inst_frame        — frame lemma for step_inst (non-INVOKE)
+ *   step_inst_invoke_frame  — frame lemma for INVOKE case
+ *   step_inst_ok_frame      — unified frame lemma for OK results
+ *   step_inst_base_frame    — frame lemma for step_inst_base
+ *   map_result_state_def    — result-level map for threading state transforms
+ *   resolve_phi_MEM         — resolve_phi returns a member of the operand list
+ *)
+
+Theory dftCommutation
+Ancestors
+  venomState venomExecSemantics venomExecProps venomEffects venomInst
+  venomInstProofs finite_map list pair
+
+(* ================================================================
+   Basic variable infrastructure
+   ================================================================ *)
+
+(* eval_operand ignores update_var at unrelated keys *)
+Theorem eval_operand_update_var:
+  !op x v s. (!y. op = Var y ==> x <> y) ==>
+  eval_operand op (update_var x v s) = eval_operand op s
+Proof
+  Cases_on `op` >>
+  rw[eval_operand_def, update_var_def, lookup_var_def, FLOOKUP_UPDATE]
+QED
+
+(* eval_operands ignores update_var at unrelated keys *)
+Theorem eval_operands_update_var:
+  !ops x v s. (!y. MEM (Var y) ops ==> x <> y) ==>
+  eval_operands ops (update_var x v s) = eval_operands ops s
+Proof
+  Induct >> rw[eval_operands_def] >>
+  Cases_on `h` >> fs[eval_operand_def, update_var_def, lookup_var_def,
+                      FLOOKUP_UPDATE]
+QED
+
+(* update_var on disjoint keys commutes *)
+Theorem update_var_commutes:
+  !x1 v1 x2 v2 s. x1 <> x2 ==>
+  update_var x1 v1 (update_var x2 v2 s) =
+  update_var x2 v2 (update_var x1 v1 s)
+Proof
+  rw[update_var_def] >>
+  simp[venom_state_component_equality, FUPDATE_COMMUTES]
+QED
+
+(* FOLDL update_var commutes with unrelated update_var *)
+Theorem foldl_update_var_commute:
+  !kvs s x v. ~MEM x (MAP FST kvs) ==>
+  FOLDL (\s' (k,val). update_var k val s') (update_var x v s) kvs =
+  update_var x v (FOLDL (\s' (k,val). update_var k val s') s kvs)
+Proof
+  Induct >> rw[] >>
+  PairCases_on `h` >> fs[MEM_MAP, FORALL_PROD] >>
+  first_x_assum (qspecl_then [`update_var h0 h1 s`, `x`, `v`] mp_tac) >>
+  rw[update_var_commutes]
+QED
+
+(* ================================================================
+   update_var commutes with all state-modifying operations
+   (because update_var only touches vs_vars)
+   ================================================================ *)
+
+Theorem update_var_mstore_commute:
+  !x v off val s.
+  update_var x v (mstore off val s) = mstore off val (update_var x v s)
+Proof
+  rw[update_var_def, mstore_def, venom_state_component_equality]
+QED
+
+Theorem update_var_mstore8_commute:
+  !x v off val s.
+  update_var x v (mstore8 off val s) = mstore8 off val (update_var x v s)
+Proof
+  rw[update_var_def, mstore8_def, venom_state_component_equality]
+QED
+
+Theorem update_var_sstore_commute:
+  !x v k val s.
+  update_var x v (sstore k val s) = sstore k val (update_var x v s)
+Proof
+  rw[update_var_def, sstore_def, venom_state_component_equality]
+QED
+
+Theorem update_var_tstore_commute:
+  !x v k val s.
+  update_var x v (tstore k val s) = tstore k val (update_var x v s)
+Proof
+  rw[update_var_def, tstore_def, venom_state_component_equality]
+QED
+
+Theorem update_var_write_memory_commute:
+  !x v off bytes s.
+  update_var x v (write_memory_with_expansion off bytes s) =
+  write_memory_with_expansion off bytes (update_var x v s)
+Proof
+  rw[update_var_def, write_memory_with_expansion_def,
+     venom_state_component_equality]
+QED
+
+Theorem update_var_mcopy_commute:
+  !x v dst src sz s.
+  update_var x v (mcopy dst src sz s) =
+  mcopy dst src sz (update_var x v s)
+Proof
+  rw[update_var_def, mcopy_def, write_memory_with_expansion_def,
+     venom_state_component_equality]
+QED
+
+Theorem update_var_halt_state_commute:
+  !x v s.
+  update_var x v (halt_state s) = halt_state (update_var x v s)
+Proof
+  rw[update_var_def, halt_state_def, venom_state_component_equality]
+QED
+
+Theorem update_var_revert_state_commute:
+  !x v s.
+  update_var x v (revert_state s) = revert_state (update_var x v s)
+Proof
+  rw[update_var_def, revert_state_def, venom_state_component_equality]
+QED
+
+Theorem update_var_set_returndata_commute:
+  !x v rd s.
+  update_var x v (set_returndata rd s) = set_returndata rd (update_var x v s)
+Proof
+  rw[update_var_def, set_returndata_def, venom_state_component_equality]
+QED
+
+Theorem update_var_jump_to_commute:
+  !x v lbl s.
+  update_var x v (jump_to lbl s) = jump_to lbl (update_var x v s)
+Proof
+  rw[update_var_def, jump_to_def, venom_state_component_equality]
+QED
+
+(* update_var commutes with arbitrary record field updates on non-vs_vars fields *)
+Theorem update_var_with_immutables_commute:
+  !x v imm s.
+  update_var x v (s with vs_immutables := imm) =
+  (update_var x v s) with vs_immutables := imm
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+Theorem update_var_with_logs_commute:
+  !x v logs s.
+  update_var x v (s with vs_logs := logs) =
+  (update_var x v s) with vs_logs := logs
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+Theorem update_var_with_accounts_commute:
+  !x v accts s.
+  update_var x v (s with vs_accounts := accts) =
+  (update_var x v s) with vs_accounts := accts
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+Theorem update_var_with_returndata_commute:
+  !x v rd s.
+  update_var x v (s with vs_returndata := rd) =
+  (update_var x v s) with vs_returndata := rd
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+Theorem update_var_with_memory_commute:
+  !x v mem s.
+  update_var x v (s with vs_memory := mem) =
+  (update_var x v s) with vs_memory := mem
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+Theorem update_var_with_transient_commute:
+  !x v tr s.
+  update_var x v (s with vs_transient := tr) =
+  (update_var x v s) with vs_transient := tr
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+Theorem update_var_with_allocas_commute:
+  !x v al s.
+  update_var x v (s with vs_allocas := al) =
+  (update_var x v s) with vs_allocas := al
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+Theorem update_var_with_alloca_next_commute:
+  !x v n s.
+  update_var x v (s with vs_alloca_next := n) =
+  (update_var x v s) with vs_alloca_next := n
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+(* General: update_var commutes with multi-field record update *)
+Theorem update_var_with_multi_commute:
+  !x v s rd accts logs mem tr.
+  update_var x v (s with <| vs_returndata := rd; vs_accounts := accts;
+                             vs_logs := logs; vs_memory := mem;
+                             vs_transient := tr |>) =
+  (update_var x v s) with <| vs_returndata := rd; vs_accounts := accts;
+                              vs_logs := logs; vs_memory := mem;
+                              vs_transient := tr |>
+Proof
+  rw[update_var_def, venom_state_component_equality]
+QED
+
+(* ================================================================
+   INVOKE pipeline commutes with unrelated update_var
+   ================================================================ *)
+
+Theorem setup_callee_update_var:
+  !fn args s x v.
+  setup_callee fn args (update_var x v s) = setup_callee fn args s
+Proof
+  rw[setup_callee_def, update_var_def, venom_state_component_equality]
+QED
+
+Theorem merge_callee_update_var:
+  !s callee_s x v.
+  merge_callee_state (update_var x v s) callee_s =
+  update_var x v (merge_callee_state s callee_s)
+Proof
+  rw[merge_callee_state_def, update_var_def, venom_state_component_equality]
+QED
+
+Theorem bind_outputs_update_var:
+  !outs vals s x v. ~MEM x outs ==>
+  bind_outputs outs vals (update_var x v s) =
+  OPTION_MAP (update_var x v) (bind_outputs outs vals s)
+Proof
+  rw[bind_outputs_def] >> rw[] >>
+  rw[foldl_update_var_commute, MAP_ZIP]
+QED
+
+(* ================================================================
+   Non-variable state fields are unchanged by update_var
+   (needed to show state-reading ops are unaffected)
+   ================================================================ *)
+
+Theorem update_var_fields[simp]:
+  (update_var x v s).vs_memory = s.vs_memory /\
+  (update_var x v s).vs_transient = s.vs_transient /\
+  (update_var x v s).vs_accounts = s.vs_accounts /\
+  (update_var x v s).vs_returndata = s.vs_returndata /\
+  (update_var x v s).vs_logs = s.vs_logs /\
+  (update_var x v s).vs_immutables = s.vs_immutables /\
+  (update_var x v s).vs_data_section = s.vs_data_section /\
+  (update_var x v s).vs_labels = s.vs_labels /\
+  (update_var x v s).vs_code = s.vs_code /\
+  (update_var x v s).vs_params = s.vs_params /\
+  (update_var x v s).vs_call_ctx = s.vs_call_ctx /\
+  (update_var x v s).vs_tx_ctx = s.vs_tx_ctx /\
+  (update_var x v s).vs_block_ctx = s.vs_block_ctx /\
+  (update_var x v s).vs_prev_bb = s.vs_prev_bb /\
+  (update_var x v s).vs_current_bb = s.vs_current_bb /\
+  (update_var x v s).vs_inst_idx = s.vs_inst_idx /\
+  (update_var x v s).vs_halted = s.vs_halted /\
+  (update_var x v s).vs_prev_hashes = s.vs_prev_hashes /\
+  (update_var x v s).vs_allocas = s.vs_allocas /\
+  (update_var x v s).vs_alloca_next = s.vs_alloca_next
+Proof
+  rw[update_var_def]
+QED
+
+(* ================================================================
+   Per-helper frame lemmas: each exec helper commutes with update_var
+   ================================================================ *)
+
+(* Result-level map for applying a state transform to exec_result values *)
+Definition map_result_state_def:
+  map_result_state f (OK s) = OK (f s) /\
+  map_result_state f (Halt s) = Halt (f s) /\
+  map_result_state f (Abort a s) = Abort a (f s) /\
+  map_result_state f (IntRet vals s) = IntRet vals (f s) /\
+  map_result_state f (Error e) = Error e
+End
+
+(* Key strategy: rewrite eval_operand through update_var FIRST,
+   then the two sides become syntactically equal modulo update_var wrapping *)
+Theorem exec_pure1_frame[local]:
+  !f inst s x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  ~MEM x inst.inst_outputs ==>
+  exec_pure1 f inst (update_var x v s) =
+  map_result_state (update_var x v) (exec_pure1 f inst s)
+Proof
+  rw[exec_pure1_def] >>
+  Cases_on `inst.inst_operands` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def, MEM, eval_operand_update_var] >>
+  Cases_on `eval_operand h s` >> gvs[map_result_state_def] >>
+  Cases_on `inst.inst_outputs` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def, MEM, update_var_commutes]
+QED
+
+Theorem exec_pure2_frame[local]:
+  !f inst s x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  ~MEM x inst.inst_outputs ==>
+  exec_pure2 f inst (update_var x v s) =
+  map_result_state (update_var x v) (exec_pure2 f inst s)
+Proof
+  rw[exec_pure2_def] >>
+  Cases_on `inst.inst_operands` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def] >>
+  Cases_on `t'` >> gvs[map_result_state_def, MEM, eval_operand_update_var] >>
+  Cases_on `eval_operand h s` >> Cases_on `eval_operand h' s` >>
+  gvs[map_result_state_def] >>
+  Cases_on `inst.inst_outputs` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def, MEM, update_var_commutes]
+QED
+
+Theorem exec_pure3_frame[local]:
+  !f inst s x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  ~MEM x inst.inst_outputs ==>
+  exec_pure3 f inst (update_var x v s) =
+  map_result_state (update_var x v) (exec_pure3 f inst s)
+Proof
+  rw[exec_pure3_def] >>
+  Cases_on `inst.inst_operands` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def] >>
+  Cases_on `t'` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def, MEM, eval_operand_update_var] >>
+  Cases_on `eval_operand h s` >> Cases_on `eval_operand h' s` >>
+  Cases_on `eval_operand h'' s` >> gvs[map_result_state_def] >>
+  Cases_on `inst.inst_outputs` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def, MEM, update_var_commutes]
+QED
+
+Theorem exec_read0_frame[local]:
+  !f inst s x v.
+  (!s0. f (update_var x v s0) = f s0) /\
+  ~MEM x inst.inst_outputs ==>
+  exec_read0 f inst (update_var x v s) =
+  map_result_state (update_var x v) (exec_read0 f inst s)
+Proof
+  rw[exec_read0_def] >>
+  Cases_on `inst.inst_outputs` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def, MEM, update_var_commutes]
+QED
+
+Theorem exec_read1_frame[local]:
+  !f inst s x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  (!w s0. f w (update_var x v s0) = f w s0) /\
+  ~MEM x inst.inst_outputs ==>
+  exec_read1 f inst (update_var x v s) =
+  map_result_state (update_var x v) (exec_read1 f inst s)
+Proof
+  rw[exec_read1_def] >>
+  Cases_on `inst.inst_operands` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def, MEM, eval_operand_update_var] >>
+  Cases_on `eval_operand h s` >> gvs[map_result_state_def] >>
+  Cases_on `inst.inst_outputs` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def, MEM, update_var_commutes]
+QED
+
+Theorem exec_write2_frame[local]:
+  !f inst s x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  (!v1 v2 s0. f v1 v2 (update_var x v s0) = update_var x v (f v1 v2 s0)) ==>
+  exec_write2 f inst (update_var x v s) =
+  map_result_state (update_var x v) (exec_write2 f inst s)
+Proof
+  rw[exec_write2_def] >>
+  Cases_on `inst.inst_operands` >> gvs[map_result_state_def] >>
+  Cases_on `t` >> gvs[map_result_state_def] >>
+  Cases_on `t'` >> gvs[map_result_state_def, MEM, eval_operand_update_var] >>
+  Cases_on `eval_operand h s` >> Cases_on `eval_operand h' s` >>
+  gvs[map_result_state_def]
+QED
+
+(* ================================================================
+   step_inst_base frame lemma: update_var on unrelated variables
+   threads through step_inst_base
+   ================================================================ *)
+
+(* ML tactic for step_inst_base_frame: process 92 opcodes.
+   Strategy: unfold step_inst_base_def once on each side, case-split the opcode,
+   then for helper cases use per-helper frame lemmas, for custom cases use
+   eval_operand_update_var + commute lemmas + case splitting. *)
+
+(* Frame lemmas for the exec_* helpers *)
+val helper_frames = [
+  exec_pure1_frame, exec_pure2_frame, exec_pure3_frame,
+  exec_read0_frame, exec_read1_frame, exec_write2_frame
+];
+
+(* Rewrites for threading update_var through state operations *)
+val update_var_rwts = [
+  update_var_fields, update_var_commutes,
+  update_var_mstore_commute, update_var_mstore8_commute, update_var_sstore_commute,
+  update_var_tstore_commute, update_var_write_memory_commute,
+  update_var_mcopy_commute, update_var_halt_state_commute,
+  update_var_revert_state_commute, update_var_set_returndata_commute,
+  update_var_jump_to_commute,
+  update_var_with_immutables_commute, update_var_with_logs_commute,
+  update_var_with_accounts_commute, update_var_with_returndata_commute,
+  update_var_with_memory_commute, update_var_with_transient_commute,
+  update_var_with_allocas_commute, update_var_with_alloca_next_commute,
+  update_var_with_multi_commute
+];
+
+(* update_var is transparent to state-reading functions.
+   These are needed to discharge exec_read0/1_frame hypotheses. *)
+Theorem update_var_transparent[simp,local]:
+  mload off (update_var x v s) = mload off s /\
+  sload key (update_var x v s) = sload key s /\
+  tload key (update_var x v s) = tload key s /\
+  contract_storage (update_var x v s) = contract_storage s
+Proof
+  rw[mload_def, sload_def, tload_def, contract_storage_def,
+     contract_transient_def, update_var_def]
+QED
+
+Theorem write_mem_expand_update_var[local]:
+  (write_memory_with_expansion off bytes (update_var x v s)).vs_memory =
+    (write_memory_with_expansion off bytes s).vs_memory
+Proof
+  rw[write_memory_with_expansion_def, update_var_def]
+QED
+
+(* resolve_phi returns an element of the operand list *)
+Theorem resolve_phi_MEM:
+  !prev ops op. resolve_phi prev ops = SOME op ==> MEM op ops
+Proof
+  recInduct resolve_phi_ind >>
+  rw[resolve_phi_def] >> gvs[] >>
+  res_tac >> gvs[]
+QED
+
+val helper_hyp_rwts = [update_var_transparent];
+
+(* Wrapper: eval_operand on EL i t is unchanged by update_var when x not in t *)
+Theorem eval_operand_update_var_el[local]:
+  !t i x v s. ~MEM (Var x) t /\ i < LENGTH t ==>
+    eval_operand (EL i t) (update_var x v s) = eval_operand (EL i t) s
+Proof
+  rpt strip_tac >> irule eval_operand_update_var >>
+  rw[] >> CCONTR_TAC >> gvs[] >>
+  `MEM (EL i t) t` by metis_tac[MEM_EL] >> gvs[]
+QED
+
+
+(* Wrapper: eval_operand on HD t is unchanged when x not in t *)
+Theorem eval_operand_update_var_hd[local]:
+  !t x v s. ~MEM (Var x) t /\ 0 < LENGTH t ==>
+    eval_operand (HD t) (update_var x v s) = eval_operand (HD t) s
+Proof
+  Cases >> rw[] >> irule eval_operand_update_var >>
+  rw[] >> CCONTR_TAC >> gvs[]
+QED
+
+(* Wrapper: eval_operands on DROP n t is unchanged when x not in t *)
+Theorem eval_operands_update_var_drop[local]:
+  !t n x v s. ~MEM (Var x) t ==>
+    eval_operands (DROP n t) (update_var x v s) = eval_operands (DROP n t) s
+Proof
+  rpt strip_tac >> irule eval_operands_update_var >>
+  rw[] >> CCONTR_TAC >> gvs[] >>
+  metis_tac[rich_listTheory.MEM_DROP_IMP]
+QED
+
+(* Core rewrites for eval_operand and map_result_state *)
+val core_rwts = [
+  eval_operand_update_var,
+  eval_operand_update_var_el, eval_operand_update_var_hd,
+  eval_operands_update_var, eval_operands_update_var_drop,
+  map_result_state_def
+];
+
+(* Definitions to unfold for custom (non-helper) cases *)
+val custom_defs = [
+  exec_ext_call_def, exec_delegatecall_def,
+  exec_create_def, exec_alloca_def,
+  extract_venom_result_def,
+  make_venom_call_state_def, make_venom_delegatecall_state_def,
+  make_venom_create_state_def,
+  venom_to_tx_params_def, eval_operands_def,
+  next_alloca_offset_def, read_memory_def
+];
+
+val all_rwts = helper_frames @ update_var_rwts @ helper_hyp_rwts @ core_rwts;
+
+(* Frame lemma for extract_venom_result: update_var threads through *)
+Theorem extract_venom_result_update_var[local]:
+  !s outf retOff retSize rr x v.
+  extract_venom_result (update_var x v s) outf retOff retSize rr =
+  OPTION_MAP (\(output, s'). (output, update_var x v s'))
+    (extract_venom_result s outf retOff retSize rr)
+Proof
+  rw[extract_venom_result_def] >>
+  BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  rw[update_var_def, write_memory_with_expansion_def,
+     venom_state_component_equality] >>
+  BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  BasicProvers.TOP_CASE_TAC >> gvs[]
+QED
+
+(* Shared proof for ext_call/delegatecall/create frame lemmas.
+   Strategy: unfold the ext_call def, show make_*_state is unchanged
+   by update_var (only reads non-var fields), then apply
+   extract_venom_result_update_var and handle the OPTION_MAP. *)
+fun ext_call_frame_proof defs =
+  rpt strip_tac >>
+  (* Unfold ext_call but NOT update_var — keep it abstract for rewriting *)
+  simp(defs @ [read_memory_def, venom_to_tx_params_def, update_var_fields]) >>
+  (* extract_venom_result_update_var fires here *)
+  simp[extract_venom_result_update_var, optionTheory.OPTION_MAP_DEF,
+       pairTheory.UNCURRY] >>
+  (* Case split on extract_venom_result *)
+  BasicProvers.TOP_CASE_TAC >> gvs[map_result_state_def] >>
+  (* Decompose the pair z *)
+  Cases_on `z` >> gvs[map_result_state_def] >>
+  (* Case split on inst_outputs *)
+  BasicProvers.TOP_CASE_TAC >> gvs[map_result_state_def] >>
+  BasicProvers.TOP_CASE_TAC >> gvs[map_result_state_def, update_var_commutes];
+
+(* Frame lemma for exec_ext_call *)
+Theorem exec_ext_call_frame[local]:
+  !inst s gas addr value ao as_ ro rs is_static x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  ~MEM x inst.inst_outputs ==>
+  exec_ext_call inst (update_var x v s) gas addr value ao as_ ro rs is_static =
+  map_result_state (update_var x v)
+    (exec_ext_call inst s gas addr value ao as_ ro rs is_static)
+Proof
+  ext_call_frame_proof [exec_ext_call_def, make_venom_call_state_def]
+QED
+
+(* Frame lemma for exec_delegatecall *)
+Theorem exec_delegatecall_frame[local]:
+  !inst s gas addr ao as_ ro rs x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  ~MEM x inst.inst_outputs ==>
+  exec_delegatecall inst (update_var x v s) gas addr ao as_ ro rs =
+  map_result_state (update_var x v)
+    (exec_delegatecall inst s gas addr ao as_ ro rs)
+Proof
+  ext_call_frame_proof [exec_delegatecall_def, make_venom_delegatecall_state_def]
+QED
+
+(* Frame lemma for exec_create *)
+Theorem exec_create_frame[local]:
+  !inst s value offset sz salt_opt x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  ~MEM x inst.inst_outputs ==>
+  exec_create inst (update_var x v s) value offset sz salt_opt =
+  map_result_state (update_var x v)
+    (exec_create inst s value offset sz salt_opt)
+Proof
+  ext_call_frame_proof [exec_create_def, make_venom_create_state_def]
+QED
+
+val ext_call_frames = [
+  exec_ext_call_frame, exec_delegatecall_frame, exec_create_frame
+];
+
+val all_rwts2 = all_rwts @ ext_call_frames;
+
+(* Per-opcode tactic: helper frames + ext_call frames + custom defs.
+   Uses TRY/NO_TAC safety net to prevent partial application. *)
+(* PHI-specific: resolve_phi result's eval_operand ignores update_var *)
+Theorem resolve_phi_eval_operand_update_var[local]:
+  !prev ops val_op x v s.
+    resolve_phi prev ops = SOME val_op /\
+    ~MEM (Var x) ops ==>
+    eval_operand val_op (update_var x v s) = eval_operand val_op s
+Proof
+  rpt strip_tac >>
+  irule eval_operand_update_var >> rw[] >>
+  CCONTR_TAC >> gvs[] >>
+  imp_res_tac resolve_phi_MEM >> gvs[]
+QED
+
+val base_frame_tac =
+  gvs all_rwts2 >>
+  TRY (gvs(all_rwts2 @ custom_defs) >>
+       rpt (CHANGED_TAC (BasicProvers.TOP_CASE_TAC >>
+                          gvs(all_rwts2 @ custom_defs))));
+
+Theorem step_inst_base_frame:
+  !inst s x v.
+  (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+  ~MEM x inst.inst_outputs ==>
+  step_inst_base inst (update_var x v s) =
+  map_result_state (update_var x v) (step_inst_base inst s)
+Proof
+  rpt strip_tac >>
+  CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [step_inst_base_def])) >>
+  CONV_TAC (RAND_CONV (RAND_CONV (ONCE_REWRITE_CONV [step_inst_base_def]))) >>
+  Cases_on `inst.inst_opcode` >>
+  simp[] >>
+  base_frame_tac >>
+  (* PHI case: resolve_phi result's eval is unchanged by update_var *)
+  imp_res_tac resolve_phi_eval_operand_update_var >>
+  gvs all_rwts2
+QED
+
+(* step_inst_frame: update_var x v commutes through step_inst for non-INVOKE.
+   INVOKE has a different frame property (see step_inst_invoke_frame).
+   Works for all non-INVOKE opcodes including ALLOCA (update_var only touches
+   vs_vars, which step_inst_base doesn't depend on for ALLOCA). *)
+Theorem step_inst_frame:
+  !fuel ctx inst s x v.
+    (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+    ~MEM x inst.inst_outputs /\
+    inst.inst_opcode <> INVOKE ==>
+    step_inst fuel ctx inst (update_var x v s) =
+    map_result_state (update_var x v) (step_inst fuel ctx inst s)
+Proof
+  rpt strip_tac >>
+  gvs[step_inst_non_invoke, step_inst_base_frame]
+QED
+
+(* step_inst_invoke_frame: for INVOKE, update_var threads through OK results.
+   Non-OK results (Halt/Abort) return the callee state unchanged. *)
+Theorem step_inst_invoke_frame:
+  !fuel ctx inst s x v.
+    (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+    ~MEM x inst.inst_outputs /\
+    inst.inst_opcode = INVOKE ==>
+    step_inst fuel ctx inst (update_var x v s) =
+    (case step_inst fuel ctx inst s of
+       OK s' => OK (update_var x v s')
+     | Halt s' => Halt s'
+     | Abort a s' => Abort a s'
+     | IntRet vals s' => IntRet vals s'
+     | Error e => Error e)
+Proof
+  rpt strip_tac >>
+  simp[step_inst_def] >>
+  BasicProvers.TOP_CASE_TAC >> simp[] >>
+  rename1 `decode_invoke inst = SOME p` >>
+  PairCases_on `p` >> simp[] >>
+  `inst.inst_operands = Label p0 :: p1`
+    by (gvs[decode_invoke_def] >>
+        Cases_on `inst.inst_operands` >> gvs[] >>
+        Cases_on `h` >> gvs[]) >>
+  BasicProvers.TOP_CASE_TAC >> simp[] >>
+  `eval_operands p1 (update_var x v s) = eval_operands p1 s`
+    by (irule eval_operands_update_var >> rw[] >> gvs[MEM]) >>
+  simp[] >>
+  BasicProvers.TOP_CASE_TAC >> simp[] >>
+  simp[setup_callee_update_var] >>
+  BasicProvers.TOP_CASE_TAC >> simp[] >>
+  BasicProvers.TOP_CASE_TAC >> simp[] >>
+  simp[merge_callee_update_var, bind_outputs_update_var] >>
+  Cases_on `bind_outputs inst.inst_outputs l (merge_callee_state s v')` >>
+  gvs[]
+QED
+
+
+(* step_inst_ok_frame: unified frame lemma for OK results.
+   Works for all opcodes (including INVOKE and ALLOCA) when step_inst returns OK.
+   update_var only touches vs_vars; step_inst_base_frame handles non-INVOKE
+   (including ALLOCA), step_inst_invoke_frame handles INVOKE. *)
+Theorem step_inst_ok_frame:
+  !fuel ctx inst s s' x v.
+    step_inst fuel ctx inst s = OK s' /\
+    (!y. MEM (Var y) inst.inst_operands ==> x <> y) /\
+    ~MEM x inst.inst_outputs ==>
+    step_inst fuel ctx inst (update_var x v s) = OK (update_var x v s')
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_opcode = INVOKE`
+  >- (imp_res_tac step_inst_invoke_frame >> gvs[])
+  >- (gvs[step_inst_non_invoke, step_inst_base_frame, map_result_state_def])
+QED

--- a/venom/passes/dft/proofs/dftCompletenessScript.sml
+++ b/venom/passes/dft/proofs/dftCompletenessScript.sml
@@ -1,0 +1,770 @@
+(*
+ * DFT DFS Completeness
+ *
+ * Key result:
+ *   schedule_output_complete — all non-pseudo ids are in schedule output
+ *
+ * Strategy: measure = stack_size + unvisited * (n+1) strictly decreases
+ *   at each non-idle step. After budget = (n+1)^2 steps, measure = 0,
+ *   meaning stack empty + all non-pseudos visited. Combined with
+ *   dfs_topo_inv (visited + not pending -> in output), completeness follows.
+ *)
+
+Theory dftCompleteness
+Ancestors
+  dftTopoSort dftScheduleFixed dftStructural dftDefs
+  venomInst
+  list rich_list sorting
+  finite_map pred_set pair arithmetic
+  combin option
+Libs
+  BasicProvers markerLib
+
+(* ===== ds_visited only grows ===== *)
+
+Triviality dfs_step_visited_mono:
+  !bi order eda om fl state id.
+    MEM id state.ds_visited ==>
+    MEM id (dfs_step bi order eda om fl state).ds_visited
+Proof
+  rpt strip_tac >>
+  simp[dfs_step_def] >>
+  EVERY_CASE_TAC >> gvs[LET_THM]
+QED
+
+Triviality funpow_visited_mono:
+  !n bi order eda om fl state id.
+    MEM id state.ds_visited ==>
+    MEM id (FUNPOW (dfs_step bi order eda om fl) n state).ds_visited
+Proof
+  Induct >> simp[FUNPOW] >> rpt strip_tac >>
+  first_x_assum irule >> irule dfs_step_visited_mono >> simp[]
+QED
+
+(* ===== dfs_step visits the top DfsProcess ===== *)
+
+Triviality dfs_step_visits_top_process:
+  !bi order eda om fl state inst rest.
+    state.ds_stack = DfsProcess inst :: rest ==>
+    MEM inst.inst_id (dfs_step bi order eda om fl state).ds_visited
+Proof
+  rpt strip_tac >>
+  simp[dfs_step_def] >>
+  Cases_on `MEM inst.inst_id state.ds_visited` >> simp[] >>
+  Cases_on `is_pseudo inst.inst_opcode` >> simp[] >>
+  simp[LET_THM]
+QED
+
+(* ===== When visiting a non-pseudo, children are pushed ===== *)
+
+Triviality dfs_step_pushes_children:
+  !bi order eda om fl state inst rest.
+    state.ds_stack = DfsProcess inst :: rest /\
+    ~MEM inst.inst_id state.ds_visited /\
+    ~is_pseudo inst.inst_opcode ==>
+    !dep. MEM dep (inst_all_deps bi order eda inst) ==>
+          MEM (DfsProcess dep)
+            (dfs_step bi order eda om fl state).ds_stack
+Proof
+  rpt strip_tac >>
+  simp[dfs_step_def, LET_THM, MEM_APPEND, MEM_MAP] >>
+  disj1_tac >> metis_tac[sort_children_mem]
+QED
+
+(* ===== Count of unvisited non-pseudos ===== *)
+
+Definition unvisited_count_def:
+  unvisited_count bi visited =
+    LENGTH (FILTER (\i. ~is_pseudo i.inst_opcode /\
+                        ~MEM i.inst_id visited) bi)
+End
+
+Triviality unvisited_count_le:
+  !bi visited. unvisited_count bi visited <= LENGTH bi
+Proof
+  rw[unvisited_count_def] >> irule LENGTH_FILTER_LEQ
+QED
+
+(* Monotonicity: more visited => smaller or equal count *)
+Triviality unvisited_count_mono:
+  !bi v1 v2.
+    (!x. MEM x v1 ==> MEM x v2) ==>
+    unvisited_count bi v2 <= unvisited_count bi v1
+Proof
+  rw[unvisited_count_def] >>
+  irule LENGTH_FILTER_LEQ_MONO >>
+  simp[] >> metis_tac[]
+QED
+
+(* Adding an already-visited id doesn't change count *)
+Triviality unvisited_add_visited:
+  !bi visited id.
+    MEM id visited ==>
+    unvisited_count bi (id :: visited) = unvisited_count bi visited
+Proof
+  rw[unvisited_count_def] >>
+  AP_TERM_TAC >>
+  simp[FILTER_EQ] >> metis_tac[]
+QED
+
+(* Adding a new non-pseudo id decreases count by exactly 1.
+   Why: ALL_DISTINCT ids means inst is the unique element with that id,
+   so FILTER removes exactly one element. *)
+(* General list lemma: removing one unique-keyed element from FILTER
+   decreases length by exactly 1 *)
+Triviality filter_remove_unique_key:
+  !P f l x.
+    ALL_DISTINCT (MAP f l) /\ MEM x l /\ P x ==>
+    LENGTH (FILTER (\y. P y /\ f y <> f x) l) + 1 =
+    LENGTH (FILTER P l)
+Proof
+  Induct_on `l` >> simp[] >> rpt gen_tac >> strip_tac >>
+  gvs[ALL_DISTINCT_MAP]
+  (* x is the head *)
+  >- (simp[] >>
+      `FILTER (\y. P y /\ f y <> f h) l = FILTER P l` suffices_by simp[] >>
+      simp[FILTER_EQ] >> rpt strip_tac >>
+      gvs[MEM_MAP] >> metis_tac[])
+  (* x is in tail *)
+  >> `f h <> f x` by (gvs[MEM_MAP] >> metis_tac[]) >>
+  Cases_on `P h` >> simp[] >>
+  first_x_assum (qspecl_then [`P`, `f`, `x`] mp_tac) >> simp[]
+QED
+
+Triviality unvisited_add_new:
+  !bi visited inst.
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+    ~MEM inst.inst_id visited /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    unvisited_count bi (inst.inst_id :: visited) + 1 =
+    unvisited_count bi visited
+Proof
+  Induct_on `bi` >> simp[unvisited_count_def] >>
+  rpt gen_tac >> strip_tac >> gvs[ALL_DISTINCT_MAP]
+  (* inst is head *)
+  >- (simp[] >>
+      `FILTER (\i. ~is_pseudo i.inst_opcode /\ i.inst_id <> h.inst_id /\
+                   ~MEM i.inst_id visited) bi =
+       FILTER (\i. ~is_pseudo i.inst_opcode /\ ~MEM i.inst_id visited) bi` by
+        (simp[FILTER_EQ] >> rpt strip_tac >> gvs[MEM_MAP] >> metis_tac[]) >>
+      simp[])
+  (* inst is in tail *)
+  >> `h.inst_id <> inst.inst_id` by (gvs[MEM_MAP] >> metis_tac[]) >>
+  `unvisited_count bi (inst.inst_id :: visited) + 1 =
+   unvisited_count bi visited` by
+    (first_x_assum irule >> simp[]) >>
+  qpat_x_assum `unvisited_count _ _ + 1 = _`
+    (mp_tac o PURE_REWRITE_RULE[unvisited_count_def]) >>
+  simp[unvisited_count_def] >> IF_CASES_TAC >> simp[]
+QED
+
+(* ===== sort_children preserves length ===== *)
+
+Triviality sort_children_length:
+  !bi order eda om parent children.
+    LENGTH (sort_children bi order eda om parent children) = LENGTH children
+Proof
+  rw[sort_children_def] >>
+  `PERM (MAPi (\i c. (i,c)) children)
+        (QSORT _ (MAPi (\i c. (i,c)) children))` by
+    simp[sortingTheory.QSORT_PERM] >>
+  imp_res_tac sortingTheory.PERM_LENGTH >>
+  simp[LENGTH_MAP, indexedListsTheory.LENGTH_MAPi]
+QED
+
+(* ===== deps count bounded by block length ===== *)
+
+(* Pigeonhole: ALL_DISTINCT list whose elements are all MEM of another list
+   has length <= that list *)
+Triviality all_distinct_subset_length:
+  !l1 l2. ALL_DISTINCT l1 /\ (!x. MEM x l1 ==> MEM x l2) ==>
+           LENGTH l1 <= LENGTH l2
+Proof
+  rpt strip_tac >>
+  `CARD (set l1) = LENGTH l1` by simp[ALL_DISTINCT_CARD_LIST_TO_SET] >>
+  `CARD (set l2) <= LENGTH l2` by simp[CARD_LIST_TO_SET] >>
+  `set l1 SUBSET set l2` by simp[SUBSET_DEF] >>
+  `FINITE (set l2)` by simp[] >>
+  `CARD (set l1) <= CARD (set l2)` by metis_tac[CARD_SUBSET] >>
+  simp[]
+QED
+
+Triviality inst_all_deps_length_bound:
+  !bi order eda inst.
+    eda_wf eda bi ==>
+    LENGTH (inst_all_deps bi order eda inst) <= LENGTH bi
+Proof
+  rpt strip_tac >>
+  irule all_distinct_subset_length >> conj_tac
+  >- (rpt strip_tac >> metis_tac[inst_all_deps_mem])
+  >> simp[inst_all_deps_def, LET_THM, all_distinct_nub]
+QED
+
+(* ===== DFS measure ===== *)
+
+Definition dfs_measure_def:
+  dfs_measure bi state =
+    LENGTH state.ds_stack +
+    unvisited_count bi state.ds_visited * (LENGTH bi + 1)
+End
+
+(* ===== dfs_step strictly decreases measure when stack non-empty ===== *)
+
+Theorem dfs_step_measure_dec:
+  !bi order eda om fl state.
+    state.ds_stack <> [] /\
+    eda_wf eda bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    dfs_good_state bi state ==>
+    dfs_measure bi (dfs_step bi order eda om fl state) <
+    dfs_measure bi state
+Proof
+  rpt strip_tac >>
+  Cases_on `state.ds_stack` >> gvs[] >>
+  Cases_on `h` >> rename1 `_ :: t`
+  (* DfsProcess *)
+  >- (rename1 `DfsProcess inst` >>
+      Cases_on `MEM inst.inst_id state.ds_visited`
+      >- simp[dfs_step_def, dfs_measure_def]
+      >> Cases_on `is_pseudo inst.inst_opcode`
+      >- suspend "pseudo"
+      >> suspend "non_pseudo")
+  (* DfsEmit *)
+  >> suspend "emit"
+QED
+
+Resume dfs_step_measure_dec[pseudo]:
+  simp[dfs_step_def, dfs_measure_def] >>
+  `unvisited_count bi (inst.inst_id :: state.ds_visited) <=
+   unvisited_count bi state.ds_visited` by
+    (irule unvisited_count_mono >> simp[]) >>
+  `(LENGTH bi + 1) * unvisited_count bi (inst.inst_id::state.ds_visited) <=
+   (LENGTH bi + 1) * unvisited_count bi state.ds_visited` by simp[] >>
+  decide_tac
+QED
+
+Resume dfs_step_measure_dec[non_pseudo]:
+  simp[dfs_step_def, LET_THM, dfs_measure_def] >>
+  `MEM inst bi` by gvs[dfs_good_state_def, EVERY_DEF] >>
+  `LENGTH (sort_children bi order eda om inst
+             (inst_all_deps bi order eda inst)) =
+   LENGTH (inst_all_deps bi order eda inst)` by
+    simp[sort_children_length] >>
+  `LENGTH (inst_all_deps bi order eda inst) <= LENGTH bi` by
+    (irule inst_all_deps_length_bound >> simp[]) >>
+  `unvisited_count bi (inst.inst_id :: state.ds_visited) + 1 =
+   unvisited_count bi state.ds_visited` by
+    (irule unvisited_add_new >> simp[]) >>
+  (* Substitute count = c'+1, then linearize multiplication *)
+  pop_assum (SUBST1_TAC o SYM) >>
+  simp[LEFT_ADD_DISTRIB]
+QED
+
+Resume dfs_step_measure_dec[emit]:
+  simp[dfs_step_def, dfs_measure_def]
+QED
+
+Finalise dfs_step_measure_dec
+
+(* ===== Measure reaches 0 after enough steps ===== *)
+
+(* General measure lemma: if each non-idle step with non-empty stack
+   strictly decreases the measure, and idle steps only happen at measure 0,
+   then after enough steps measure = 0.
+
+   We split into: step decreases when stack non-empty, and
+   stack empty => measure = 0 (maintained as invariant). *)
+Triviality funpow_idle:
+  !n (f:'a -> 'a) s. f s = s ==> FUNPOW f n s = s
+Proof
+  Induct >> simp[FUNPOW]
+QED
+
+(* Measure 0 means stack empty and all non-pseudos visited *)
+Triviality measure_zero_imp_visited:
+  !bi state inst.
+    dfs_measure bi state = 0 /\
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode ==>
+    MEM inst.inst_id state.ds_visited
+Proof
+  rw[dfs_measure_def] >>
+  gvs[unvisited_count_def] >>
+  `FILTER (\i. ~is_pseudo i.inst_opcode /\ ~MEM i.inst_id state.ds_visited) bi
+   = []` by (Cases_on `FILTER _ bi` >> gvs[]) >>
+  gvs[FILTER_EQ_NIL, EVERY_MEM] >>
+  first_x_assum (qspec_then `inst` mp_tac) >> simp[]
+QED
+
+Triviality measure_zero_imp_stack_empty:
+  !bi state.
+    dfs_measure bi state = 0 ==> state.ds_stack = []
+Proof
+  rw[dfs_measure_def] >> Cases_on `state.ds_stack` >> gvs[]
+QED
+
+(* General abstract lemma: if f either decreases the measure or is idle,
+   and idle ⟹ measure=0, then after n ≥ measure(s) steps, measure=0.
+   Proof by complete induction on n. *)
+Triviality measure_decreases_to_zero:
+  !n (f:'a -> 'a) (m:'a -> num) s.
+    (!x. m x > 0 ==> m (f x) < m x) /\
+    (!x. m (f x) >= m x ==> f x = x) /\
+    m s <= n ==>
+    m (FUNPOW f n s) = 0
+Proof
+  completeInduct_on `n` >> rpt strip_tac >>
+  Cases_on `n`
+  >- (gvs[] >> Cases_on `m s` >> gvs[])
+  >> rename1 `SUC k` >>
+  Cases_on `m s = 0`
+  >- (`f s = s` by (first_x_assum (qspec_then `s` mp_tac) >> simp[]) >>
+      `FUNPOW f (SUC k) s = s` by (irule funpow_idle >> simp[]) >>
+      simp[])
+  >> `m (f s) < m s` by (first_x_assum match_mp_tac >> simp[]) >>
+  simp[FUNPOW]
+QED
+
+(* Key helper: non-entry non-pseudos are deps of something.
+   This is the contrapositive of entry_instructions_def:
+   if inst is non-pseudo and NOT in entry_instructions,
+   then inst.inst_id appears as a dep of some other non-pseudo. *)
+Triviality all_distinct_map_inj:
+  !f l x y. ALL_DISTINCT (MAP f l) /\ MEM x l /\ MEM y l /\ f x = f y ==>
+             x = y
+Proof
+  rpt strip_tac >> gvs[MEM_EL] >>
+  `EL n (MAP f l) = EL n' (MAP f l)` by simp[EL_MAP] >>
+  metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP]
+QED
+
+Triviality non_entry_is_dep:
+  !bi order eda inst.
+    eda_wf eda bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+    ~MEM inst (entry_instructions bi order eda) ==>
+    ?parent. MEM parent bi /\ ~is_pseudo parent.inst_opcode /\
+             MEM inst (inst_all_deps bi order eda parent)
+Proof
+  rpt strip_tac >>
+  gvs[entry_instructions_def, LET_THM, MEM_FILTER] >>
+  gvs[MEM_FLAT, MEM_MAP, MEM_nub, MEM_FILTER] >>
+  qexists `i` >> simp[] >>
+  `MEM d bi` by metis_tac[inst_all_deps_mem] >>
+  metis_tac[all_distinct_map_inj]
+QED
+
+(* ===== Coverage invariant ===== *)
+
+(* Every unvisited non-pseudo is either directly on the stack as DfsProcess,
+   or is a dep of some unvisited non-pseudo (which will eventually be visited,
+   pushing the dep onto the stack). *)
+Definition dfs_coverage_def:
+  dfs_coverage bi order eda state <=>
+    !inst. MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+           ~MEM inst.inst_id state.ds_visited ==>
+      MEM (DfsProcess inst) state.ds_stack \/
+      ?parent. MEM parent bi /\ ~is_pseudo parent.inst_opcode /\
+               MEM inst (inst_all_deps bi order eda parent) /\
+               ~MEM parent.inst_id state.ds_visited
+End
+
+(* Coverage + stack empty => all non-pseudos visited.
+   Proof: by contradiction using eda_topo_compatible to get infinite
+   ascending index chain, contradicting finiteness. *)
+(* No unvisited non-pseudo at index k when coverage holds and stack is empty.
+   Proof by strong induction on LENGTH bi - k: coverage gives unvisited parent
+   at later index j > k; IH at j gives contradiction. *)
+Triviality no_unvisited_at_index:
+  !bi order eda visited k.
+    eda_topo_compatible bi eda order /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    (!inst. MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+            ~MEM inst.inst_id visited ==>
+       ?parent. MEM parent bi /\ ~is_pseudo parent.inst_opcode /\
+                MEM inst (inst_all_deps bi order eda parent) /\
+                ~MEM parent.inst_id visited) /\
+    k < LENGTH bi /\
+    ~is_pseudo (EL k bi).inst_opcode ==>
+    MEM (EL k bi).inst_id visited
+Proof
+  rpt gen_tac >> strip_tac >>
+  pop_assum mp_tac >> pop_assum mp_tac >>
+  qid_spec_tac `k` >>
+  completeInduct_on `LENGTH bi - k` >> rpt strip_tac >>
+  spose_not_then assume_tac >>
+  (* By coverage: EL k bi has unvisited non-pseudo parent *)
+  last_assum (qspec_then `EL k bi` mp_tac) >>
+  (impl_tac >- simp[EL_MEM]) >>
+  disch_then strip_assume_tac >>
+  (* eda_topo_compatible: parent at later index than dep *)
+  `?i j. i < j /\ j < LENGTH bi /\ i < LENGTH bi /\
+         EL i bi = EL k bi /\ EL j bi = parent` by
+    (fs[eda_topo_compatible_def] >>
+     first_x_assum (qspecl_then [`parent`, `EL k bi`] mp_tac) >>
+     simp[EL_MEM]) >>
+  `i = k` by
+    (`EL i (MAP (\i. i.inst_id) bi) = EL k (MAP (\i. i.inst_id) bi)` by
+       simp[EL_MAP] >>
+     metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP]) >>
+  gvs[]
+QED
+
+(* Coverage + empty stack => all non-pseudos visited. *)
+Triviality coverage_stack_empty_imp_visited:
+  !bi order eda state.
+    eda_topo_compatible bi eda order /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    dfs_coverage bi order eda state /\
+    state.ds_stack = [] ==>
+    unvisited_count bi state.ds_visited = 0
+Proof
+  rpt strip_tac >> simp[unvisited_count_def] >>
+  simp[FILTER_EQ_NIL, EVERY_MEM] >> rpt strip_tac >>
+  spose_not_then assume_tac >>
+  (* Get index for the unvisited element *)
+  `?k. k < LENGTH bi /\ EL k bi = i` by metis_tac[MEM_EL] >>
+  (* coverage + stack=[] gives parent clause *)
+  `!inst. MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+          ~MEM inst.inst_id state.ds_visited ==>
+     ?parent. MEM parent bi /\ ~is_pseudo parent.inst_opcode /\
+              MEM inst (inst_all_deps bi order eda parent) /\
+              ~MEM parent.inst_id state.ds_visited` by
+    (gvs[dfs_coverage_def] >> rpt strip_tac >>
+     first_x_assum drule_all >> strip_tac >> gvs[]) >>
+  qspecl_then [`bi`, `order`, `eda`, `state.ds_visited`, `k`]
+    mp_tac no_unvisited_at_index >> gvs[]
+QED
+
+(* Coverage preserved by dfs_step *)
+(* Helper: use coverage assumption for a specific inst *)
+Triviality use_coverage:
+  !bi order eda state inst.
+    dfs_coverage bi order eda state /\
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+    ~MEM inst.inst_id state.ds_visited ==>
+    MEM (DfsProcess inst) state.ds_stack \/
+    ?parent. MEM parent bi /\ ~is_pseudo parent.inst_opcode /\
+             MEM inst (inst_all_deps bi order eda parent) /\
+             ~MEM parent.inst_id state.ds_visited
+Proof
+  simp[dfs_coverage_def]
+QED
+
+Triviality good_state_process_mem:
+  !bi state top rest.
+    dfs_good_state bi state /\
+    state.ds_stack = DfsProcess top :: rest ==>
+    MEM top bi
+Proof
+  rpt strip_tac >> gvs[dfs_good_state_def]
+QED
+
+Theorem dfs_step_preserves_coverage:
+  !bi order eda om fl state.
+    eda_wf eda bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    dfs_good_state bi state /\
+    dfs_coverage bi order eda state ==>
+    dfs_coverage bi order eda (dfs_step bi order eda om fl state)
+Proof
+  rpt strip_tac >>
+  CONV_TAC (PURE_REWRITE_CONV [dfs_coverage_def]) >>
+  rpt gen_tac >> strip_tac >>
+  `~MEM inst.inst_id state.ds_visited` by
+    (strip_tac >> imp_res_tac dfs_step_visited_mono >> gvs[]) >>
+  drule_all use_coverage >>
+  disch_then assume_tac >>
+  Cases_on `state.ds_stack`
+  >- suspend "empty_stack"
+  >> Cases_on `h`
+  >- (rename1 `DfsProcess top :: rest` >>
+      Cases_on `MEM top.inst_id state.ds_visited`
+      >- suspend "process_visited"
+      >> Cases_on `is_pseudo top.inst_opcode`
+      >- suspend "process_pseudo"
+      >> suspend "process_nonpseudo")
+  >> suspend "emit"
+QED
+
+(* --- empty_stack: dfs_step = identity --- *)
+Resume dfs_step_preserves_coverage[empty_stack]:
+  simp[dfs_step_def] >> gvs[] >> metis_tac[]
+QED
+
+(* --- process_visited: top already visited, pop, visited unchanged --- *)
+Resume dfs_step_preserves_coverage[process_visited]:
+  simp[dfs_step_def] >>
+  qpat_x_assum `_ \/ _` mp_tac >> strip_tac
+  >- (gvs[MEM] >> disj1_tac >> simp[])
+  >> disj2_tac >> metis_tac[]
+QED
+
+(* --- process_pseudo: top is pseudo, pop, mark visited --- *)
+Resume dfs_step_preserves_coverage[process_pseudo]:
+  simp[dfs_step_def] >>
+  qpat_x_assum `_ \/ _` mp_tac >> strip_tac
+  (* on-stack: inst ∈ DfsProcess top :: rest *)
+  >- (gvs[MEM] (* splits inst=top | inst∈rest; inst=top gives F *) >>
+      disj1_tac >> simp[])
+  (* has-parent: parent.inst_id ≠ top.inst_id by pseudo/non-pseudo *)
+  >> disj2_tac >> qexists `parent` >> simp[] >>
+  `MEM top bi` by metis_tac[good_state_process_mem] >>
+  strip_tac >>
+  `parent = top` by metis_tac[all_distinct_map_inj] >>
+  gvs[]
+QED
+
+(* --- process_nonpseudo: top is non-pseudo, push children, mark visited --- *)
+Resume dfs_step_preserves_coverage[process_nonpseudo]:
+  `MEM top bi` by
+    (qpat_x_assum `dfs_good_state _ _` mp_tac >>
+     qpat_x_assum `state.ds_stack = _` mp_tac >>
+     metis_tac[good_state_process_mem]) >>
+  simp[dfs_step_def, LET_THM] >>
+  qpat_x_assum `_ \/ _` mp_tac >> strip_tac
+  (* on-stack: inst ∈ DfsProcess top :: rest *)
+  >- (gvs[MEM]
+      (* inst = top: top.inst_id is visited by dfs_step, contradiction *)
+      >- metis_tac[dfs_step_visits_top_process]
+      (* inst ∈ rest: still on stack *)
+      >> disj1_tac >> simp[])
+  (* has parent *)
+  >> Cases_on `parent.inst_id = top.inst_id`
+  (* parent = top: inst pushed as child *)
+  >- (`parent = top` by metis_tac[all_distinct_map_inj] >>
+      gvs[] >> disj1_tac >>
+      simp[MEM_MAP] >>
+      metis_tac[sort_children_mem])
+  (* parent ≠ top: parent still unvisited *)
+  >> disj2_tac >> qexists `parent` >> simp[]
+QED
+
+(* --- emit: DfsEmit, pop, visited unchanged --- *)
+Resume dfs_step_preserves_coverage[emit]:
+  rename1 `DfsEmit top :: rest` >>
+  simp[dfs_step_def] >>
+  qpat_x_assum `_ \/ _` mp_tac >> strip_tac
+  >- (gvs[MEM] >> disj1_tac >> simp[])
+  >> disj2_tac >> metis_tac[]
+QED
+
+Finalise dfs_step_preserves_coverage
+
+(* Coverage holds for initial entry_instructions state *)
+Triviality entry_instructions_coverage:
+  !bi order eda.
+    eda_wf eda bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    dfs_coverage bi order eda
+      <| ds_stack := MAP DfsProcess (entry_instructions bi order eda);
+         ds_output := []; ds_visited := [] |>
+Proof
+  simp[dfs_coverage_def] >> rpt strip_tac >>
+  Cases_on `MEM inst (entry_instructions bi order eda)`
+  >- (disj1_tac >> simp[MEM_MAP] >> qexists `inst` >> simp[])
+  >> disj2_tac >>
+  drule_all non_entry_is_dep >> strip_tac >>
+  qexists `parent` >> simp[]
+QED
+
+(* DFS-specific: measure reaches 0 using coverage invariant.
+   Coverage + stack=[] => unvisited=0, so measure=0 when idle.
+   Combined with dfs_step_measure_dec, measure strictly decreases
+   at each non-idle step. *)
+Theorem measure_reaches_zero:
+  !n bi order eda om fl state.
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    dfs_good_state bi state /\
+    dfs_coverage bi order eda state /\
+    dfs_measure bi state <= n ==>
+    dfs_measure bi
+      (FUNPOW (dfs_step bi order eda om fl) n state) = 0
+Proof
+  Induct_on `n` >> rpt strip_tac
+  >- gvs[dfs_measure_def]
+  >> Cases_on `dfs_measure bi state = 0`
+  >- (`state.ds_stack = []` by metis_tac[measure_zero_imp_stack_empty] >>
+      simp[funpow_dfs_step_idle])
+  >> `state.ds_stack <> []` by
+       (CCONTR_TAC >>
+        `unvisited_count bi state.ds_visited = 0` by
+          metis_tac[coverage_stack_empty_imp_visited] >>
+        gvs[dfs_measure_def]) >>
+  `dfs_measure bi (dfs_step bi order eda om fl state) <
+   dfs_measure bi state` by
+    (irule dfs_step_measure_dec >> simp[]) >>
+  simp[FUNPOW] >>
+  first_x_assum (qspecl_then [`bi`, `order`, `eda`, `om`, `fl`,
+    `dfs_step bi order eda om fl state`] mp_tac) >>
+  impl_tac
+  >- (simp[] >> rpt conj_tac
+      >- (irule dfs_step_preserves_good >> simp[])
+      >- (irule dfs_step_preserves_coverage >> simp[])
+      >> decide_tac)
+  >> simp[]
+QED
+
+(* ===== entries are a subset of non-pseudos of bi ===== *)
+
+Triviality entry_instructions_length:
+  !bi order eda.
+    LENGTH (entry_instructions bi order eda) <= LENGTH bi
+Proof
+  rw[entry_instructions_def, LET_THM] >>
+  irule LESS_EQ_TRANS >>
+  qexists `LENGTH (FILTER (\i. ~is_pseudo i.inst_opcode) bi)` >>
+  simp[LENGTH_FILTER_LEQ]
+QED
+
+(* ===== Main completeness: all non-pseudos visited after budget ===== *)
+
+Theorem schedule_all_visited:
+  !bi order eda offspring_map.
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    let entries = entry_instructions bi order eda in
+    let final = FUNPOW (dfs_step bi order eda offspring_map T)
+                       ((LENGTH bi + 1) * (LENGTH bi + 1))
+                       <| ds_stack := MAP DfsProcess entries;
+                          ds_output := []; ds_visited := [] |> in
+    (!inst. MEM inst bi /\ ~is_pseudo inst.inst_opcode ==>
+            MEM inst.inst_id final.ds_visited) /\
+    final.ds_stack = []
+Proof
+  rpt strip_tac >> simp[LET_THM] >>
+  qabbrev_tac `entries = entry_instructions bi order eda` >>
+  qabbrev_tac `init = <| ds_stack := MAP DfsProcess entries;
+                          ds_output := []; ds_visited := [] |>` >>
+  qmatch_goalsub_abbrev_tac `FUNPOW f budget init` >>
+  (* Show measure reaches 0 *)
+  `dfs_measure bi (FUNPOW f budget init) = 0` by
+    suspend "measure_zero" >>
+  conj_tac
+  >- (rpt strip_tac >> drule_all measure_zero_imp_visited >> simp[])
+  >> metis_tac[measure_zero_imp_stack_empty]
+QED
+
+Resume schedule_all_visited[measure_zero]:
+  simp[Abbr `f`] >>
+  qspecl_then [`budget`, `bi`, `order`, `eda`, `offspring_map`, `T`,
+               `init`] mp_tac measure_reaches_zero >>
+  simp[Abbr `budget`, Abbr `init`, Abbr `entries`] >>
+  impl_tac
+  >- (rpt conj_tac
+      >- (irule init_dfs_state_good >> simp[entry_instructions_mem])
+      >- (irule entry_instructions_coverage >> simp[])
+      >> simp[dfs_measure_def, LENGTH_MAP, unvisited_count_def, MEM] >>
+      `LENGTH (entry_instructions bi order eda) <= LENGTH bi` by
+        simp[entry_instructions_length] >>
+      `LENGTH (FILTER (\i. ~is_pseudo i.inst_opcode) bi) <= LENGTH bi` by
+        simp[LENGTH_FILTER_LEQ] >>
+      irule LESS_EQ_TRANS >>
+      qexists `LENGTH bi + LENGTH bi * (LENGTH bi + 1)` >>
+      conj_tac
+      >- (irule LESS_EQ_LESS_EQ_MONO >>
+          conj_tac >- simp[] >>
+          irule LESS_MONO_MULT >> simp[])
+      >> rewrite_tac[EXP_2] >>
+      simp[LEFT_ADD_DISTRIB, RIGHT_ADD_DISTRIB])
+  >> simp[]
+QED
+
+Finalise schedule_all_visited
+
+(* ===== FUNPOW preserves dfs_topo_inv ===== *)
+
+Triviality funpow_preserves_topo_inv:
+  !n bi order eda om fl state.
+    dfs_topo_inv bi order eda state /\
+    dfs_good_state bi state /\
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    np_defs_before_uses bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    dfs_topo_inv bi order eda
+      (FUNPOW (dfs_step bi order eda om fl) n state)
+Proof
+  Induct >> simp[FUNPOW] >> rpt strip_tac >>
+  first_x_assum irule >> simp[] >> conj_tac
+  >- (irule dfs_step_preserves_good >> simp[])
+  >> irule dfs_step_preserves_topo >> simp[]
+QED
+
+(* ===== Combining: all non-pseudo ids in schedule output ===== *)
+
+Theorem schedule_output_complete:
+  !bi order eda offspring_map.
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    np_defs_before_uses bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    !inst. MEM inst bi /\ ~is_pseudo inst.inst_opcode ==>
+           MEM inst.inst_id
+             (MAP (\i. i.inst_id)
+                (schedule_from_entries bi order eda offspring_map
+                   (entry_instructions bi order eda)))
+Proof
+  rpt strip_tac >>
+  simp[schedule_from_entries_def, LET_THM] >>
+  qabbrev_tac `entries = entry_instructions bi order eda` >>
+  qabbrev_tac `budget = (LENGTH bi + 1) * (LENGTH bi + 1)` >>
+  qabbrev_tac `init = <| ds_stack := MAP DfsProcess entries;
+                          ds_output := []; ds_visited := [] |>` >>
+  qabbrev_tac `final = FUNPOW (dfs_step bi order eda offspring_map T)
+                               budget init` >>
+  (* All non-pseudos visited and stack empty *)
+  `MEM inst.inst_id final.ds_visited /\ final.ds_stack = []` by
+    (simp[Abbr `final`, Abbr `init`, Abbr `budget`] >>
+     drule_all schedule_all_visited >>
+     simp[LET_THM]) >>
+  (* dfs_topo_inv holds at final state *)
+  `dfs_topo_inv bi order eda final` by
+    suspend "topo_inv" >>
+  (* dfs_topo_inv: visited /\ ~pending => in output. Stack empty => not pending. *)
+  `stack_emit_ids final.ds_stack = []` by simp[stack_emit_ids_def] >>
+  gvs[dfs_topo_inv_def] >>
+  first_x_assum irule >> simp[]
+QED
+
+Triviality stack_emit_ids_map_process:
+  !l. stack_emit_ids (MAP DfsProcess l) = []
+Proof
+  Induct >> simp[stack_emit_ids_def]
+QED
+
+Triviality stack_well_ordered_map_process:
+  !l resolved bi order eda.
+    stack_well_ordered (MAP DfsProcess l) resolved bi order eda
+Proof
+  Induct >> simp[stack_well_ordered_def, stack_emit_ids_map_process]
+QED
+
+Triviality stack_pos_ordered_map_process:
+  !l bi. stack_pos_ordered bi (MAP DfsProcess l)
+Proof
+  Induct >> simp[stack_pos_ordered_def, stack_emit_ids_map_process]
+QED
+
+Resume schedule_output_complete[topo_inv]:
+  simp[Abbr `final`, Abbr `budget`] >>
+  irule funpow_preserves_topo_inv >> simp[Abbr `init`] >>
+  conj_tac
+  >- (irule init_dfs_state_good >>
+      simp[Abbr `entries`, entry_instructions_mem])
+  >> simp[dfs_topo_inv_def, output_producer_before_def, output_eda_before_def,
+          stack_well_ordered_map_process, stack_pos_ordered_map_process,
+          stack_emit_ids_map_process]
+QED
+
+Finalise schedule_output_complete
+

--- a/venom/passes/dft/proofs/dftCorrectnessScript.sml
+++ b/venom/passes/dft/proofs/dftCorrectnessScript.sml
@@ -1,157 +1,7086 @@
 (*
  * DFT Pass — Correctness
  *
- * Instruction reordering preserves semantics when the reordered
- * sequence respects all data and effect dependencies.
- *
- * Key properties:
- *   1. Data deps preserved: operand producers appear earlier
- *   2. Effect deps preserved: RAW/WAR/WAW ordering maintained
- *   3. Independent instructions commute
- *
  * TOP-LEVEL:
- *   independent_commute          — independent instructions commute
- *   dft_block_simulates          — block-level simulation
- *   dft_pass_correct             — pass correctness
+ *   dft_pass_correct — DFT preserves execution semantics (pass_correct)
+ *
+ * Proof strategy:
+ *   1. dft_fn only changes bb_instructions of each block (labels preserved)
+ *   2. For each block, run_block on dft_block produces lift_result-compatible
+ *      results: OK states are identical (run_insts_perm_ok), Abort/Halt have
+ *      same constructor and abort type (state is T, irrelevant in EVM).
+ *   3. run_function lift_result follows by induction on fuel
+ *   4. pass_correct follows from lift_result bridge
+ *
+ * R_term = execution_equiv {} for Halt/IntRet (states identical).
+ * R_abort = revert_equiv for Abort (only returndata survives EVM rollback).
+ * DFT can reorder independent instructions past aborters, so variable
+ * state at abort points may differ — but that state gets rolled back.
  *)
 
 Theory dftCorrectness
 Ancestors
-  dftDefs passSimulationDefs passSimulationProofs
-  stateEquiv stateEquivProofs venomExecSemantics venomExecProps venomEffects
-  execEquivParamProofs
+  dftTopoSort dftWf dftDefs stateEquiv stateEquivProps passSimulationDefs
+  venomExecSemantics venomWf venomState finite_map venomInst
+  analysisSimDefs analysisSimProofsBase dftPermSim dftCompleteness dftPipelineInvar
+  dftStructural dftIdempotent venomEffects sorting
+  list rich_list combin arithmetic
+  venomExecProps passSimulationProofs crossBlockSimProps
+  dftBlockSim passSharedProps venomInstProps
+  passSharedFrame passSharedDefs relation
+  allocaRemapSSA
+  pred_set pair
 Libs
-  venomExecSemanticsTheory
+  wordsLib BasicProvers dep_rewrite
 
-(* ===== Valid topological ordering ===== *)
+(* ===== Structural: dft_block preserves bb_label ===== *)
 
-Definition valid_topo_order_def:
-  valid_topo_order block_insts order eda reordered <=>
-    PERM reordered (FILTER (\i. ~is_pseudo i.inst_opcode) block_insts) /\
-    !i j.
-      i < j /\ j < LENGTH reordered ==>
-      ~MEM (EL j reordered)
-           (inst_all_deps block_insts order eda (EL i reordered))
-End
-
-(* ===== Independent instructions commute ===== *)
-
-Definition independent_insts_def:
-  independent_insts block_insts order eda inst1 inst2 <=>
-    ~MEM inst1 (inst_all_deps block_insts order eda inst2) /\
-    ~MEM inst2 (inst_all_deps block_insts order eda inst1)
-End
-
-Theorem independent_commute:
-  !fuel ctx inst1 inst2 s.
-    (* No data dependency: operands don't use each other's outputs *)
-    DISJOINT (set inst1.inst_outputs)
-             (set (MAP (\op. case op of Var v => v | _ => "")
-                       inst2.inst_operands)) /\
-    DISJOINT (set inst2.inst_outputs)
-             (set (MAP (\op. case op of Var v => v | _ => "")
-                       inst1.inst_operands)) /\
-    (* No output aliasing *)
-    DISJOINT (set inst1.inst_outputs) (set inst2.inst_outputs) /\
-    (* No effect conflict: read/write effects don't interfere *)
-    effects_independent inst1.inst_opcode inst2.inst_opcode /\
-    (* ALLOCA modifies vs_allocas (untracked by effects system) which
-       INVOKE reads via setup_callee — exclude from commutativity *)
-    ~is_alloca_op inst1.inst_opcode /\
-    ~is_alloca_op inst2.inst_opcode ==>
-    (case step_inst fuel ctx inst1 s of
-       OK s1 => step_inst fuel ctx inst2 s1
-     | other => other)
-    =
-    (case step_inst fuel ctx inst2 s of
-       OK s2 => step_inst fuel ctx inst1 s2
-     | other => other)
+Triviality dft_block_label[simp]:
+  (dft_block order bb).bb_label = bb.bb_label
 Proof
-  cheat
+  simp[dft_block_def, LET_THM]
 QED
 
-(* ===== Block simulation ===== *)
+(* ===== Structural: dft_process_one preserves MAP bb_label ===== *)
 
-(* CHEATED: Block simulation for DFT reordering.
-   Requires the reordered instructions to respect all dependencies.
-   The DFT algorithm produces a valid topological order by construction. *)
-Theorem dft_block_simulates:
-  !order eda fuel ctx bb s.
-    s.vs_inst_idx = 0 /\
-    valid_topo_order bb.bb_instructions order eda
-                     (dft_block order bb).bb_instructions ==>
+Triviality map_replace_label:
+  !lbl bb bbs.
+    bb.bb_label = lbl ==>
+    MAP (\b. b.bb_label)
+        (MAP (\b. if b.bb_label = lbl then dft_block order bb else b) bbs) =
+    MAP (\b. b.bb_label) bbs
+Proof
+  Induct_on `bbs` >> simp[] >> rpt strip_tac >> rw[]
+QED
+
+Triviality dft_process_one_labels:
+  !cfg lr fn st lbl labels.
+    MAP (\b. b.bb_label) st.dls_blocks = labels ==>
+    MAP (\b. b.bb_label) (FST (dft_process_one cfg lr fn st lbl)).dls_blocks =
+    labels
+Proof
+  rpt strip_tac >>
+  simp[dft_process_one_def, LET_THM] >>
+  Cases_on `lookup_block lbl st.dls_blocks` >> simp[] >>
+  rename1 `SOME bb` >>
+  imp_res_tac lookup_block_label >>
+  pairarg_tac >> simp[] >> pairarg_tac >> simp[] >>
+  BasicProvers.TOP_CASE_TAC >> simp[map_replace_label]
+QED
+
+(* ===== Structural: dft_loop_step preserves MAP bb_label ===== *)
+
+Triviality dft_loop_step_labels:
+  !cfg lr fn trip labels.
+    MAP (\b. b.bb_label) (FST trip).dls_blocks = labels ==>
+    MAP (\b. b.bb_label) (FST (dft_loop_step cfg lr fn trip)).dls_blocks =
+    labels
+Proof
+  rpt gen_tac >> PairCases_on `trip` >>
+  simp[dft_loop_step_def, LET_THM] >>
+  IF_CASES_TAC >> simp[] >>
+  Cases_on `trip1` >> simp[] >>
+  strip_tac >>
+  pairarg_tac >> simp[] >>
+  IF_CASES_TAC >> simp[] >>
+  qspecl_then [`cfg`,`lr`,`fn`,`trip0`,`h`,`labels`] mp_tac
+    dft_process_one_labels >>
+  simp[]
+QED
+
+(* ===== Structural: dft_fn preserves MAP bb_label (FUNPOW invariant) ===== *)
+
+Triviality funpow_dft_loop_labels:
+  !n cfg lr fn trip labels.
+    MAP (\b. b.bb_label) (FST trip).dls_blocks = labels ==>
+    MAP (\b. b.bb_label)
+      (FST (FUNPOW (dft_loop_step cfg lr fn) n trip)).dls_blocks = labels
+Proof
+  Induct >> simp[FUNPOW_SUC] >> rpt strip_tac >>
+  irule dft_loop_step_labels >>
+  first_x_assum irule >> simp[]
+QED
+
+Theorem dft_fn_labels_map:
+  !fn. MAP (\b. b.bb_label) (dft_fn fn).fn_blocks =
+       MAP (\b. b.bb_label) fn.fn_blocks
+Proof
+  gen_tac >> rewrite_tac[dft_fn_def, LET_THM] >>
+  CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV) >>
+  simp[funpow_dft_loop_labels]
+QED
+
+(* ===== Corollaries of label preservation ===== *)
+
+Triviality mem_label_from_map:
+  !l1 l2 bb.
+    MAP (\b. b.bb_label) l1 = MAP (\b. b.bb_label) l2 /\
+    MEM bb l1 ==>
+    ?bb'. MEM bb' l2 /\ bb.bb_label = bb'.bb_label
+Proof
+  Induct >> simp[] >> gen_tac >> Cases >> simp[] >>
+  rpt strip_tac >> gvs[] >> metis_tac[]
+QED
+
+Theorem dft_fn_labels:
+  !fn bb. MEM bb (dft_fn fn).fn_blocks ==>
+          ?bb'. MEM bb' fn.fn_blocks /\ bb.bb_label = bb'.bb_label
+Proof
+  metis_tac[mem_label_from_map, dft_fn_labels_map]
+QED
+
+Triviality MEM_P_FIND:
+  !P l x. MEM x l /\ P x ==> ?y. FIND P l = SOME y
+Proof
+  Induct_on `l` >> simp[] >> rpt strip_tac >> gvs[]
+  >- (Cases_on `FIND P l` >> simp[listTheory.FIND_thm])
+  >> (simp[listTheory.FIND_thm] >> IF_CASES_TAC >> simp[] >>
+      metis_tac[])
+QED
+
+Triviality lookup_block_map_labels:
+  !l1 l2 lbl bb.
+    MAP (\b. b.bb_label) l1 = MAP (\b. b.bb_label) l2 /\
+    lookup_block lbl l1 = SOME bb ==>
+    ?bb'. lookup_block lbl l2 = SOME bb'
+Proof
+  rpt strip_tac >>
+  `MEM bb l1 /\ bb.bb_label = lbl` by
+    (fs[lookup_block_def] >>
+     imp_res_tac venomExecPropsTheory.FIND_MEM >>
+     imp_res_tac venomExecPropsTheory.FIND_P >> gs[]) >>
+  drule_all mem_label_from_map >> strip_tac >>
+  simp[lookup_block_def] >> irule MEM_P_FIND >> metis_tac[]
+QED
+
+Theorem dft_fn_lookup_block:
+  !fn lbl bb.
+    lookup_block lbl fn.fn_blocks = SOME bb ==>
+    ?bb'. lookup_block lbl (dft_fn fn).fn_blocks = SOME bb'
+Proof
+  metis_tac[lookup_block_map_labels, dft_fn_labels_map]
+QED
+
+(* ===== Block-level: run_block equality ===== *)
+
+(* A block is a permutation-variant of a block in fn: same phis,
+   non-pseudos are from_block (= same or flip) of the original *)
+Definition block_perm_of_def:
+  block_perm_of fn bb <=>
+    ?bb_orig. MEM bb_orig fn.fn_blocks /\
+      bb.bb_label = bb_orig.bb_label /\
+      FILTER (\i. is_pseudo i.inst_opcode) bb.bb_instructions =
+      FILTER (\i. is_pseudo i.inst_opcode) bb_orig.bb_instructions /\
+      EVERY (\i. from_block bb_orig.bb_instructions i)
+        (FILTER (\i. ~is_pseudo i.inst_opcode) bb.bb_instructions) /\
+      PERM (MAP (\i. i.inst_id)
+              (FILTER (\i. ~is_pseudo i.inst_opcode) bb.bb_instructions))
+           (MAP (\i. i.inst_id)
+              (FILTER (\i. ~is_pseudo i.inst_opcode) bb_orig.bb_instructions))
+End
+
+(* ===== Permutation lift_result for run_insts ===== *)
+
+(* Non-terminator, non-INVOKE instructions never produce Halt or IntRet *)
+(* run_insts on non-term/non-INVOKE/non-ext-call list can only return OK, Abort, or Error *)
+(* Pre-compute: non-terminator non-INVOKE opcodes never produce Halt/IntRet.
+   Uses same ML pre-computation pattern as dftPermSim.per_op_no_halt_abort. *)
+local
+  val nt_ni_ops = List.filter (fn op_tm =>
+    let val nt = EVAL ``~is_terminator ^op_tm``
+        val ni = EVAL ``^op_tm <> INVOKE``
+    in aconv (rhs (concl nt)) T andalso aconv (rhs (concl ni)) T end
+  ) (TypeBase.constructors_of ``:opcode``);
+
+  val nt_ni_clauses = map (fn op_tm =>
+    SIMP_CONV (srw_ss()) [step_inst_base_def]
+      (mk_comb(mk_comb(``step_inst_base``,
+        ``inst with inst_opcode := ^op_tm``), ``st:venom_state``))
+  ) nt_ni_ops;
+
+  val exec_helper_defs = [
+    exec_pure1_def, exec_pure2_def, exec_pure3_def,
+    exec_read0_def, exec_read1_def, exec_write2_def,
+    exec_alloca_def, exec_ext_call_def, exec_create_def,
+    exec_delegatecall_def, LET_THM, AllCaseEqs()];
+
+  val per_op_not_halt_intret = map (fn (op_tm, clause) =>
+    prove(
+      ``inst.inst_opcode = ^op_tm ==>
+        (!v. step_inst_base inst st <> Halt v) /\
+        (!vals v. step_inst_base inst st <> IntRet vals v)``,
+      strip_tac >>
+      `inst with inst_opcode := ^op_tm = inst`
+        by simp[instruction_component_equality] >>
+      pop_assum (fn eq => ONCE_REWRITE_TAC [GSYM eq]) >>
+      ONCE_REWRITE_TAC [clause] >> simp exec_helper_defs)
+  ) (ListPair.zip(nt_ni_ops, nt_ni_clauses));
+in
+  val step_inst_base_not_halt_intret_combined = LIST_CONJ per_op_not_halt_intret;
+end
+
+Triviality step_inst_base_not_halt_intret:
+  !inst s.
+    ~is_terminator inst.inst_opcode /\ inst.inst_opcode <> INVOKE ==>
+    (!v. step_inst_base inst s <> Halt v) /\
+    (!vals v. step_inst_base inst s <> IntRet vals v)
+Proof
+  rpt gen_tac >> Cases_on `inst.inst_opcode` >>
+  simp[is_terminator_def, step_inst_base_not_halt_intret_combined]
+QED
+
+Triviality perm_every_imp:
+  !P l1 l2. PERM l1 l2 /\ EVERY P l1 ==> EVERY P l2
+Proof
+  rw[EVERY_MEM] >> metis_tac[PERM_MEM_EQ]
+QED
+
+Triviality run_insts_no_halt_intret:
+  !fuel ctx l s.
+    EVERY (\i. ~is_terminator i.inst_opcode /\ i.inst_opcode <> INVOKE) l ==>
+    (!v. run_insts fuel ctx l s <> Halt v) /\
+    (!vals v. run_insts fuel ctx l s <> IntRet vals v)
+Proof
+  gen_tac >> gen_tac >> Induct >> simp[run_insts_def] >>
+  rpt gen_tac >> strip_tac >>
+  simp[step_inst_non_invoke] >>
+  Cases_on `step_inst_base h s` >> gvs[] >>
+  metis_tac[step_inst_base_not_halt_intret]
+QED
+
+(* Abort type is determined by opcode_fail_class for non-term/non-INVOKE *)
+Triviality step_inst_base_abort_type:
+  !inst s a s'.
+    step_inst_base inst s = Abort a s' /\
+    ~is_terminator inst.inst_opcode /\
+    inst.inst_opcode <> INVOKE ==>
+    (opcode_fail_class inst.inst_opcode = CanRevert ==> a = Revert_abort) /\
+    (opcode_fail_class inst.inst_opcode = CanExHalt ==> a = ExHalt_abort)
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[opcode_fail_class_def, is_terminator_def] >>
+  gvs[step_inst_base_def, AllCaseEqs()]
+QED
+
+(* Two abort_compatible non-term/non-INVOKE instructions that both abort
+   produce the same abort type *)
+Triviality abort_compatible_same_type:
+  !i1 i2 s1 s2 a1 a2 s1' s2'.
+    abort_compatible i1.inst_opcode i2.inst_opcode /\
+    ~is_terminator i1.inst_opcode /\ ~is_terminator i2.inst_opcode /\
+    i1.inst_opcode <> INVOKE /\ i2.inst_opcode <> INVOKE /\
+    step_inst_base i1 s1 = Abort a1 s1' /\
+    step_inst_base i2 s2 = Abort a2 s2' ==>
+    a1 = a2
+Proof
+  rpt strip_tac >>
+  fs[abort_compatible_def] >> gvs[]
+  >- metis_tac[step_inst_nofail_not_halt_abort]
+  >- metis_tac[step_inst_nofail_not_halt_abort]
+  >> (Cases_on `opcode_fail_class i1.inst_opcode` >> gvs[]
+      >- metis_tac[step_inst_nofail_not_halt_abort]
+      >- (`a1 = Revert_abort` by metis_tac[step_inst_base_abort_type] >>
+          `a2 = Revert_abort` by metis_tac[step_inst_base_abort_type] >> gvs[])
+      >- (`a1 = ExHalt_abort` by metis_tac[step_inst_base_abort_type] >>
+          `a2 = ExHalt_abort` by metis_tac[step_inst_base_abort_type] >> gvs[])
+      (* AnyFail: only INVOKE, excluded *)
+      >> (Cases_on `i1.inst_opcode` >>
+          gvs[opcode_fail_class_def]))
+QED
+
+(* step_inst_base abort always clears returndata for non-term/ext/INVOKE *)
+Triviality step_inst_base_abort_returndata:
+  !inst s a s'.
+    step_inst_base inst s = Abort a s' /\
+    ~is_terminator inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\
+    inst.inst_opcode <> INVOKE ==>
+    s'.vs_returndata = []
+Proof
+  rpt strip_tac >>
+  Cases_on `opcode_fail_class inst.inst_opcode` >> gvs[]
+  >- metis_tac[step_inst_nofail_not_halt_abort]
+  >- ((* CanRevert — only ASSERT has this class among non-term/non-ext *)
+      Cases_on `inst.inst_opcode` >>
+      gvs[opcode_fail_class_def, is_terminator_def, is_ext_call_op_def] >>
+      gvs[step_inst_base_def, AllCaseEqs(),
+          revert_state_def, set_returndata_def])
+  >- ((* CanExHalt — INVALID, ASSERT_UNREACHABLE, RETURNDATACOPY *)
+      Cases_on `inst.inst_opcode` >>
+      gvs[opcode_fail_class_def, is_terminator_def, is_ext_call_op_def] >>
+      gvs[step_inst_base_def, AllCaseEqs(),
+          halt_state_def, set_returndata_def])
+  >> ((* AnyFail — only INVOKE, excluded *)
+      Cases_on `inst.inst_opcode` >>
+      gvs[opcode_fail_class_def, is_terminator_def, is_ext_call_op_def])
+QED
+
+(* Non-terminator non-ext-call aborters always set returndata = [] *)
+Theorem run_insts_abort_clears_returndata:
+  !fuel ctx l s a s'.
+    run_insts fuel ctx l s = Abort a s' /\
+    EVERY (\i. ~is_terminator i.inst_opcode /\ ~is_ext_call_op i.inst_opcode /\
+               i.inst_opcode <> INVOKE) l ==>
+    s'.vs_returndata = []
+Proof
+  gen_tac >> gen_tac >> Induct >> rpt strip_tac >> gvs[run_insts_def] >>
+  gvs[AllCaseEqs(), step_inst_non_invoke] >>
+  metis_tac[step_inst_base_abort_returndata]
+QED
+
+(* For pairwise bi_independent permutations:
+   - OK case: identical result (run_insts_perm_ok)
+   - Non-OK case: both have same constructor, abort types match,
+     returndata = [] (revert_equiv) *)
+(* If instruction x OKs on s giving sx, and y is bi_independent of x,
+   then y produces the same result constructor on sx as on s.
+   Specifically: if y aborts on s, y also aborts on sx with the same type;
+   if y doesn't error on s, y doesn't error on sx. *)
+(* Helper: MEM (Var v) ops ==> MEM v (operand_vars ops) *)
+Triviality MEM_operand_vars_iff:
+  !ops v. MEM v (operand_vars ops) <=> MEM (Var v) ops
+Proof
+  Induct >> simp[operand_vars_def] >>
+  rpt gen_tac >> Cases_on `operand_var h` >> simp[operand_var_def] >>
+  Cases_on `h` >> gvs[operand_var_def]
+QED
+
+val MEM_Var_operand_vars =
+  MEM_operand_vars_iff |> SPEC_ALL |> EQ_IMP_RULE |> snd
+    |> GENL [``ops : operand list``, ``v : string``];
+
+(* ML pre-computation: non-aborting opcodes can't produce Abort *)
+local
+  val nt_ni_nec_na_ops = List.filter (fn op_tm =>
+    let val nt = EVAL ``~is_terminator ^op_tm``
+        val ni = EVAL ``^op_tm <> INVOKE``
+        val nec = EVAL ``~is_ext_call_op ^op_tm``
+        val na = EVAL ``~is_alloca_op ^op_tm``
+    in aconv (rhs (concl nt)) T andalso aconv (rhs (concl ni)) T
+       andalso aconv (rhs (concl nec)) T andalso aconv (rhs (concl na)) T end
+  ) (TypeBase.constructors_of ``:opcode``);
+  val abort_ops = [``ASSERT``, ``ASSERT_UNREACHABLE``, ``RETURNDATACOPY``];
+  val non_abort_ops = List.filter (fn op_tm =>
+    not (List.exists (fn t => aconv t op_tm) abort_ops)) nt_ni_nec_na_ops;
+  val nt_ni_clauses = map (fn op_tm =>
+    SIMP_CONV (srw_ss()) [step_inst_base_def]
+      (mk_comb(mk_comb(``step_inst_base``,
+        ``inst with inst_opcode := ^op_tm``), ``st:venom_state``))
+  ) non_abort_ops;
+  val exec_helper_defs = [
+    exec_pure1_def, exec_pure2_def, exec_pure3_def,
+    exec_read0_def, exec_read1_def, exec_write2_def,
+    exec_alloca_def, exec_ext_call_def, exec_create_def,
+    exec_delegatecall_def, LET_THM, AllCaseEqs()];
+  val per_op_no_abort = map (fn (op_tm, clause) =>
+    prove(
+      ``inst.inst_opcode = ^op_tm ==>
+        (!a s'. step_inst_base inst st <> Abort a s')``,
+      strip_tac >>
+      `inst with inst_opcode := ^op_tm = inst`
+        by simp[instruction_component_equality] >>
+      pop_assum (fn eq => ONCE_REWRITE_TAC [GSYM eq]) >>
+      ONCE_REWRITE_TAC [clause] >> simp exec_helper_defs)
+  ) (ListPair.zip(non_abort_ops, nt_ni_clauses));
+in
+  val step_inst_base_no_abort_combined = LIST_CONJ per_op_no_abort;
+end
+
+(* Helper: effects_independent with RETURNDATACOPY implies no returndata write *)
+Triviality eff_ind_returndatacopy_no_write_rd:
+  !op. effects_independent op RETURNDATACOPY ==>
+       Eff_RETURNDATA NOTIN write_effects op
+Proof
+  rpt strip_tac >> gvs[effects_independent_def] >>
+  spose_not_then assume_tac >>
+  `Eff_RETURNDATA IN (read_effects RETURNDATACOPY UNION
+                      write_effects RETURNDATACOPY)` by EVAL_TAC >>
+  gvs[pred_setTheory.IN_DISJOINT] >>
+  metis_tac[]
+QED
+
+(* Shared helper: if x OKs on s giving sx, and bi_independent x y,
+   then y's operands evaluate identically on sx and s.
+   This is THE core frame lemma for cross-instruction reasoning. *)
+Triviality bi_ind_ok_preserves_eval_operand:
+  !fuel ctx x y s sx op.
+    bi_independent x y /\
+    step_inst fuel ctx x s = OK sx /\
+    MEM op y.inst_operands ==>
+    eval_operand op sx = eval_operand op s
+Proof
+  rpt strip_tac >> fs[bi_independent_def] >>
+  Cases_on `op` >> simp[eval_operand_def]
+  (* Var case *)
+  >- (`!v. ~MEM v x.inst_outputs ==> lookup_var v sx = lookup_var v s` by
+        metis_tac[step_preserves_non_output_vars] >>
+      first_x_assum irule >>
+      `MEM s' (inst_uses y)` by
+        (simp[inst_uses_def] >> irule MEM_Var_operand_vars >> simp[]) >>
+      spose_not_then assume_tac >>
+      `MEM s' (inst_defs x)` by fs[inst_defs_def] >>
+      qpat_x_assum `DISJOINT (set (inst_defs x)) (set (inst_uses y))` mp_tac >>
+      simp[pred_setTheory.DISJOINT_DEF, pred_setTheory.EXTENSION] >>
+      qexists_tac `s'` >> simp[])
+  (* Label case *)
+  >> (drule_all step_preserves_labels >> simp[])
+QED
+
+(* Corollary: all of y's operands evaluate the same on sx as s *)
+Triviality bi_ind_ok_all_operands_same:
+  !fuel ctx x y s sx.
+    bi_independent x y /\
+    step_inst fuel ctx x s = OK sx ==>
+    MAP (\op. eval_operand op sx) y.inst_operands =
+    MAP (\op. eval_operand op s) y.inst_operands
+Proof
+  rpt strip_tac >> irule MAP_CONG >> simp[] >>
+  metis_tac[bi_ind_ok_preserves_eval_operand]
+QED
+
+(* Abort transfers between states with same operand values and returndata.
+   If a non-term/non-alloca/non-ext/non-INVOKE instruction aborts from s,
+   it also aborts (with the same abort type) from any s' that agrees on
+   operand values and returndata. *)
+Triviality step_inst_base_abort_transfer:
+  !inst s s' a v.
+    step_inst_base inst s = Abort a v /\
+    ~is_terminator inst.inst_opcode /\
+    ~is_alloca_op inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\
+    inst.inst_opcode <> INVOKE /\
+    (!op. MEM op inst.inst_operands ==>
+          eval_operand op s' = eval_operand op s) /\
+    (inst.inst_opcode = RETURNDATACOPY ==>
+     s'.vs_returndata = s.vs_returndata) ==>
+    ?v'. step_inst_base inst s' = Abort a v'
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_terminator_def, is_alloca_op_def, is_ext_call_op_def,
+      step_inst_base_no_abort_combined] >>
+  (* Only ASSERT, ASSERT_UNREACHABLE, RETURNDATACOPY remain *)
+  qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  simp[AllCaseEqs(), revert_state_def, halt_state_def,
+       set_returndata_def, LET_THM] >>
+  rpt strip_tac >> gvs[]
+QED
+
+Triviality bi_independent_cross_abort:
+  !fuel ctx x y s sx a s_ab.
+    bi_independent x y /\
+    step_inst fuel ctx x s = OK sx /\
+    step_inst fuel ctx y s = Abort a s_ab ==>
+    ?s_ab'. step_inst fuel ctx y sx = Abort a s_ab' /\
+            s_ab'.vs_returndata = [] /\ s_ab.vs_returndata = []
+Proof
+  rpt strip_tac >>
+  drule bi_ind_ok_all_operands_same >>
+  disch_then drule >> strip_tac >>
+  fs[bi_independent_def] >>
+  (* Convert step_inst -> step_inst_base *)
+  qpat_x_assum `step_inst _ _ y _ = Abort _ _` mp_tac >>
+  simp[step_inst_non_invoke] >> strip_tac >>
+  simp[step_inst_non_invoke] >>
+  (* Only 3 opcodes can abort *)
+  Cases_on `y.inst_opcode` >>
+  gvs[is_terminator_def, is_ext_call_op_def, is_alloca_op_def,
+      step_inst_base_no_abort_combined] >>
+  (* Shared pattern: decompose abort on s, rebuild on sx using same evals.
+     ONCE_REWRITE_TAC[step_inst_base_def] unfolds once with known opcode. *)
+  qpat_x_assum `step_inst_base _ s = _` mp_tac >>
+  ONCE_REWRITE_TAC [step_inst_base_def] >>
+  simp[AllCaseEqs(), revert_state_def, halt_state_def,
+       set_returndata_def, LET_THM] >>
+  strip_tac >> gvs[] >>
+  ONCE_REWRITE_TAC [step_inst_base_def] >>
+  simp[revert_state_def, halt_state_def, set_returndata_def, LET_THM] >>
+  (* RETURNDATACOPY: also needs sx.vs_returndata = s.vs_returndata *)
+  metis_tac[write_effects_sound_returndata,
+            eff_ind_returndatacopy_no_write_rd]
+QED
+
+(* bi_independent is symmetric *)
+Triviality bi_independent_sym:
+  !x y. bi_independent x y ==> bi_independent y x
+Proof
+  rw[bi_independent_def, effects_independent_def, abort_compatible_def] >>
+  metis_tac[pred_setTheory.DISJOINT_SYM]
+QED
+
+(* Chain: if inst aborts from s with type a, and we run a sequence of
+   bi_independent instructions that all OK, inst still aborts with type a
+   from the resulting state. *)
+Triviality bi_ind_cross_abort_chain:
+  !prefix fuel ctx inst s a v s'.
+    EVERY (bi_independent inst) prefix /\
+    step_inst fuel ctx inst s = Abort a v /\
+    run_insts fuel ctx prefix s = OK s' ==>
+    ?v'. step_inst fuel ctx inst s' = Abort a v'
+Proof
+  Induct >> simp[run_insts_def] >> rpt strip_tac >>
+  gvs[EVERY_DEF] >>
+  rename1 `bi_independent inst h` >>
+  Cases_on `step_inst fuel ctx h s` >> gvs[] >>
+  rename1 `step_inst _ _ h s = OK sh` >>
+  drule bi_independent_sym >> strip_tac >>
+  drule_all bi_independent_cross_abort >> strip_tac >>
+  first_x_assum (qspecl_then [`fuel`,`ctx`,`inst`,`sh`,`a`,`s_ab'`,`s'`] mp_tac) >>
+  simp[]
+QED
+
+(* Prefix of bi_independent OK steps preserves operands *)
+Triviality eval_operand_bi_ind_prefix_invariant:
+  !prefix fuel ctx inst s s'.
+    EVERY (\e. bi_independent inst e) prefix /\
+    EVERY (\i. ~is_terminator i.inst_opcode) prefix /\
+    run_insts fuel ctx prefix s = OK s' ==>
+    !op. MEM op inst.inst_operands ==> eval_operand op s' = eval_operand op s
+Proof
+  Induct >> simp[run_insts_def] >> rpt gen_tac >> strip_tac >>
+  Cases_on `step_inst fuel ctx h s` >> gvs[run_insts_def] >>
+  rename1 `step_inst _ _ h s = OK sh` >>
+  rpt strip_tac >>
+  `eval_operand op sh = eval_operand op s` by
+    metis_tac[bi_ind_ok_preserves_eval_operand, bi_independent_sym] >>
+  last_x_assum (qspecl_then [`fuel`, `ctx`, `inst`, `sh`, `s'`] mp_tac) >>
+  simp[]
+QED
+
+(* Prefix of bi_independent OK steps preserves returndata when inst
+   reads/writes returndata (e.g. RETURNDATACOPY barrier) *)
+Triviality returndata_bi_ind_prefix_invariant:
+  !prefix fuel ctx inst s s'.
+    EVERY (\e. bi_independent inst e) prefix /\
+    EVERY (\i. ~is_terminator i.inst_opcode) prefix /\
+    run_insts fuel ctx prefix s = OK s' /\
+    Eff_RETURNDATA IN
+      (read_effects inst.inst_opcode UNION write_effects inst.inst_opcode) ==>
+    s'.vs_returndata = s.vs_returndata
+Proof
+  Induct >> simp[run_insts_def] >>
+  rpt gen_tac >> strip_tac >>
+  Cases_on `step_inst fuel ctx h s` >> gvs[run_insts_def] >>
+  rename1 `step_inst _ _ h s = OK sh` >>
+  `Eff_RETURNDATA NOTIN write_effects h.inst_opcode` by
+    (qpat_x_assum `bi_independent _ _` mp_tac >>
+     simp[bi_independent_def, effects_independent_def,
+          pred_setTheory.IN_DISJOINT] >> metis_tac[]) >>
+  `~is_alloca_op h.inst_opcode` by
+    (qpat_x_assum `bi_independent _ _` mp_tac >>
+     simp[bi_independent_def]) >>
+  `sh.vs_returndata = s.vs_returndata` by
+    metis_tac[write_effects_sound_returndata] >>
+  last_x_assum (qspecl_then [`fuel`, `ctx`, `inst`, `sh`, `s'`] mp_tac) >>
+  simp[]
+QED
+
+(* Cross-step preserves OK: if both succeed on s and are bi_independent,
+   each also succeeds on the other's result state *)
+Triviality bi_ind_cross_step_ok:
+  !fuel ctx x y s sx.
+    bi_independent x y /\
+    step_inst fuel ctx x s = OK sx /\
+    step_inst fuel ctx y s = OK (sy : venom_state) ==>
+    ?v. step_inst_base y sx = OK v
+Proof
+  rpt strip_tac >>
+  drule_all bi_ind_ok_all_operands_same >> strip_tac >>
+  `~is_terminator x.inst_opcode /\ ~is_alloca_op x.inst_opcode /\
+   ~is_ext_call_op x.inst_opcode /\ x.inst_opcode <> INVOKE /\
+   ~is_terminator y.inst_opcode /\ ~is_alloca_op y.inst_opcode /\
+   ~is_ext_call_op y.inst_opcode /\ y.inst_opcode <> INVOKE /\
+   effects_independent x.inst_opcode y.inst_opcode` by
+    fs[bi_independent_def] >>
+  `step_inst_base y s = OK sy` by fs[step_inst_non_invoke] >>
+  `sx.vs_prev_bb = s.vs_prev_bb` by
+    metis_tac[step_inst_preserves_prev_bb, step_inst_non_invoke] >>
+  `sx.vs_params = s.vs_params` by
+    metis_tac[step_preserves_params, step_inst_non_invoke] >>
+  qspecl_then [`y`,`s`,`sy`,`sx`] mp_tac step_inst_base_ok_transfer >>
+  simp[] >> disch_then irule >> conj_tac
+  >- (rpt strip_tac >>
+      qpat_x_assum `MAP _ _ = MAP _ _` mp_tac >>
+      simp[listTheory.MAP_EQ_f])
+  >> (strip_tac >>
+      `Eff_RETURNDATA NOTIN write_effects x.inst_opcode` by
+        metis_tac[eff_ind_returndatacopy_no_write_rd] >>
+      metis_tac[write_effects_sound_returndata, step_inst_non_invoke])
+QED
+
+(* Non-terminator, non-INVOKE bi_independent instructions never Halt or IntRet *)
+Triviality bi_independent_no_halt_intret:
+  !fuel ctx x y s.
+    bi_independent x y ==>
+    (!v. step_inst fuel ctx x s <> Halt v) /\
+    (!v s'. step_inst fuel ctx x s <> IntRet v s') /\
+    (!v. step_inst fuel ctx y s <> Halt v) /\
+    (!v s'. step_inst fuel ctx y s <> IntRet v s')
+Proof
+  rw[bi_independent_def, step_inst_non_invoke] >>
+  metis_tac[step_inst_base_not_halt_intret]
+QED
+
+(* Swap case helper: two bi_independent non-erroring instructions produce
+   lift_result equivalent composed results. *)
+Triviality step_swap_lift:
+  !fuel ctx x y s.
+    bi_independent x y /\
+    (!e. step_inst fuel ctx x s <> Error e) /\
+    (!e. step_inst fuel ctx y s <> Error e) ==>
+    lift_result (=) (=) revert_equiv
+      (case step_inst fuel ctx x s of
+         OK sx => step_inst fuel ctx y sx
+       | Halt v => Halt v | Abort a s' => Abort a s'
+       | IntRet v s' => IntRet v s' | Error e => Error e)
+      (case step_inst fuel ctx y s of
+         OK sy => step_inst fuel ctx x sy
+       | Halt v => Halt v | Abort a s' => Abort a s'
+       | IntRet v s' => IntRet v s' | Error e => Error e)
+Proof
+  rpt strip_tac >>
+  (* Get specific no-Halt/IntRet facts that gvs can use *)
+  qspecl_then [`fuel`,`ctx`,`x`,`y`,`s`] mp_tac
+    bi_independent_no_halt_intret >> (impl_tac >- simp[]) >> strip_tac >>
+  Cases_on `step_inst fuel ctx x s` >> gvs[] >>
+  Cases_on `step_inst fuel ctx y s` >> gvs[]
+  (* OK x, OK y: commute via independent_commute_eq *)
+  >- suspend "ok_ok"
+  (* OK x, Abort y: cross_abort *)
+  >- (drule_all bi_independent_cross_abort >> strip_tac >>
+      simp[lift_result_def, revert_equiv_def])
+  (* Abort x, OK y: symmetric — use cross_abort with roles swapped *)
+  >- (rename1 `step_inst _ _ y s = OK sy` >>
+      rename1 `step_inst _ _ x s = Abort abt sab` >>
+      `bi_independent y x` by metis_tac[bi_independent_sym] >>
+      qspecl_then [`fuel`,`ctx`,`y`,`x`,`s`,`sy`,`abt`,`sab`] mp_tac
+        bi_independent_cross_abort >>
+      (impl_tac >- simp[]) >> strip_tac >>
+      simp[lift_result_def, revert_equiv_def])
+  (* Abort x, Abort y: same type + both clear returndata *)
+  >> (simp[lift_result_def, revert_equiv_def] >>
+      fs[bi_independent_def] >>
+      conj_tac
+      >- metis_tac[abort_compatible_same_type, step_inst_non_invoke]
+      >> metis_tac[step_inst_base_abort_returndata, step_inst_non_invoke])
+QED
+
+Resume step_swap_lift[ok_ok]:
+  rename1 `step_inst _ _ x s = OK sx` >>
+  rename1 `step_inst _ _ y s = OK sy` >>
+  fs[bi_independent_def] >>
+  simp[step_inst_non_invoke] >>
+  (* Cross-steps both give OK (by bi_ind_cross_step_ok) *)
+  `?vy. step_inst_base y sx = OK vy` by
+    metis_tac[bi_ind_cross_step_ok, bi_independent_def] >>
+  `?vx. step_inst_base x sy = OK vx` by
+    metis_tac[bi_ind_cross_step_ok, bi_independent_sym, bi_independent_def] >>
+  simp[lift_result_def] >>
+  qspecl_then [`fuel`,`ctx`,`x`,`y`,`s`,`sx`,`sy`] mp_tac
+    independent_commute_eq >>
+  simp[step_inst_non_invoke]
+QED
+
+Finalise step_swap_lift
+
+(* bi_independent OK step preserves non-Error property *)
+Triviality bi_ind_ok_preserves_no_error:
+  !fuel ctx x i s s'.
+    bi_independent x i /\
+    step_inst fuel ctx x s = OK s' /\
+    (!e. step_inst fuel ctx i s <> Error e) ==>
+    (!e. step_inst fuel ctx i s' <> Error e)
+Proof
+  rpt strip_tac >>
+  Cases_on `step_inst fuel ctx i s` >> gvs[]
+  (* OK: cross_step_ok gives OK on s' *)
+  >- (drule_all bi_ind_cross_step_ok >> strip_tac >>
+      gvs[bi_independent_def, step_inst_non_invoke])
+  (* Halt: impossible *)
+  >- (qspecl_then [`fuel`,`ctx`,`x`,`i`,`s`] mp_tac
+        bi_independent_no_halt_intret >> simp[])
+  (* Abort: cross_abort gives Abort on s' *)
+  >- (drule_all bi_independent_cross_abort >> strip_tac >>
+      gvs[bi_independent_def, step_inst_non_invoke])
+  (* IntRet: impossible *)
+  >- (qspecl_then [`fuel`,`ctx`,`x`,`i`,`s`] mp_tac
+        bi_independent_no_halt_intret >> simp[])
+QED
+
+(* Stepping a bi-independent instruction preserves no-Error in both
+   directions. Subsumes bi_ind_ok_preserves_no_error. *)
+Triviality bi_ind_ok_no_error_iff:
+  !fuel ctx x i s s'.
+    bi_independent x i /\
+    step_inst fuel ctx x s = OK s' ==>
+    ((!e. step_inst fuel ctx i s <> Error e) <=>
+     (!e. step_inst fuel ctx i s' <> Error e))
+Proof
+  rpt strip_tac >> eq_tac >> strip_tac
+  (* Forward: no-Error on s → no-Error on s' *)
+  >- metis_tac[bi_ind_ok_preserves_no_error]
+  (* Reverse: no-Error on s' → no-Error on s.
+     We show step_inst i s gives the same constructor as step_inst i s'
+     (which is not Error). Uses contrapositive on constructor case analysis. *)
+  >> (rpt strip_tac >>
+      (* Extract flags from bi_independent for BOTH x and i *)
+      `~is_terminator x.inst_opcode /\ ~is_alloca_op x.inst_opcode /\
+       ~is_ext_call_op x.inst_opcode /\ x.inst_opcode <> INVOKE /\
+       ~is_terminator i.inst_opcode /\ ~is_alloca_op i.inst_opcode /\
+       ~is_ext_call_op i.inst_opcode /\ i.inst_opcode <> INVOKE` by
+        (fs[bi_independent_def]) >>
+      (* Derive operand equivalence *)
+      drule_all bi_ind_ok_all_operands_same >> strip_tac >>
+      (* Get state field preservation *)
+      `s'.vs_prev_bb = s.vs_prev_bb` by
+        (qspecl_then [`fuel`,`ctx`,`x`,`s`,`s'`] mp_tac
+           step_inst_preserves_prev_bb >> simp[]) >>
+      `s'.vs_params = s.vs_params` by
+        (qspecl_then [`fuel`,`ctx`,`x`,`s`,`s'`] mp_tac
+           step_preserves_params >> simp[]) >>
+      (* Returndata: conditional on i being RETURNDATACOPY *)
+      `i.inst_opcode = RETURNDATACOPY ==>
+       s'.vs_returndata = s.vs_returndata` by
+        (strip_tac >>
+         `Eff_RETURNDATA NOTIN write_effects x.inst_opcode` by
+           metis_tac[eff_ind_returndatacopy_no_write_rd,
+                     bi_independent_def] >>
+         metis_tac[write_effects_sound_returndata]) >>
+      suspend "reverse")
+QED
+
+Resume bi_ind_ok_no_error_iff[reverse]:
+  (* Convert step_inst → step_inst_base, derive pointwise operand equality *)
+  fs[step_inst_non_invoke] >>
+  `!op. MEM op i.inst_operands ==>
+        eval_operand op s' = eval_operand op s` by (
+    qpat_x_assum `MAP _ _ = MAP _ _` mp_tac >>
+    simp[listTheory.MAP_EQ_f]) >>
+  Cases_on `step_inst_base i s'` >> gvs[] >>
+  TRY (metis_tac[step_inst_base_not_halt_intret])
+  (* OK case: transfer OK from s' to s, contradicts Error *)
+  >- (qspecl_then [`i`,`s'`,`v`,`s`] mp_tac
+        passSharedPropsTheory.step_inst_base_ok_transfer >>
+      simp[] >> strip_tac >> gvs[])
+  (* Abort case: for each aborting opcode, unfold step_inst_base on both
+     states; operand equality ensures same branch taken *)
+  >> (Cases_on `i.inst_opcode` >>
+      gvs[is_terminator_def, is_ext_call_op_def, is_alloca_op_def,
+          step_inst_base_no_abort_combined] >>
+      qpat_x_assum `step_inst_base _ s' = Abort _ _` mp_tac >>
+      qpat_x_assum `step_inst_base _ s = Error _` mp_tac >>
+      ntac 2 (ONCE_REWRITE_TAC [step_inst_base_def]) >>
+      every_case_tac >> gvs[] >> IF_CASES_TAC >> gvs[])
+QED
+
+Finalise bi_ind_ok_no_error_iff;
+
+(* PERM preserves pairwise_bi_independent and EVERY (bi_independent x) *)
+Triviality perm_preserves_pairwise_bi_ind:
+  !l1 l2.
+    PERM l1 l2 ==>
+    (pairwise_bi_independent l1 ==> pairwise_bi_independent l2) /\
+    (!x. EVERY (bi_independent x) l1 ==> EVERY (bi_independent x) l2)
+Proof
+  ho_match_mp_tac PERM_IND >>
+  rw[pairwise_bi_independent_def, EVERY_DEF] >>
+  gvs[pairwise_bi_independent_def, EVERY_DEF] >>
+  metis_tac[bi_independent_sym]
+QED
+
+(* Stepping a bi-independent instruction preserves no-error for an entire list *)
+Triviality bi_ind_list_preserves_no_error:
+  !fuel ctx x l s s'.
+    EVERY (bi_independent x) l /\
+    step_inst fuel ctx x s = OK s' /\
+    EVERY (\i. !e. step_inst fuel ctx i s <> Error e) l ==>
+    EVERY (\i. !e. step_inst fuel ctx i s' <> Error e) l
+Proof
+  rpt strip_tac >> gvs[EVERY_MEM] >> rpt gen_tac >> strip_tac >>
+  irule bi_ind_ok_preserves_no_error >>
+  qexistsl [`s`, `x`] >> simp[]
+QED
+
+(* Main PERM lift_result lemma — uses perm_preserves_pairwise_bi_ind *)
+Theorem run_insts_perm_lift_strong:
+  !l1 l2.
+    PERM l1 l2 ==>
+    !fuel ctx s.
+       pairwise_bi_independent l1 /\
+       EVERY (\i. !e. step_inst fuel ctx i s <> Error e) l1 ==>
+       lift_result (=) (=) revert_equiv
+         (run_insts fuel ctx l1 s) (run_insts fuel ctx l2 s)
+Proof
+  ho_match_mp_tac PERM_STRONG_IND >> rpt conj_tac
+  (* nil *)
+  >- simp[run_insts_def, lift_result_def]
+  (* cons *)
+  >- suspend "cons"
+  (* swap *)
+  >- suspend "swap"
+  (* trans *)
+  >> suspend "trans"
+QED
+
+Resume run_insts_perm_lift_strong[cons]:
+  rpt strip_tac >>
+  gvs[pairwise_bi_independent_def, EVERY_DEF, run_insts_def] >>
+  Cases_on `step_inst fuel ctx x s` >> gvs[lift_result_def]
+  >- (first_x_assum $ qspecl_then [`fuel`,`ctx`,`v`] mp_tac >>
+      impl_tac
+      >- suspend "cons_no_err"
+      >> simp[])
+  >> simp[revert_equiv_def]
+QED
+
+Resume run_insts_perm_lift_strong[cons_no_err]:
+  irule bi_ind_list_preserves_no_error >>
+  qexistsl [`s`, `x`] >> simp[]
+QED
+
+Resume run_insts_perm_lift_strong[swap]:
+  rpt strip_tac >>
+  gvs[pairwise_bi_independent_def, EVERY_DEF, run_insts_def] >>
+  qspecl_then [`fuel`,`ctx`,`x`,`y`,`s`] mp_tac
+    bi_independent_no_halt_intret >>
+  (impl_tac >- simp[]) >> strip_tac >>
+  Cases_on `step_inst fuel ctx x s` >> gvs[] >>
+  Cases_on `step_inst fuel ctx y s` >> gvs[]
+  (* OK/OK *)
+  >- suspend "swap_ok_ok"
+  (* OK/Abort *)
+  >- (gvs[step_inst_non_invoke] >>
+      drule_all bi_independent_cross_abort >>
+      strip_tac >> gvs[lift_result_def, revert_equiv_def])
+  (* Abort/OK *)
+  >- (`bi_independent y x` by metis_tac[bi_independent_sym] >>
+      gvs[step_inst_non_invoke] >>
+      drule_all bi_independent_cross_abort >>
+      strip_tac >> gvs[lift_result_def, revert_equiv_def])
+  (* Abort/Abort *)
+  >> gvs[bi_independent_def, step_inst_non_invoke,
+         lift_result_def, revert_equiv_def] >>
+     metis_tac[step_inst_base_abort_returndata,
+               abort_compatible_same_type]
+QED
+
+Resume run_insts_perm_lift_strong[swap_ok_ok]:
+  (* 1. Cross-step OK results — keep bi_independent intact for helpers *)
+  `?s12. step_inst_base y v = OK s12` by
+    metis_tac[bi_ind_cross_step_ok] >>
+  `bi_independent y x` by metis_tac[bi_independent_sym] >>
+  `?s21. step_inst_base x v' = OK s21` by
+    metis_tac[bi_ind_cross_step_ok] >>
+  (* 2. Convert step_inst_base to step_inst using ¬INVOKE from bi_independent *)
+  `y.inst_opcode <> INVOKE /\ x.inst_opcode <> INVOKE` by
+    fs[bi_independent_def] >>
+  `step_inst fuel ctx y v = OK s12` by simp[step_inst_non_invoke] >>
+  `step_inst fuel ctx x v' = OK s21` by simp[step_inst_non_invoke] >>
+  (* 3. No-error transfer: s -> v (through x) -> s12 (through y) *)
+  `EVERY (\i. !e. step_inst fuel ctx i v <> Error e) l1` by
+    (irule bi_ind_list_preserves_no_error >>
+     qexistsl [`s`, `x`] >> simp[]) >>
+  `EVERY (\i. !e. step_inst fuel ctx i s12 <> Error e) l1` by
+    (irule bi_ind_list_preserves_no_error >>
+     qexistsl [`v`, `y`] >> simp[]) >>
+  (* 4. Diamond: s12 = s21, using independent_commute_eq *)
+  `s12 = s21` by
+    (qspecl_then [`fuel`,`ctx`,`x`,`y`,`s`,`v`,`v'`,`s12`,`s21`] mp_tac
+       independent_commute_eq >>
+     (impl_tac >- gvs[bi_independent_def, step_inst_non_invoke]) >>
+     simp[]) >>
+  gvs[]
+QED
+
+Resume run_insts_perm_lift_strong[trans]:
+  rpt strip_tac >>
+  imp_res_tac perm_preserves_pairwise_bi_ind >>
+  `EVERY (\i. !e. step_inst fuel ctx i s <> Error e) l1'` by
+    metis_tac[PERM_EVERY] >>
+  `lift_result $= $= revert_equiv
+     (run_insts fuel ctx l1 s) (run_insts fuel ctx l1' s)` by
+    metis_tac[] >>
+  `lift_result $= $= revert_equiv
+     (run_insts fuel ctx l1' s) (run_insts fuel ctx l2 s)` by
+    metis_tac[] >>
+  irule (SRULE [] lift_result_trans_proof) >>
+  simp[revert_equiv_def] >>
+  qexists `run_insts fuel ctx l1' s` >> simp[]
+QED
+
+Finalise run_insts_perm_lift_strong
+
+
+Theorem run_insts_perm_lift:
+  !l1 l2 fuel ctx s.
+    PERM l1 l2 /\ pairwise_bi_independent l1 /\
+    EVERY (\i. !e. step_inst fuel ctx i s <> Error e) l1 ==>
+    lift_result (=) (=) revert_equiv
+      (run_insts fuel ctx l1 s) (run_insts fuel ctx l2 s)
+Proof
+  metis_tac[run_insts_perm_lift_strong]
+QED
+
+(* ===== Topo-sorted permutation lift_result ===== *)
+
+(* When run_insts aborts, the abort type is determined by some instruction's
+   opcode fail class. This instruction is MEM of the list. *)
+Triviality run_insts_abort_fail_class:
+  !fuel ctx l s a s'.
+    run_insts fuel ctx l s = Abort a s' /\
+    EVERY (\i. ~is_terminator i.inst_opcode /\
+               ~is_ext_call_op i.inst_opcode /\ i.inst_opcode <> INVOKE) l ==>
+    ?i. MEM i l /\ opcode_fail_class i.inst_opcode <> NoFail /\
+        (opcode_fail_class i.inst_opcode = CanRevert ==> a = Revert_abort) /\
+        (opcode_fail_class i.inst_opcode = CanExHalt ==> a = ExHalt_abort)
+Proof
+  gen_tac >> gen_tac >> Induct >> rpt strip_tac >> gvs[run_insts_def] >>
+  gvs[AllCaseEqs(), step_inst_non_invoke]
+  >- ((* Recursive case: head OKs, tail aborts *)
+      first_x_assum $ qspecl_then [`s''`, `a`, `s'`] mp_tac >>
+      simp[] >> strip_tac >> qexists `i` >> simp[])
+  >> ((* Base case: head aborts *)
+      qexists `h` >> simp[] >>
+      conj_tac >- metis_tac[step_inst_nofail_not_halt_abort] >>
+      metis_tac[step_inst_base_abort_type])
+QED
+
+(* When both orderings abort and all non-NoFail instructions are dep-chained,
+   the abort types must match. Argument: the aborters are both non-NoFail,
+   both MEM of the same set (PERM), hence dep-chained, so topo_sorted forces
+   same relative order. The abort type is determined by the fail class of the
+   aborter, and dep-chained non-NoFail instructions that both abort must have
+   abort_compatible fail classes.
+   Simpler: bi_independent (from non-dep) requires abort_compatible, and the
+   chaining hypothesis ensures non-NoFail pairs ARE dep-related. Since the
+   aborter's fail class determines the abort type, and all non-NoFail
+   instructions in l have consistent fail class (being chained), a = a'. *)
+
+(* Case-split approach: OK case by run_insts_topo_equiv (symmetric),
+   non-OK case by structure (no Halt/IntRet, both Abort → revert_equiv).
+   Requires: no Error in either execution (added as hypothesis).
+   The non-NoFail chaining hypothesis ensures abort type consistency. *)
+(* Topo-sorted permutations produce same OK result and revert_equiv Abort.
+   Does NOT claim abort types match — that requires the abort chaining
+   property from build_full_eda, proved at the exec_block level. *)
+Theorem run_insts_topo_lift:
+  !l1 l2 dep fuel ctx s.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> bi_independent x y) /\
+    EVERY (\i. ~is_terminator i.inst_opcode /\
+               ~is_ext_call_op i.inst_opcode /\ i.inst_opcode <> INVOKE) l1 /\
+    (!e. run_insts fuel ctx l1 s <> Error e) /\
+    (!e. run_insts fuel ctx l2 s <> Error e) ==>
+    (* OK case: identical results *)
+    (!r. run_insts fuel ctx l1 s = OK r ==>
+         run_insts fuel ctx l2 s = OK r) /\
+    (!r. run_insts fuel ctx l2 s = OK r ==>
+         run_insts fuel ctx l1 s = OK r) /\
+    (* Same constructor: both OK, both Abort, or both Error *)
+    (?r. run_insts fuel ctx l1 s = OK r) =
+    (?r. run_insts fuel ctx l2 s = OK r) /\
+    (* Abort case: revert_equiv *)
+    (!a1 s1 a2 s2.
+       run_insts fuel ctx l1 s = Abort a1 s1 /\
+       run_insts fuel ctx l2 s = Abort a2 s2 ==>
+       revert_equiv s1 s2)
+Proof
+  rpt gen_tac >> strip_tac >>
+  rpt conj_tac
+  >- suspend "fwd"
+  >- suspend "rev"
+  >- suspend "iff"
+  >> suspend "abort"
+QED
+
+Resume run_insts_topo_lift[fwd]:
+  rpt strip_tac >> irule run_insts_topo_equiv >>
+  qexistsl [`dep`, `l1`] >> simp[]
+QED
+
+Resume run_insts_topo_lift[rev]:
+  rpt strip_tac >> irule run_insts_topo_equiv >>
+  qexistsl [`dep`, `l2`] >> simp[] >>
+  `!x. MEM x l2 <=> MEM x l1` by metis_tac[PERM_MEM_EQ] >>
+  simp[] >> metis_tac[ALL_DISTINCT_PERM, PERM_SYM]
+QED
+
+Resume run_insts_topo_lift[iff]:
+  eq_tac >> rpt strip_tac >> gvs[]
+  >- (`run_insts fuel ctx l2 s = OK r` by
+        (irule run_insts_topo_equiv >>
+         qexistsl [`dep`, `l1`] >> simp[]) >>
+      metis_tac[])
+  >> (`run_insts fuel ctx l1 s = OK r` by
+        (irule run_insts_topo_equiv >>
+         qexistsl [`dep`, `l2`] >> simp[] >>
+         `!x. MEM x l2 <=> MEM x l1` by metis_tac[PERM_MEM_EQ] >>
+         simp[] >> metis_tac[ALL_DISTINCT_PERM, PERM_SYM]) >>
+      metis_tac[])
+QED
+
+Resume run_insts_topo_lift[abort]:
+  rpt strip_tac >> simp[revert_equiv_def] >>
+  `!x. MEM x l2 <=> MEM x l1` by metis_tac[PERM_MEM_EQ] >>
+  `EVERY (\i. ~is_terminator i.inst_opcode /\
+              ~is_ext_call_op i.inst_opcode /\ i.inst_opcode <> INVOKE) l2` by
+    (fs[EVERY_MEM] >> metis_tac[]) >>
+  metis_tac[run_insts_abort_clears_returndata]
+QED
+
+Finalise run_insts_topo_lift
+
+(* Abort type is determined by the non-NoFail instruction that caused it.
+   If all non-NoFail instructions in both permutations are pairwise
+   abort_compatible, any two aborts have the same type. *)
+(* ===== Generalized topo-sorted equivalence ===== *)
+
+(* Parameterized by:
+   - P: symmetric pairwise commutation predicate
+   - Q: per-element property (e.g. inst_wf, ~is_pseudo)
+   - swap: P a b /\ Q a /\ Q b /\ step a ok /\ step b ok ==>
+           exists sb. step b s = OK sb /\ step a sb = OK sab *)
+
+Triviality prefix_commutes_gen:
+  !P prefix x suffix rest dep.
+    PERM (prefix ++ [x] ++ suffix) (x :: rest) /\
+    ALL_DISTINCT (prefix ++ [x] ++ suffix) /\
+    topo_sorted dep (prefix ++ [x] ++ suffix) /\
+    topo_sorted dep (x :: rest) /\
+    (!a b. P a b ==> P b a) /\
+    (!x' y. MEM x' (prefix ++ [x] ++ suffix) /\
+            MEM y (prefix ++ [x] ++ suffix) /\
+            x' <> y /\ ~dep x' y /\ ~dep y x' ==> P x' y) ==>
+    EVERY (P x) prefix
+Proof
+  rw[EVERY_MEM] >>
+  `?k. k < LENGTH prefix /\ e = EL k prefix` by metis_tac[MEM_EL] >> gvs[] >>
+  `ALL_DISTINCT (x :: rest)` by metis_tac[ALL_DISTINCT_PERM] >>
+  `~dep (EL k prefix) x` by
+    (qpat_x_assum `topo_sorted _ (prefix ++ _ ++ _)` mp_tac >>
+     rw[topo_sorted_def] >>
+     first_x_assum (qspecl_then [`k`, `LENGTH prefix`] mp_tac) >>
+     simp[EL_APPEND1, EL_APPEND2]) >>
+  `MEM (EL k prefix) (x :: rest)` by
+    (irule (iffLR PERM_MEM_EQ) >>
+     qexists_tac `prefix ++ [x] ++ suffix` >>
+     simp[MEM_APPEND, MEM_EL]) >>
+  `EL k prefix <> x` by
+    (gvs[ALL_DISTINCT_APPEND] >> metis_tac[MEM_EL]) >>
+  `MEM (EL k prefix) rest` by gvs[MEM] >>
+  `~dep x (EL k prefix)` by
+    (qpat_x_assum `topo_sorted _ (x :: rest)` mp_tac >>
+     rw[topo_sorted_def] >>
+     `?m. m < LENGTH rest /\ EL k prefix = EL m rest` by metis_tac[MEM_EL] >>
+     first_x_assum (qspecl_then [`0`, `SUC m`] mp_tac) >> simp[]) >>
+  first_x_assum irule >> simp[MEM_APPEND]
+QED
+
+Triviality run_insts_bubble_to_front_gen:
+  !P Q prefix fuel ctx x suffix s r.
+    EVERY (P x) prefix /\
+    (!a b s sa sab.
+       P a b /\ Q a /\ Q b /\
+       step_inst fuel ctx a s = OK sa /\
+       step_inst fuel ctx b sa = OK sab ==>
+       ?sb. step_inst fuel ctx b s = OK sb /\
+            step_inst fuel ctx a sb = OK sab) /\
+    (!a b. P a b ==> P b a) /\
+    EVERY Q (x :: prefix) /\
+    run_insts fuel ctx (prefix ++ [x] ++ suffix) s = OK r ==>
+    run_insts fuel ctx ([x] ++ prefix ++ suffix) s = OK r
+Proof
+  Induct_on `prefix` >> simp[] >>
+  rpt strip_tac >> gvs[EVERY_DEF] >>
+  gvs[run_insts_def, AllCaseEqs()] >>
+  rename1 `step_inst fuel ctx h s = OK sh` >>
+  first_x_assum (qspecl_then [`P`, `Q`, `fuel`, `ctx`, `x`,
+                              `suffix`, `sh`, `r`] mp_tac) >>
+  simp[] >> strip_tac >>
+  rename1 `step_inst fuel ctx x sh = OK sx` >>
+  `P h x` by metis_tac[] >>
+  first_x_assum (qspecl_then [`h`, `x`, `s`, `sh`, `sx`] mp_tac) >>
+  simp[] >> strip_tac >>
+  qexists `sb` >> simp[]
+QED
+
+Triviality run_insts_topo_equiv_gen_aux:
+  !P Q n l1 l2 dep fuel ctx s r.
+    LENGTH l2 = n /\
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!a b. P a b ==> P b a) /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> P x y) /\
+    (!a b s sa sab.
+       P a b /\ Q a /\ Q b /\
+       step_inst fuel ctx a s = OK sa /\
+       step_inst fuel ctx b sa = OK sab ==>
+       ?sb. step_inst fuel ctx b s = OK sb /\
+            step_inst fuel ctx a sb = OK sab) /\
+    EVERY Q l1 /\
+    run_insts fuel ctx l1 s = OK r ==>
+    run_insts fuel ctx l2 s = OK r
+Proof
+  Induct_on `n` >> rpt strip_tac
+  >- (gvs[LENGTH_NIL, PERM_NIL, run_insts_def])
+  >>
+  Cases_on `l2` >> gvs[] >>
+  rename1 `PERM l1 (x :: rest)` >>
+  `MEM x l1` by (imp_res_tac PERM_MEM_EQ >> gvs[]) >>
+  pop_assum (strip_assume_tac o REWRITE_RULE[Once MEM_SPLIT]) >>
+  rename1 `l1 = pfx ++ x :: sfx` >>
+  `l1 = pfx ++ [x] ++ sfx` by simp[] >>
+  pop_assum SUBST_ALL_TAC >>
+  qpat_x_assum `_ = pfx ++ _ :: _` kall_tac >>
+  (* Step 1: prefix elements commute with x *)
+  `EVERY (P x) pfx` by
+    (qspecl_then [`P`, `pfx`, `x`, `sfx`, `rest`, `dep`]
+       mp_tac prefix_commutes_gen >> simp[]) >>
+  (* Step 2: bubble x to front *)
+  `EVERY Q (x :: pfx)` by gvs[EVERY_APPEND, EVERY_DEF] >>
+  `run_insts fuel ctx ([x] ++ pfx ++ sfx) s = OK r` by
+    (qspecl_then [`P`, `Q`, `pfx`, `fuel`, `ctx`, `x`, `sfx`, `s`, `r`]
+       mp_tac run_insts_bubble_to_front_gen >>
+     disch_then match_mp_tac >> simp[]) >>
+  (* Step 3: split off head step *)
+  gvs[run_insts_def, AllCaseEqs()] >>
+  rename1 `step_inst fuel ctx x s = OK sx` >>
+  (* Step 4: apply IH to tails *)
+  first_x_assum
+    (qspecl_then [`P`, `Q`, `pfx ++ sfx`, `rest`,
+                  `dep`, `fuel`, `ctx`, `sx`, `r`] mp_tac) >>
+  disch_then match_mp_tac >>
+  gvs[EVERY_APPEND, ALL_DISTINCT_APPEND_3] >>
+  rpt conj_tac
+  >- metis_tac[perm_cons_delete]
+  >- metis_tac[topo_sorted_delete]
+  >- metis_tac[topo_sorted_tail]
+  >> (rpt strip_tac >>
+      qpat_x_assum `!x' y. _ ==> P x' y` match_mp_tac >>
+      gvs[MEM_APPEND])
+QED
+
+Theorem run_insts_topo_equiv_gen:
+  !P Q l1 l2 dep fuel ctx s r.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!a b. P a b ==> P b a) /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> P x y) /\
+    (!a b s sa sab.
+       P a b /\ Q a /\ Q b /\
+       step_inst fuel ctx a s = OK sa /\
+       step_inst fuel ctx b sa = OK sab ==>
+       ?sb. step_inst fuel ctx b s = OK sb /\
+            step_inst fuel ctx a sb = OK sab) /\
+    EVERY Q l1 /\
+    run_insts fuel ctx l1 s = OK r ==>
+    run_insts fuel ctx l2 s = OK r
+Proof
+  rpt strip_tac >>
+  qspecl_then [`P`, `Q`, `LENGTH l2`, `l1`, `l2`, `dep`, `fuel`, `ctx`, `s`, `r`]
+    mp_tac run_insts_topo_equiv_gen_aux >>
+  simp[]
+QED
+
+(* Instantiation: ext_bi_independent version *)
+Theorem run_insts_topo_equiv_ext:
+  !l1 l2 dep fuel ctx s r.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> ext_bi_independent x y) /\
+    EVERY inst_wf l1 /\
+    run_insts fuel ctx l1 s = OK r ==>
+    run_insts fuel ctx l2 s = OK r
+Proof
+  rpt strip_tac >>
+  qspecl_then [`ext_bi_independent`, `inst_wf`, `l1`, `l2`, `dep`,
+               `fuel`, `ctx`, `s`, `r`]
+    mp_tac run_insts_topo_equiv_gen >>
+  simp[] >> metis_tac[ext_bi_independent_sym, step_swap_ok_ext]
+QED
+
+(* from_block gives step_inst equivalence (uses strengthened from_block) *)
+Triviality all_distinct_map_mem_inj:
+  !f l a b. ALL_DISTINCT (MAP f l) /\ MEM a l /\ MEM b l /\
+            f a = f b ==> a = b
+Proof
+  rpt strip_tac >> gvs[MEM_EL] >>
+  metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP, EL_MAP]
+QED
+
+(* Two blocks in fn_blocks with the same label must be equal (under wf_function) *)
+Triviality wf_fn_same_label_eq:
+  !fn bb1 bb2.
+    wf_function fn /\ MEM bb1 fn.fn_blocks /\ MEM bb2 fn.fn_blocks /\
+    bb1.bb_label = bb2.bb_label ==>
+    bb1 = bb2
+Proof
+  rpt strip_tac >> gvs[MEM_EL] >>
+  `ALL_DISTINCT (MAP (\b. b.bb_label) fn.fn_blocks)` by
+    fs[wf_function_def, fn_labels_def] >>
+  `n < LENGTH (MAP (\b. b.bb_label) fn.fn_blocks)` by simp[] >>
+  `n' < LENGTH (MAP (\b. b.bb_label) fn.fn_blocks)` by simp[] >>
+  `EL n (MAP (\b. b.bb_label) fn.fn_blocks) =
+   EL n' (MAP (\b. b.bb_label) fn.fn_blocks)` by simp[EL_MAP] >>
+  `n = n'` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+  gvs[]
+QED
+
+Triviality from_block_step_equiv:
+  !bi i j fuel ctx s.
+    from_block bi i /\ MEM j bi /\ ~is_pseudo j.inst_opcode /\
+    i.inst_id = j.inst_id /\ ALL_DISTINCT (MAP (\x. x.inst_id) bi) ==>
+    step_inst fuel ctx i s = step_inst fuel ctx j s
+Proof
+  rpt strip_tac >> gvs[from_block_def]
+  >- (`i = j` by metis_tac[all_distinct_map_mem_inj] >> gvs[])
+  >> (`j' = j` by metis_tac[all_distinct_map_mem_inj] >>
+      gvs[flip_operands_step_inst])
+QED
+
+(* Core block-level theorem: original block and a block_perm_of variant
+   produce lift_result-equivalent exec_block results.
+   bb must be the original (from fn.fn_blocks); bb' is the variant.
+   bb_well_formed bb' needed because exec_block behavior depends on
+   terminator position — without it, exec_block might exit early.
+   NOTE: Two arbitrary block_perm_of blocks can reorder aborters,
+   giving different abort types. Comparing to original avoids this
+   because abort chaining preserves aborter order. *)
+(* Sub-lemma: extract body (non-pseudo, non-terminator) instructions *)
+(* For a well-formed block, the body is the middle section:
+   instructions = phis ++ body ++ [terminator] *)
+Definition block_body_def:
+  block_body bb =
+    FILTER (\i. ~is_pseudo i.inst_opcode /\ ~is_terminator i.inst_opcode)
+      bb.bb_instructions
+End
+
+(*
+ * Strategy: decompose into helpers, prove each independently.
+ *
+ * Helper 1: eda_non_dep_bi_independent
+ *   If x,y are non-pseudo body instructions in a wf_ssa block, and
+ *   not related by TC(eda_dep) in either direction, then bi_independent x y.
+ *
+ * Helper 2: block_perm_of_run_insts_body_lift
+ *   run_insts on the body of bb and body of bb' produce lift_result
+ *   equivalent results (OK → equal, Abort → revert_equiv).
+ *
+ * Main: compose helpers with exec_block_skip_prefix and
+ *   run_insts_lift_exec_block.
+ *)
+
+(* Helper: execution_equiv {} implies revert_equiv *)
+Triviality execution_equiv_imp_revert_equiv:
+  !s1 s2. execution_equiv {} s1 s2 ==> revert_equiv s1 s2
+Proof
+  rw[execution_equiv_def, revert_equiv_def, state_equiv_def, FDOM_FEMPTY]
+QED
+
+(* Helper: lift_result monotonicity for R_abort weakening *)
+Triviality lift_result_weaken_abort:
+  !R_ok R_term R_abort R_abort' r1 r2.
+    lift_result R_ok R_term R_abort r1 r2 /\
+    (!s1 s2. R_abort s1 s2 ==> R_abort' s1 s2) ==>
+    lift_result R_ok R_term R_abort' r1 r2
+Proof
+  Cases_on `r1` >> Cases_on `r2` >> simp[lift_result_def]
+QED
+
+(* not volatile implies not ext_call and not INVOKE *)
+Triviality not_volatile_imp:
+  !op. ~is_volatile op ==> ~is_ext_call_op op /\ op <> INVOKE
+Proof
+  Cases >> simp[is_volatile_def, is_ext_call_op_def]
+QED
+
+(* not barrier implies not volatile and not alloca *)
+Triviality not_barrier_imp:
+  !inst. ~is_barrier inst ==>
+    ~is_volatile inst.inst_opcode /\ ~is_alloca_op inst.inst_opcode
+Proof
+  rw[is_barrier_def]
+QED
+
+(* ===== run_insts pointwise equivalence ===== *)
+
+(* If two instruction lists have the same step_inst for all states
+   (pointwise), then run_insts produces the same result. *)
+Triviality run_insts_pointwise_equiv:
+  !l1 l2 fuel ctx s.
+    LENGTH l1 = LENGTH l2 /\
+    (!k s'. k < LENGTH l1 ==>
+            step_inst fuel ctx (EL k l1) s' = step_inst fuel ctx (EL k l2) s') ==>
+    run_insts fuel ctx l1 s = run_insts fuel ctx l2 s
+Proof
+  Induct >> simp[run_insts_def] >>
+  rpt gen_tac >> Cases_on `l2` >> simp[run_insts_def] >>
+  strip_tac >>
+  `step_inst fuel ctx h s = step_inst fuel ctx h' s` by
+    (first_x_assum (qspecl_then [`0`, `s`] mp_tac) >> simp[]) >>
+  simp[] >>
+  Cases_on `step_inst fuel ctx h' s` >> simp[] >>
+  first_x_assum irule >> simp[] >>
+  rpt strip_tac >>
+  first_x_assum (qspecl_then [`SUC k`, `s'`] mp_tac) >> simp[]
+QED
+
+(* ===== EDA-level commutativity (wider than ext_bi_independent) ===== *)
+
+(* is_effect_free_op implies not alloca, not ext_call, not INVOKE *)
+Triviality effect_free_not_alloca_ext:
+  !op. is_effect_free_op op ==>
+    ~is_alloca_op op /\ ~is_ext_call_op op /\ op <> INVOKE
+Proof
+  Cases >> simp[is_effect_free_op_def, is_alloca_op_def,
+                is_ext_call_op_def]
+QED
+
+(* EDA-level commutativity: either ext_bi_independent (handles effects_independent)
+   or both effect-free with disjoint defs/uses (handles Eff_MSIZE gap).
+   This is the widest predicate under which two non-pseudo body instructions
+   can be swapped while preserving the OK result. *)
+Definition eda_commutes_def:
+  eda_commutes i1 i2 <=>
+    ext_bi_independent i1 i2 \/
+    (is_effect_free_op i1.inst_opcode /\ is_effect_free_op i2.inst_opcode /\
+     DISJOINT (set (inst_defs i1)) (set (inst_uses i2)) /\
+     DISJOINT (set (inst_defs i2)) (set (inst_uses i1)) /\
+     DISJOINT (set (inst_defs i1)) (set (inst_defs i2)) /\
+     ~is_terminator i1.inst_opcode /\ ~is_terminator i2.inst_opcode)
+End
+
+Triviality eda_commutes_sym:
+  !i1 i2. eda_commutes i1 i2 <=> eda_commutes i2 i1
+Proof
+  rw[eda_commutes_def] >> eq_tac >> strip_tac
+  >- (disj1_tac >> fs[ext_bi_independent_sym])
+  >- (disj2_tac >> fs[inst_defs_def, inst_uses_def, pred_setTheory.DISJOINT_SYM])
+  >- (disj1_tac >> fs[ext_bi_independent_sym])
+  >> (disj2_tac >> fs[inst_defs_def, inst_uses_def, pred_setTheory.DISJOINT_SYM])
+QED
+
+(* Backward transfer for effect-free ops: if a is effect-free and
+   step_inst b succeeds on (step a s), then step_inst b succeeds on s
+   (given disjoint defs/uses). *)
+Triviality effect_free_backward_transfer:
+  !fuel ctx a b s sa sab.
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab /\
+    is_effect_free_op a.inst_opcode /\
+    DISJOINT (set (inst_defs a)) (set (inst_uses b)) /\
+    is_effect_free_op b.inst_opcode /\
+    ~is_terminator b.inst_opcode ==>
+    ?sb. step_inst fuel ctx b s = OK sb
+Proof
+  rpt strip_tac >>
+  imp_res_tac effect_free_not_alloca_ext >>
+  (`step_inst_base b sa = OK sab` by gvs[step_inst_non_invoke]) >>
+  (`state_equiv (set a.inst_outputs) s sa` by
+    metis_tac[step_effect_free_state_equiv]) >>
+  (* Extract field equalities from state_equiv (only 1 state_equiv, safe) *)
+  gvs[state_equiv_def, execution_equiv_def] >>
+  qspecl_then [`b`, `sa`, `sab`, `s`] mp_tac
+    passSharedPropsTheory.step_inst_base_ok_transfer >>
+  simp[] >> strip_tac >>
+  `!op. MEM op b.inst_operands ==> eval_operand op sa = eval_operand op s` by
+    (rpt strip_tac >>
+     Cases_on `op` >> simp[eval_operand_def] >>
+     rename1 `MEM (Var vv) _` >>
+     `~MEM vv a.inst_outputs` by
+       (gvs[inst_defs_def, inst_uses_def,
+            pred_setTheory.DISJOINT_DEF, pred_setTheory.EXTENSION] >>
+        metis_tac[mem_var_operand_vars, listTheory.MEM]) >>
+     first_x_assum (qspec_then `vv` mp_tac) >> simp[]) >>
+  (* Fire the conditional assumption to get ∃v'. step_inst_base b s = OK v' *)
+  first_x_assum drule >>
+  strip_tac >> qexists_tac `v'` >> gvs[step_inst_non_invoke]
+QED
+
+(* Forward transfer: if b is effect-free and step a succeeds on s,
+   then step a also succeeds on (step b s), given disjoint defs/uses. *)
+Triviality effect_free_forward_transfer:
+  !fuel ctx a b s sa sb.
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b s = OK sb /\
+    is_effect_free_op b.inst_opcode /\
+    DISJOINT (set (inst_defs b)) (set (inst_uses a)) /\
+    is_effect_free_op a.inst_opcode /\
+    ~is_terminator a.inst_opcode ==>
+    ?sba. step_inst fuel ctx a sb = OK sba
+Proof
+  rpt strip_tac >>
+  imp_res_tac effect_free_not_alloca_ext >>
+  (`step_inst_base a s = OK sa` by gvs[step_inst_non_invoke]) >>
+  (`state_equiv (set b.inst_outputs) s sb` by
+    metis_tac[step_effect_free_state_equiv]) >>
+  gvs[state_equiv_def, execution_equiv_def] >>
+  qspecl_then [`a`, `s`, `sa`, `sb`] mp_tac
+    passSharedPropsTheory.step_inst_base_ok_transfer >>
+  simp[] >> strip_tac >>
+  `!op. MEM op a.inst_operands ==> eval_operand op s = eval_operand op sb` by
+    (rpt strip_tac >>
+     Cases_on `op` >> simp[eval_operand_def] >>
+     rename1 `MEM (Var vv) _` >>
+     `~MEM vv b.inst_outputs` by
+       (gvs[inst_defs_def, inst_uses_def,
+            pred_setTheory.DISJOINT_DEF, pred_setTheory.EXTENSION] >>
+        metis_tac[mem_var_operand_vars, listTheory.MEM]) >>
+     first_x_assum (qspec_then `vv` mp_tac) >> simp[]) >>
+  first_x_assum drule >>
+  strip_tac >> qexists_tac `v'` >> gvs[step_inst_non_invoke]
+QED
+
+(* The core swap lemma for eda_commutes: if a→b OK, then b→a OK with same result *)
+Triviality step_swap_ok_eda:
+  !fuel ctx a b s sa sab.
+    eda_commutes a b /\
+    inst_wf a /\ inst_wf b /\
+    ~is_pseudo a.inst_opcode /\ ~is_pseudo b.inst_opcode /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  gvs[eda_commutes_def]
+  (* Case 1: ext_bi_independent *)
+  >- (drule_all step_swap_ok_ext >> simp[])
+  (* Case 2: both effect_free with disjoint defs/uses *)
+  >> (
+    (* backward: ∃sb. step b s = OK sb *)
+    qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`sa`,`sab`]
+      strip_assume_tac effect_free_backward_transfer >> gvs[] >>
+    (* forward: ∃sba. step a sb = OK sba *)
+    qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`sa`,`sb`]
+      strip_assume_tac effect_free_forward_transfer >> gvs[] >>
+    (* commute_eq: sba = sab *)
+    qspecl_then [`fuel`, `ctx`, `a`, `b`, `s`, `sa`, `sb`, `sab`, `sba`]
+      mp_tac effect_free_commute_eq >>
+    simp[])
+QED
+
+(* Instantiation: eda_commutes version (requires inst_wf + ~is_pseudo) *)
+Theorem run_insts_topo_equiv_eda:
+  !l1 l2 dep fuel ctx s r.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> eda_commutes x y) /\
+    EVERY inst_wf l1 /\
+    EVERY (\i. ~is_pseudo i.inst_opcode) l1 /\
+    run_insts fuel ctx l1 s = OK r ==>
+    run_insts fuel ctx l2 s = OK r
+Proof
+  rpt strip_tac >>
+  qspecl_then [`eda_commutes`,
+               `\i. inst_wf i /\ ~is_pseudo i.inst_opcode`,
+               `l1`, `l2`, `dep`, `fuel`, `ctx`, `s`, `r`]
+    mp_tac run_insts_topo_equiv_gen >>
+  simp[EVERY_MEM] >> disch_then match_mp_tac >>
+  rpt strip_tac
+  >- metis_tac[eda_commutes_sym]
+  >- metis_tac[step_swap_ok_eda]
+  >> gvs[EVERY_MEM]
+QED
+
+(* ===== Block body lift_result ===== *)
+
+(* Helper: block_perm_of with matching label resolves to bb *)
+Triviality block_perm_of_resolves:
+  !fn bb bb'.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label ==>
+    FILTER (\i. is_pseudo i.inst_opcode) bb'.bb_instructions =
+    FILTER (\i. is_pseudo i.inst_opcode) bb.bb_instructions /\
+    EVERY (\i. from_block bb.bb_instructions i)
+      (FILTER (\i. ~is_pseudo i.inst_opcode) bb'.bb_instructions)
+Proof
+  rpt strip_tac >> gvs[block_perm_of_def] >>
+  `bb_orig = bb` by
+    (gvs[wf_function_def, fn_labels_def] >>
+     `lookup_block bb.bb_label fn.fn_blocks = SOME bb` by
+       (irule venomExecPropsTheory.MEM_lookup_block >> simp[]) >>
+     `lookup_block bb.bb_label fn.fn_blocks = SOME bb_orig` by
+       (irule venomExecPropsTheory.MEM_lookup_block >> simp[]) >>
+     gvs[]) >>
+  pop_assum SUBST_ALL_TAC >> gvs[]
+QED
+
+(* Helper: run_insts on body of bb' equals run_insts on body of bb
+   when both OK (no Error case needed for OK). *)
+Triviality from_block_step_inst_equiv:
+  !bi i. from_block bi i ==>
+    ?j. MEM j bi /\ ~is_pseudo j.inst_opcode /\
+        i.inst_id = j.inst_id /\
+        !fuel ctx s. step_inst fuel ctx i s = step_inst fuel ctx j s
+Proof
+  rw[from_block_def]
+  >- (qexists_tac `i` >> simp[])
+  >> qexists_tac `j` >> simp[flip_operands_inst_id, flip_operands_step_inst]
+QED
+
+(* Key: from_block instructions produce identical step_inst results, so
+   run_insts on a from_block permutation = run_insts on originals in
+   the same order. We reduce to run_insts_topo_equiv_eda via an
+   intermediate "originals" list constructed by Hilbert choice. *)
+Triviality flip_operands_not_terminator:
+  !i. ~is_terminator (flip_operands i).inst_opcode ==>
+    ~is_terminator i.inst_opcode
+Proof
+  rw[flip_operands_def] >> every_case_tac >> gvs[] >>
+  gvs[is_terminator_def, passSharedDefsTheory.is_comparator_def,
+      passSharedDefsTheory.flip_comparison_opcode_def]
+QED
+
+Triviality from_block_not_terminator:
+  !bi i. from_block bi i /\ ~is_terminator i.inst_opcode ==>
+    ?j. MEM j bi /\ ~is_pseudo j.inst_opcode /\
+        ~is_terminator j.inst_opcode /\
+        i.inst_id = j.inst_id /\
+        !fuel ctx s. step_inst fuel ctx i s = step_inst fuel ctx j s
+Proof
+  rw[from_block_def]
+  >- (qexists_tac `i` >> simp[])
+  >> qexists_tac `j` >> simp[flip_operands_inst_id, flip_operands_step_inst] >>
+  metis_tac[flip_operands_not_terminator]
+QED
+
+(* Choose an original instruction from l1 for each instruction in l2 *)
+Definition choose_original_def:
+  choose_original l1 i = @j. MEM j l1 /\ j.inst_id = i.inst_id
+End
+
+Triviality choose_original_correct:
+  !l1 i j.
+    MEM j l1 /\ j.inst_id = i.inst_id ==>
+    MEM (choose_original l1 i) l1 /\
+    (choose_original l1 i).inst_id = i.inst_id
+Proof
+  rw[choose_original_def] >> SELECT_ELIM_TAC >> metis_tac[]
+QED
+
+Triviality choose_original_unique:
+  !l1 i j.
+    MEM j l1 /\ j.inst_id = i.inst_id /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) l1) ==>
+    choose_original l1 i = j
+Proof
+  rw[choose_original_def] >> SELECT_ELIM_TAC >>
+  conj_tac >- metis_tac[] >>
+  rpt strip_tac >>
+  metis_tac[all_distinct_map_mem_inj]
+QED
+
+(* EDA dependency relation: x depends on y iff some inst with y's inst_id
+   is in x's dep list. Defined via inst_ids for transferability. *)
+Definition eda_dep_def:
+  eda_dep eda x y <=>
+    ?d. MEM d (case FLOOKUP eda x.inst_id of NONE => [] | SOME ds => ds) /\
+        d.inst_id = y.inst_id
+End
+
+(* eda_topo_compatible implies topo_sorted for non-pseudo instructions *)
+Triviality eda_topo_compatible_topo_sorted:
+  !bi eda order.
+    eda_topo_compatible bi eda order /\
+    eda_wf eda bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    topo_sorted (eda_dep eda)
+      (FILTER (\i. ~is_pseudo i.inst_opcode /\ ~is_terminator i.inst_opcode) bi)
+Proof
+  rw[topo_sorted_def, eda_dep_def] >>
+  qabbrev_tac `fl = FILTER (\i. ~is_pseudo i.inst_opcode /\
+                                 ~is_terminator i.inst_opcode) bi` >>
+  spose_not_then strip_assume_tac >>
+  (* d witnesses the eda_dep: MEM d (FLOOKUP eda fl[i].inst_id), d.inst_id = fl[j].inst_id *)
+  (* d is MEM bi and non-pseudo from eda_wf *)
+  `MEM d bi /\ ~is_pseudo d.inst_opcode` by
+    (fs[eda_wf_def] >>
+     Cases_on `FLOOKUP eda (EL i fl).inst_id` >> gvs[] >>
+     metis_tac[]) >>
+  (* fl elements are in bi *)
+  `MEM (EL j fl) bi` by
+    (`MEM (EL j fl) fl` by (simp[MEM_EL] >> qexists `j` >> simp[]) >>
+     fs[Abbr `fl`, MEM_FILTER]) >>
+  (* d = fl[j] by ALL_DISTINCT inst_ids *)
+  `d = EL j fl` by metis_tac[all_distinct_map_mem_inj] >>
+  (* fl[i] is MEM bi and non-pseudo *)
+  `MEM (EL i fl) bi /\ ~is_pseudo (EL i fl).inst_opcode` by
+    (`MEM (EL i fl) fl` by (simp[MEM_EL] >> qexists `i` >> simp[]) >>
+     fs[Abbr `fl`, MEM_FILTER]) >>
+  (* fl[j] is in inst_all_deps of fl[i] (via eda deps) *)
+  `MEM (EL j fl) (inst_all_deps bi order eda (EL i fl))` by
+    (simp[inst_all_deps_def, LET_THM, MEM_nub] >>
+     Cases_on `FLOOKUP eda (EL i fl).inst_id` >> gvs[]) >>
+  (* eda_topo_compatible: dep fl[j] before inst fl[i] in bi *)
+  `?p q. p < q /\ q < LENGTH bi /\ p < LENGTH bi /\
+         EL p bi = EL j fl /\ EL q bi = EL i fl` by
+    (fs[eda_topo_compatible_def] >>
+     first_x_assum (qspecl_then [`EL i fl`, `EL j fl`] mp_tac) >>
+     simp[]) >>
+  (* filter_el_mono: fl[i] before fl[j] in bi *)
+  `?a b. a < b /\ b < LENGTH bi /\
+         EL a bi = EL i fl /\ EL b bi = EL j fl` by
+    (qspecl_then [`\i. ~is_pseudo i.inst_opcode /\ ~is_terminator i.inst_opcode`,
+                  `bi`, `i`, `j`] mp_tac filter_el_mono >>
+     simp[Abbr `fl`]) >>
+  (* ALL_DISTINCT: bi[a] = bi[q] = fl[i], bi[b] = bi[p] = fl[j] *)
+  `a = q /\ b = p` by
+    (`a < LENGTH bi` by simp[] >>
+     `EL a (MAP (\i. i.inst_id) bi) = EL q (MAP (\i. i.inst_id) bi)` by
+       simp[EL_MAP] >>
+     `EL b (MAP (\i. i.inst_id) bi) = EL p (MAP (\i. i.inst_id) bi)` by
+       simp[EL_MAP] >>
+     metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP]) >>
+  (* a < b = p < q = a — contradiction *)
+  simp[]
+QED
+
+(* Combined dependency: eda + data deps + output aliasing.
+   full_dep eda x y means "x depends on y" = "y must come before x" *)
+Definition full_dep_def:
+  full_dep eda x y <=>
+    eda_dep eda x y \/
+    ~DISJOINT (set (inst_uses x)) (set (inst_defs y)) \/
+    ~DISJOINT (set (inst_defs x)) (set (inst_defs y))
+End
+
+(* Strengthen topo_sorted with additional dep *)
+Triviality topo_sorted_strengthen:
+  !dep1 dep2 l.
+    topo_sorted dep1 l /\
+    (!i j. i < j /\ j < LENGTH l ==> ~dep2 (EL i l) (EL j l)) ==>
+    topo_sorted (\x y. dep1 x y \/ dep2 x y) l
+Proof
+  rw[topo_sorted_def] >> metis_tac[]
+QED
+
+(* full_non_dep_commutes is FALSE in general (intervening writer scenario:
+   MSTORE_A, MSTORE_B, MLOAD_C — no direct full_dep between A and C, but
+   ~eda_commutes since ~effects_independent MSTORE MLOAD).
+   We need TC (transitive closure) of full_dep to rule this out. *)
+
+(* topo_sorted is preserved by transitive closure when dep is closed on l
+   and l has no duplicates. Each dep step decreases position index;
+   a TC chain from pos i can only reach positions ≤ i, contradicting j > i. *)
+(* Helper: TC chain decreases position in a topo-sorted list *)
+Triviality tc_decreases_position:
+  !dep a b.
+    TC dep a b ==>
+    !l k.
+      topo_sorted dep l /\
+      (!x y. dep x y ==> MEM x l /\ MEM y l) /\
+      k < LENGTH l /\ a = EL k l ==>
+      ?m. m <= k /\ m < LENGTH l /\ b = EL m l
+Proof
+  gen_tac >> ho_match_mp_tac TC_INDUCT_RIGHT1 >> rpt conj_tac
+  (* Base: dep a b *)
+  >- (rpt strip_tac >>
+      `MEM b l` by
+        (qpat_x_assum `!x y. dep x y ==> _`
+           (qspecl_then [`a`,`b`] mp_tac) >> simp[]) >>
+      pop_assum (strip_assume_tac o REWRITE_RULE [MEM_EL]) >>
+      rename1 `b = EL nb l` >>
+      qexists `nb` >> simp[] >>
+      spose_not_then assume_tac >>
+      `k < nb` by simp[] >>
+      fs[topo_sorted_def])
+  (* Step: TC dep a b, dep b b' — IH gives b at pos mc <= k *)
+  >> rpt strip_tac >>
+     first_x_assum (qspecl_then [`l`, `k`] mp_tac) >>
+     (impl_tac >- (simp[] >> first_assum ACCEPT_TAC)) >> strip_tac >>
+     rename1 `b = EL mc l` >>
+     `MEM b' l` by
+       (qpat_x_assum `!x y. dep x y ==> _`
+          (qspecl_then [`b`,`b'`] mp_tac) >> simp[]) >>
+     pop_assum (strip_assume_tac o REWRITE_RULE [MEM_EL]) >>
+     rename1 `b' = EL mb l` >>
+     qexists `mb` >> simp[] >>
+     spose_not_then assume_tac >>
+     `mc < mb` by simp[] >>
+     fs[topo_sorted_def]
+QED
+
+Triviality topo_sorted_tc_closed:
+  !dep l.
+    topo_sorted dep l /\ ALL_DISTINCT l /\
+    (!x y. dep x y ==> MEM x l /\ MEM y l) ==>
+    topo_sorted (TC dep) l
+Proof
+  rw[topo_sorted_def] >>
+  spose_not_then strip_assume_tac >>
+  drule tc_decreases_position >>
+  disch_then (qspecl_then [`l`, `i`] mp_tac) >>
+  (impl_tac >- (simp[topo_sorted_def] >> first_assum ACCEPT_TAC)) >>
+  strip_tac >>
+  (* m ≤ i < j, m < LENGTH l, j < LENGTH l, l[j] = l[m], ALL_DISTINCT l *)
+  `m = j` by
+    (qspecl_then [`l`,`m`,`j`] mp_tac ALL_DISTINCT_EL_IMP >>
+     simp[]) >>
+  simp[]
+QED
+
+(* Every non-pseudo, non-terminator opcode is either effect_free or a barrier *)
+Triviality effect_free_or_barrier:
+  !i. ~is_pseudo i.inst_opcode /\ ~is_terminator i.inst_opcode ==>
+      is_effect_free_op i.inst_opcode \/ is_barrier i
+Proof
+  rpt strip_tac >> Cases_on `i.inst_opcode` >>
+  gvs[is_effect_free_op_def, is_barrier_def,
+      is_volatile_def, is_alloca_op_def, is_pseudo_def, is_terminator_def]
+QED
+
+(* If both non-pseudo, non-terminator, and BOTH effect_free (hence
+   non-barrier), and ~full_dep in both directions → eda_commutes
+   via the effect_free disjunct *)
+Triviality effect_free_non_dep_commutes:
+  !eda x y.
+    is_effect_free_op x.inst_opcode /\ is_effect_free_op y.inst_opcode /\
+    ~is_terminator x.inst_opcode /\ ~is_terminator y.inst_opcode /\
+    ~full_dep eda x y /\ ~full_dep eda y x ==>
+    eda_commutes x y
+Proof
+  rw[full_dep_def, eda_commutes_def] >>
+  disj2_tac >> gvs[pred_setTheory.DISJOINT_SYM]
+QED
+
+(* ===== Barrier TC connectivity ===== *)
+
+(* Subsequent EDA passes are monotone: add_chain_deps, add_barrier_deps, etc.
+   only add entries, never remove existing deps. *)
+
+(* FOLDL (\ds p. if MEM p ds then ds else p :: ds) preserves existing members *)
+Triviality foldl_add_preserves_mem:
+  !ps ds x. MEM x ds ==>
+    MEM x (FOLDL (\ds p. if MEM p ds then ds else p :: ds) ds ps)
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  first_x_assum irule >>
+  IF_CASES_TAC >> simp[]
+QED
+
+(* add_deps_from_barrier preserves existing deps — let-expanded FOLDL body *)
+Triviality add_deps_from_barrier_foldl_mono:
+  !non_phis acc prev_insts id d.
+    MEM d (case FLOOKUP acc id of NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (FST (FOLDL (\(acc, prev_insts) inst.
+      if is_barrier inst then
+        (acc |+ (inst.inst_id,
+           FOLDL (\ds p. if MEM p ds then ds else p :: ds)
+             (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+             prev_insts), prev_insts ++ [inst])
+      else
+        (acc, prev_insts ++ [inst]))
+    (acc, prev_insts) non_phis)) id of NONE => [] | SOME ds => ds)
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  Cases_on `is_barrier h` >> gvs[] >>
+  first_x_assum irule >>
+  Cases_on `h.inst_id = id` >> simp[FLOOKUP_UPDATE] >>
+  irule foldl_add_preserves_mem >>
+  Cases_on `FLOOKUP acc id` >> gvs[]
+QED
+
+Triviality add_deps_from_barrier_mono:
+  !bi eda id d.
+    MEM d (case FLOOKUP eda id of NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (add_deps_from_barrier bi eda) id of
+             NONE => [] | SOME ds => ds)
+Proof
+  rw[add_deps_from_barrier_def, LET_THM] >>
+  irule add_deps_from_barrier_foldl_mono >> simp[]
+QED
+
+(* add_deps_on_barrier: let-expanded FOLDL mono *)
+Triviality add_deps_on_barrier_foldl_mono:
+  !non_phis acc last_bar id d.
+    MEM d (case FLOOKUP acc id of NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (FST (FOLDL (\(acc, last_bar) inst.
+      if is_barrier inst then
+        (acc, SOME inst)
+      else
+        (acc |+ (inst.inst_id,
+           case last_bar of
+             NONE => (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+           | SOME b =>
+               if MEM b (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+               then (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+               else b :: (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)),
+         last_bar))
+    (acc, last_bar) non_phis)) id of NONE => [] | SOME ds => ds)
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  Cases_on `is_barrier h` >> gvs[] >>
+  first_x_assum irule >>
+  Cases_on `h.inst_id = id` >> simp[FLOOKUP_UPDATE] >>
+  Cases_on `last_bar` >> simp[] >>
+  IF_CASES_TAC >> simp[] >>
+  Cases_on `FLOOKUP acc id` >> gvs[]
+QED
+
+Triviality add_deps_on_barrier_mono:
+  !bi eda id d.
+    MEM d (case FLOOKUP eda id of NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (add_deps_on_barrier bi eda) id of
+             NONE => [] | SOME ds => ds)
+Proof
+  rw[add_deps_on_barrier_def, LET_THM] >>
+  irule add_deps_on_barrier_foldl_mono >> simp[]
+QED
+
+(* add_chain_deps: let-expanded FOLDL mono *)
+Triviality add_chain_deps_foldl_mono:
+  !matching acc prev id d.
+    MEM d (case FLOOKUP acc id of NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (FST (FOLDL (\(acc, prev) inst.
+      (acc |+ (inst.inst_id,
+         case prev of
+           NONE => (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+         | SOME p =>
+             if MEM p (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+             then (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+             else p :: (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)),
+       SOME inst))
+    (acc, prev) matching)) id of NONE => [] | SOME ds => ds)
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  first_x_assum irule >>
+  Cases_on `h.inst_id = id` >> simp[FLOOKUP_UPDATE] >>
+  Cases_on `prev` >> simp[] >>
+  IF_CASES_TAC >> simp[] >>
+  Cases_on `FLOOKUP acc id` >> gvs[]
+QED
+
+Triviality add_chain_deps_mono:
+  !P bi eda id d.
+    MEM d (case FLOOKUP eda id of NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (add_chain_deps P bi eda) id of
+             NONE => [] | SOME ds => ds)
+Proof
+  rw[add_chain_deps_def, LET_THM] >>
+  irule add_chain_deps_foldl_mono >> simp[]
+QED
+
+(* build_full_eda is monotone over add_barrier_deps *)
+Triviality build_full_eda_mono_barrier:
+  !bi id d.
+    MEM d (case FLOOKUP (add_barrier_deps bi (add_abort_deps bi (build_eda bi))) id of
+             NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (build_full_eda bi) id of NONE => [] | SOME ds => ds)
+Proof
+  rw[build_full_eda_def, add_alloca_deps_def] >>
+  irule add_chain_deps_mono >> simp[]
+QED
+
+(* Combined: add_deps_from_barrier result survives to build_full_eda *)
+Triviality build_full_eda_mono_from_barrier:
+  !bi id d.
+    MEM d (case FLOOKUP
+      (add_deps_from_barrier bi
+        (add_deps_on_barrier bi
+          (add_abort_deps bi (build_eda bi)))) id of
+             NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (build_full_eda bi) id of NONE => [] | SOME ds => ds)
+Proof
+  rw[build_full_eda_def, add_barrier_deps_def, add_alloca_deps_def] >>
+  irule add_chain_deps_mono >> simp[]
+QED
+
+(* add_deps_on_barrier result survives through add_deps_from_barrier to build_full_eda *)
+Triviality build_full_eda_mono_on_barrier:
+  !bi id d.
+    MEM d (case FLOOKUP
+      (add_deps_on_barrier bi
+        (add_abort_deps bi (build_eda bi))) id of
+             NONE => [] | SOME ds => ds) ==>
+    MEM d (case FLOOKUP (build_full_eda bi) id of NONE => [] | SOME ds => ds)
+Proof
+  rpt strip_tac >> irule build_full_eda_mono_from_barrier >>
+  irule add_deps_from_barrier_mono >> simp[]
+QED
+
+(* ===== FOLDL add_if_absent: prev members end up in result ===== *)
+Triviality foldl_add_includes_prev:
+  !ps ds x. MEM x ps ==>
+    MEM x (FOLDL (\ds p. if MEM p ds then ds else p :: ds) ds ps)
+Proof
+  Induct >> simp[] >> rpt strip_tac >> gvs[]
+  >- (Cases_on `MEM h ds` >> simp[foldl_add_preserves_mem])
+  >> first_x_assum irule >> simp[]
+QED
+
+(* ===== add_deps_from_barrier spec: barrier gets deps on all preceding ===== *)
+
+(* Helper: FOLDL prev_insts accumulates all processed elements *)
+Triviality from_barrier_snd_accumulates:
+  !non_phis acc prev_insts.
+    SND (FOLDL (\(acc, prev_insts) inst.
+      if is_barrier inst then
+        (acc |+ (inst.inst_id,
+           FOLDL (\ds p. if MEM p ds then ds else p :: ds)
+             (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+             prev_insts), prev_insts ++ [inst])
+      else (acc, prev_insts ++ [inst]))
+    (acc, prev_insts) non_phis) = prev_insts ++ non_phis
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  Cases_on `is_barrier h` >> simp[]
+QED
+
+(* Helper: barrier x gets all prev_insts when processed *)
+Triviality from_barrier_at_barrier:
+  !non_phis acc prev_insts x suffix.
+    non_phis = x :: suffix /\ is_barrier x ==>
+    !y. MEM y prev_insts ==>
+    MEM y (case FLOOKUP (FST (FOLDL (\(acc, prev_insts) inst.
+      if is_barrier inst then
+        (acc |+ (inst.inst_id,
+           FOLDL (\ds p. if MEM p ds then ds else p :: ds)
+             (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+             prev_insts), prev_insts ++ [inst])
+      else (acc, prev_insts ++ [inst]))
+    (acc, prev_insts) non_phis)) x.inst_id of NONE => [] | SOME ds => ds)
+Proof
+  rpt strip_tac >> gvs[] >> simp[FOLDL] >>
+  irule add_deps_from_barrier_foldl_mono >>
+  simp[FLOOKUP_UPDATE] >>
+  irule foldl_add_includes_prev >> simp[]
+QED
+
+(* Main spec: after processing, barrier x has all preceding non-phis as deps.
+   Split-based formulation: non_phis = prefix ++ [x] ++ suffix *)
+Triviality add_deps_from_barrier_foldl_spec:
+  !prefix x suffix acc prev_insts.
+    ALL_DISTINCT (MAP (\i. i.inst_id) (prev_insts ++ prefix ++ [x] ++ suffix)) /\
+    is_barrier x ==>
+    !y. MEM y (prev_insts ++ prefix) ==>
+    MEM y (case FLOOKUP (FST (FOLDL (\(acc, prev_insts) inst.
+      if is_barrier inst then
+        (acc |+ (inst.inst_id,
+           FOLDL (\ds p. if MEM p ds then ds else p :: ds)
+             (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+             prev_insts), prev_insts ++ [inst])
+      else (acc, prev_insts ++ [inst]))
+    (acc, prev_insts) (prefix ++ [x] ++ suffix))) x.inst_id of
+      NONE => [] | SOME ds => ds)
+Proof
+  Induct >> rpt strip_tac
+  >- suspend "base"
+  >> suspend "step"
+QED
+
+Resume add_deps_from_barrier_foldl_spec[base]:
+  gvs[] >>
+  irule (SRULE [] from_barrier_at_barrier) >> simp[]
+QED
+
+Resume add_deps_from_barrier_foldl_spec[step]:
+  (* Unfold one FOLDL step for h, then apply IH.
+     Both barrier/non-barrier cases: prev_insts becomes prev_insts ++ [h],
+     acc may change. IH universally quantifies both. *)
+  simp[FOLDL] >>
+  Cases_on `is_barrier h` >> simp[] >> (
+    (* In both cases, apply IH with prev_insts := prev_insts ++ [h] *)
+    first_x_assum irule >> simp[] >>
+    fs[ALL_DISTINCT_APPEND, MAP_APPEND, MEM_MAP, MEM_APPEND] >>
+    metis_tac[])
+QED
+
+Finalise add_deps_from_barrier_foldl_spec
+
+(* ===== add_deps_on_barrier spec ===== *)
+
+(* Helper: SND of add_deps_on_barrier's FOLDL tracks last_bar.
+   After processing a list, last_bar = last barrier in list (or initial). *)
+Triviality on_barrier_snd_last_bar:
+  !non_phis acc last_bar.
+    SND (FOLDL (\(acc, last_bar) inst.
+      if is_barrier inst then (acc, SOME inst)
+      else (acc |+ (inst.inst_id,
+              case last_bar of
+                NONE => (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+              | SOME b =>
+                  if MEM b (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+                  then (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+                  else b :: (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)),
+           last_bar))
+    (acc, last_bar) non_phis) =
+    case FILTER is_barrier non_phis of
+      [] => last_bar
+    | bs => SOME (LAST bs)
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  Cases_on `is_barrier h` >> simp[] >>
+  Cases_on `FILTER is_barrier non_phis` >> simp[]
+QED
+
+(* Helper: when processing non-barrier x with last_bar = SOME b,
+   b ends up in x's deps in the result acc *)
+Triviality on_barrier_at_inst:
+  !x suffix acc b.
+    ~is_barrier x ==>
+    MEM b (case FLOOKUP (FST (FOLDL (\(acc, last_bar) inst.
+      if is_barrier inst then (acc, SOME inst)
+      else (acc |+ (inst.inst_id,
+              case last_bar of
+                NONE => (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+              | SOME b =>
+                  if MEM b (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+                  then (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+                  else b :: (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)),
+           last_bar))
+    (acc, SOME b) (x :: suffix))) x.inst_id of NONE => [] | SOME ds => ds)
+Proof
+  rpt strip_tac >> simp[FOLDL] >>
+  irule add_deps_on_barrier_foldl_mono >>
+  simp[FLOOKUP_UPDATE] >>
+  Cases_on `MEM b (case FLOOKUP acc x.inst_id of NONE => [] | SOME ds => ds)` >>
+  simp[]
+QED
+
+(* Main spec: if prefix contains a barrier and x is non-barrier,
+   then the last barrier in prefix is in x's deps.
+   FOLDL processes prefix ++ [x] ++ suffix starting with (acc, last_bar_init). *)
+Triviality add_deps_on_barrier_foldl_spec:
+  !prefix x suffix acc last_bar_init b.
+    ALL_DISTINCT (MAP (\i. i.inst_id) (prefix ++ [x] ++ suffix)) /\
+    ~is_barrier x /\
+    (case FILTER is_barrier prefix of
+       [] => last_bar_init = SOME b
+     | bs => LAST bs = b) ==>
+    MEM b (case FLOOKUP (FST (FOLDL (\(acc, last_bar) inst.
+      if is_barrier inst then (acc, SOME inst)
+      else (acc |+ (inst.inst_id,
+              case last_bar of
+                NONE => (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+              | SOME b =>
+                  if MEM b (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+                  then (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+                  else b :: (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)),
+           last_bar))
+    (acc, last_bar_init) (prefix ++ [x] ++ suffix))) x.inst_id of
+      NONE => [] | SOME ds => ds)
+Proof
+  Induct >> rpt strip_tac
+  >- ((* Base: prefix = [], last_bar_init = SOME b *)
+      gvs[] >>
+      qspecl_then [`x`, `suffix`, `acc`, `b`] mp_tac on_barrier_at_inst >>
+      simp[])
+  >> ((* Step: unfold one FOLDL step for h, apply IH *)
+      Cases_on `is_barrier h` >> gvs[FILTER] >>
+      simp[FOLDL] >>
+      first_x_assum irule >> simp[] >>
+      fs[ALL_DISTINCT_APPEND, MAP_APPEND, MEM_MAP, MEM_APPEND] >>
+      Cases_on `FILTER is_barrier prefix` >> simp[])
+QED
+
+(* MAP choose_original preserves PERM of inst_ids *)
+Triviality map_choose_original_perm:
+  !l1 l2.
+    PERM (MAP (\i. i.inst_id) l1) (MAP (\i. i.inst_id) l2) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) l1) /\
+    (!i. MEM i l2 ==> ?j. MEM j l1 /\ j.inst_id = i.inst_id) ==>
+    PERM l1 (MAP (choose_original l1) l2)
+Proof
+  rpt strip_tac >>
+  MATCH_MP_TAC PERM_ALL_DISTINCT >> rpt conj_tac
+  >- suspend "ad_l1"
+  >- suspend "ad_map"
+  >> suspend "mem_eq"
+QED
+
+Resume map_choose_original_perm[ad_l1]:
+  metis_tac[ALL_DISTINCT_MAP]
+QED
+
+Resume map_choose_original_perm[ad_map]:
+  (`ALL_DISTINCT (MAP (\i. i.inst_id) l2)` by
+    metis_tac[ALL_DISTINCT_PERM]) >>
+  (`ALL_DISTINCT l2` by metis_tac[ALL_DISTINCT_MAP]) >>
+  irule ALL_DISTINCT_MAP_INJ >> conj_tac
+  >- (rpt strip_tac >>
+      `(choose_original l1 x).inst_id = x.inst_id` by
+        (irule (cj 2 choose_original_correct) >> metis_tac[]) >>
+      `(choose_original l1 y).inst_id = y.inst_id` by
+        (irule (cj 2 choose_original_correct) >> metis_tac[]) >>
+      `x.inst_id = y.inst_id` by metis_tac[] >>
+      metis_tac[all_distinct_map_mem_inj])
+  >- simp[]
+QED
+
+Resume map_choose_original_perm[mem_eq]:
+  gen_tac >> eq_tac >> strip_tac
+  >- suspend "fwd"
+  >> suspend "bwd"
+QED
+
+Resume map_choose_original_perm[fwd]:
+  (* MEM x l1 → MEM x (MAP (choose_original l1) l2) *)
+  simp[MEM_MAP] >>
+  drule PERM_MEM_EQ >>
+  disch_then (qspec_then `x.inst_id` mp_tac) >>
+  simp[MEM_MAP] >>
+  disch_then (mp_tac o #1 o EQ_IMP_RULE) >>
+  (impl_tac >- (qexists `x` >> simp[])) >>
+  strip_tac >> rename1 `MEM z l2` >>
+  qexists `z` >> conj_tac >- metis_tac[choose_original_unique] >>
+  simp[]
+QED
+
+Resume map_choose_original_perm[bwd]:
+  (* MEM x (MAP (choose_original l1) l2) → MEM x l1 *)
+  fs[MEM_MAP] >> metis_tac[choose_original_correct]
+QED
+
+Finalise map_choose_original_perm
+
+(* MAP choose_original gives pointwise step_inst equivalence *)
+Triviality map_choose_original_step_equiv:
+  !l1 l2 fuel ctx.
+    ALL_DISTINCT (MAP (\i. i.inst_id) l1) /\
+    (!i. MEM i l2 ==>
+      ?j. MEM j l1 /\ j.inst_id = i.inst_id /\
+          !fuel ctx s. step_inst fuel ctx i s = step_inst fuel ctx j s) ==>
+    !k s. k < LENGTH l2 ==>
+      step_inst fuel ctx (EL k l2) s =
+      step_inst fuel ctx (EL k (MAP (choose_original l1) l2)) s
+Proof
+  rpt strip_tac >>
+  simp[EL_MAP] >>
+  `MEM (EL k l2) l2` by metis_tac[MEM_EL] >>
+  res_tac >> rename1 `MEM j l1` >>
+  `choose_original l1 (EL k l2) = j` by
+    (irule choose_original_unique >> metis_tac[]) >>
+  metis_tac[]
+QED
+
+(* topo_sorted transfers through choose_original mapping *)
+Triviality map_choose_original_topo_sorted:
+  !l1 l2 dep.
+    ALL_DISTINCT (MAP (\i. i.inst_id) l1) /\
+    topo_sorted dep l2 /\
+    (!i. MEM i l2 ==> ?j. MEM j l1 /\ j.inst_id = i.inst_id) /\
+    (* dep only depends on inst_id *)
+    (!x y x' y'. x.inst_id = x'.inst_id /\ y.inst_id = y'.inst_id ==>
+       (dep x y <=> dep x' y')) ==>
+    topo_sorted dep (MAP (choose_original l1) l2)
+Proof
+  rw[topo_sorted_def, LENGTH_MAP] >>
+  simp[EL_MAP] >>
+  `MEM (EL i l2) l2` by (simp[MEM_EL] >> qexists `i` >> simp[]) >>
+  `MEM (EL j l2) l2` by (simp[MEM_EL] >> qexists `j` >> simp[]) >>
+  `(choose_original l1 (EL i l2)).inst_id = (EL i l2).inst_id` by
+    (irule (cj 2 choose_original_correct) >> metis_tac[]) >>
+  `(choose_original l1 (EL j l2)).inst_id = (EL j l2).inst_id` by
+    (irule (cj 2 choose_original_correct) >> metis_tac[]) >>
+  metis_tac[]
+QED
+
+(* eda_dep only depends on inst_id *)
+Triviality eda_dep_inst_id_only:
+  !eda x y x' y'.
+    x.inst_id = x'.inst_id /\ y.inst_id = y'.inst_id ==>
+    (eda_dep eda x y <=> eda_dep eda x' y')
+Proof
+  rw[eda_dep_def]
+QED
+
+(* Effect-free swap: no inst_wf needed. If both effect-free with disjoint
+   defs/uses, step a→b OK implies step b→a OK with same result. *)
+Triviality step_swap_ok_effect_free:
+  !fuel ctx a b s sa sab.
+    is_effect_free_op a.inst_opcode /\ is_effect_free_op b.inst_opcode /\
+    ~is_terminator a.inst_opcode /\ ~is_terminator b.inst_opcode /\
+    DISJOINT (set (inst_defs a)) (set (inst_uses b)) /\
+    DISJOINT (set (inst_defs b)) (set (inst_uses a)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`sa`,`sab`]
+    strip_assume_tac effect_free_backward_transfer >> gvs[] >>
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`sa`,`sb`]
+    strip_assume_tac effect_free_forward_transfer >> gvs[] >>
+  qspecl_then [`fuel`, `ctx`, `a`, `b`, `s`, `sa`, `sb`, `sab`, `sba`]
+    mp_tac effect_free_commute_eq >>
+  simp[]
+QED
+
+(* Effect-free commutation predicate — no inst_wf needed *)
+Definition ef_commutes_def:
+  ef_commutes a b <=>
+    is_effect_free_op a.inst_opcode /\ is_effect_free_op b.inst_opcode /\
+    ~is_terminator a.inst_opcode /\ ~is_terminator b.inst_opcode /\
+    DISJOINT (set (inst_defs a)) (set (inst_uses b)) /\
+    DISJOINT (set (inst_defs b)) (set (inst_uses a)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b))
+End
+
+Triviality ef_commutes_sym:
+  !a b. ef_commutes a b ==> ef_commutes b a
+Proof
+  rw[ef_commutes_def, pred_setTheory.DISJOINT_SYM]
+QED
+
+(* Non-dep, non-barrier → ef_commutes *)
+Triviality non_dep_non_barrier_ef_commutes:
+  !eda x y.
+    ~is_terminator x.inst_opcode /\ ~is_terminator y.inst_opcode /\
+    is_effect_free_op x.inst_opcode /\ is_effect_free_op y.inst_opcode /\
+    ~full_dep eda x y /\ ~full_dep eda y x ==>
+    ef_commutes x y
+Proof
+  rw[full_dep_def, ef_commutes_def, pred_setTheory.DISJOINT_SYM]
+QED
+
+(* Instantiation: ef_commutes topo_equiv (no inst_wf) *)
+Theorem run_insts_topo_equiv_ef:
+  !l1 l2 dep fuel ctx s r.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> ef_commutes x y) /\
+    run_insts fuel ctx l1 s = OK r ==>
+    run_insts fuel ctx l2 s = OK r
+Proof
+  rpt strip_tac >>
+  qspecl_then [`ef_commutes`,
+               `\i:instruction. T`,
+               `l1`, `l2`, `dep`, `fuel`, `ctx`, `s`, `r`]
+    mp_tac run_insts_topo_equiv_gen >>
+  simp[EVERY_MEM] >> disch_then match_mp_tac >>
+  rpt strip_tac
+  >- metis_tac[ef_commutes_sym]
+  >> (gvs[ef_commutes_def] >> metis_tac[step_swap_ok_effect_free])
+QED
+
+(* ===== block_body_ok_equiv skeleton ===== *)
+
+(* MEM x l ==> ?pfx sfx. l = pfx ++ [x] ++ sfx *)
+Triviality last_split_sfx_nil:
+  !pfx x sfx.
+    x = LAST (pfx ++ [x] ++ sfx) /\ ALL_DISTINCT (pfx ++ [x] ++ sfx) ==>
+    sfx = []
+Proof
+  rpt strip_tac >>
+  spose_not_then assume_tac >>
+  Cases_on `sfx` >- gvs[] >>
+  `LAST (pfx ++ [x] ++ h::t) = LAST (h::t)` by
+    (once_rewrite_tac [GSYM APPEND_ASSOC] >>
+     simp[LAST_APPEND_CONS, LAST_CONS_cond]) >>
+  `MEM x (h::t)` by metis_tac[MEM_LAST] >>
+  gvs[ALL_DISTINCT_APPEND] >> metis_tac[MEM]
+QED
+
+Triviality last_split_sfx_nil_map:
+  !f pfx x sfx.
+    f x = LAST (MAP f (pfx ++ [x] ++ sfx)) /\
+    ALL_DISTINCT (MAP f (pfx ++ [x] ++ sfx)) ==>
+    sfx = []
+Proof
+  rpt strip_tac >>
+  spose_not_then assume_tac >>
+  Cases_on `sfx` >- gvs[] >>
+  gvs[MAP_APPEND, LAST_APPEND_CONS] >>
+  `MEM (f x) (MAP f (h::t))` by
+    (qpat_assum `f x = _` SUBST1_TAC >>
+     irule MEM_MAP_f >> simp[MEM_LAST]) >>
+  gvs[ALL_DISTINCT_APPEND, MEM_MAP] >>
+  metis_tac[MEM]
+QED
+
+Triviality mem_split_append:
+  !x l. MEM x l ==> ?pfx sfx. l = pfx ++ [x] ++ sfx
+Proof
+  metis_tac[MEM_SPLIT_APPEND_first]
+QED
+
+(* H1: block body instructions have ALL_DISTINCT inst_ids *)
+Triviality all_distinct_flat_mem:
+  !ls l. ALL_DISTINCT (FLAT ls) /\ MEM l ls ==> ALL_DISTINCT l
+Proof
+  Induct >> simp[] >> rpt strip_tac >> gvs[ALL_DISTINCT_APPEND]
+QED
+
+(* General: if ALL_DISTINCT (FLAT (MAP f ls)), distinct elements a,b of ls
+   have disjoint images under f *)
+Triviality all_distinct_flat_map_disjoint:
+  !ls f a b x.
+    ALL_DISTINCT (FLAT (MAP f ls)) /\
+    MEM a ls /\ MEM b ls /\ a <> b /\
+    MEM x (f a) ==> ~MEM x (f b)
+Proof
+  Induct >> simp[] >> rpt strip_tac >> gvs[MAP, FLAT, ALL_DISTINCT_APPEND]
+  >> metis_tac[MEM_FLAT, MEM_MAP]
+QED
+
+Triviality block_body_all_distinct:
+  !fn bb.
+    wf_function fn /\ MEM bb fn.fn_blocks ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) (block_body bb))
+Proof
+  rpt strip_tac >>
+  simp[block_body_def] >>
+  irule all_distinct_map_filter >>
+  irule all_distinct_flat_mem >>
+  qexists `MAP (\bb. MAP (\i. i.inst_id) bb.bb_instructions) fn.fn_blocks` >>
+  gvs[wf_function_def, fn_inst_ids_distinct_def] >>
+  simp[MEM_MAP] >> qexists `bb` >> simp[]
+QED
+
+(* Given wf_function with distinct labels, block_perm_of's witness
+   bb_orig must equal any fn block with the same label *)
+Triviality block_perm_of_orig_unique:
+  !fn bb bb'.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label ==>
+    !bb_orig.
+      MEM bb_orig fn.fn_blocks /\ bb'.bb_label = bb_orig.bb_label ==>
+      bb_orig = bb
+Proof
+  rpt strip_tac >>
+  `ALL_DISTINCT (MAP (\b. b.bb_label) fn.fn_blocks)` by
+    fs[wf_function_def, fn_labels_def] >>
+  `lookup_block bb.bb_label fn.fn_blocks = SOME bb` by
+    (irule MEM_lookup_block >> simp[]) >>
+  `lookup_block bb.bb_label fn.fn_blocks = SOME bb_orig` by
+    (irule MEM_lookup_block >> simp[]) >>
+  gvs[]
+QED
+
+(* Eliminate block_perm_of: replace bb_orig with bb *)
+Triviality block_perm_of_elim:
+  !fn bb bb'.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label ==>
+    EVERY (\i. from_block bb.bb_instructions i)
+      (FILTER (\i. ~is_pseudo i.inst_opcode) bb'.bb_instructions) /\
+    PERM (MAP (\i. i.inst_id)
+            (FILTER (\i. ~is_pseudo i.inst_opcode) bb'.bb_instructions))
+         (MAP (\i. i.inst_id)
+            (FILTER (\i. ~is_pseudo i.inst_opcode) bb.bb_instructions)) /\
+    FILTER (\i. is_pseudo i.inst_opcode) bb'.bb_instructions =
+    FILTER (\i. is_pseudo i.inst_opcode) bb.bb_instructions
+Proof
+  rpt strip_tac >>
+  `!bb_orig. MEM bb_orig fn.fn_blocks /\
+             bb'.bb_label = bb_orig.bb_label ==> bb_orig = bb` by
+    (rpt strip_tac >> irule block_perm_of_orig_unique >> metis_tac[]) >>
+  fs[block_perm_of_def] >>
+  `bb_orig = bb` by (first_x_assum irule >> simp[]) >>
+  gvs[]
+QED
+
+(* flip_operands preserves is_terminator *)
+Triviality is_flippable_not_terminator:
+  !op. is_flippable op ==> ~is_terminator op
+Proof
+  Cases >> simp[is_flippable_def, is_commutative_def, is_comparator_def,
+                is_terminator_def]
+QED
+
+(* H2: block_body bb' instructions have from_block equivalents *)
+Triviality block_body_from_block:
+  !fn bb bb' i.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label /\
+    MEM i (block_body bb') ==>
+    ?j. MEM j (block_body bb) /\ j.inst_id = i.inst_id /\
+        !fuel ctx s. step_inst fuel ctx i s = step_inst fuel ctx j s
+Proof
+  rpt strip_tac >>
+  gvs[block_body_def, MEM_FILTER] >>
+  drule_all block_perm_of_elim >> strip_tac >>
+  (* Instantiate EVERY for i, get from_block *)
+  fs[EVERY_MEM, MEM_FILTER] >>
+  first_x_assum (qspec_then `i` mp_tac) >> simp[] >> strip_tac >>
+  (* Case split: i = j (original) or i = flip_operands j *)
+  fs[from_block_def] >> gvs[]
+  >- (qexists `i` >> simp[])
+  >> (qexists `j` >>
+      simp[flip_operands_inst_id] >>
+      conj_tac >- metis_tac[is_flippable_not_terminator] >>
+      simp[flip_operands_step_inst])
+QED
+
+(* Per-block ALL_DISTINCT inst_ids from wf_function *)
+Triviality bb_inst_ids_distinct:
+  !fn bb. wf_function fn /\ MEM bb fn.fn_blocks ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions)
+Proof
+  rpt strip_tac >>
+  irule all_distinct_flat_mem >>
+  qexists `MAP (\bb. MAP (\i. i.inst_id) bb.bb_instructions) fn.fn_blocks` >>
+  gvs[wf_function_def, fn_inst_ids_distinct_def] >>
+  simp[MEM_MAP] >> qexists `bb` >> simp[]
+QED
+
+Triviality flip_operands_is_terminator:
+  !i. is_terminator (flip_operands i).inst_opcode = is_terminator i.inst_opcode
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  IF_CASES_TAC >> simp[] >>
+  Cases_on `i.inst_opcode` >> gvs[] >>
+  EVAL_TAC
+QED
+
+(* Forward: for j in block_body bb, matching instruction in block_body bb' *)
+Triviality block_body_from_block_rev:
+  !fn bb bb' j.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label /\
+    bb_well_formed bb' /\
+    MEM j (block_body bb) ==>
+    ?k. MEM k (block_body bb') /\ k.inst_id = j.inst_id
+Proof
+  rpt strip_tac >>
+  drule_all block_perm_of_elim >> strip_tac >>
+  gvs[block_body_def, MEM_FILTER] >>
+  (* Get ALL_DISTINCT inst_ids for bb.insts early *)
+  `ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions)` by
+    metis_tac[bb_inst_ids_distinct] >>
+  (* j.inst_id in MAP inst_id (FILTER ¬pseudo bb'.insts) via PERM *)
+  `MEM j.inst_id (MAP (\i. i.inst_id)
+      (FILTER (\i. ~is_pseudo i.inst_opcode) bb'.bb_instructions))` by
+    (drule PERM_MEM_EQ >> disch_then (qspec_then `j.inst_id` mp_tac) >>
+     simp[MEM_MAP, MEM_FILTER] >> metis_tac[]) >>
+  gvs[MEM_MAP, MEM_FILTER] >>
+  rename1 `MEM k bb'.bb_instructions` >>
+  (* k is non-pseudo, from_block gives it comes from some orig in bb *)
+  `from_block bb.bb_instructions k` by
+    (fs[EVERY_MEM, MEM_FILTER]) >>
+  gvs[from_block_def] >> rename1 `MEM orig bb.bb_instructions`
+  >- ((* k = orig directly: orig.inst_id = j.inst_id + ALL_DISTINCT ⟹ orig = j *)
+      `orig = j` by metis_tac[all_distinct_map_mem_inj] >>
+      gvs[] >> qexists `j` >> simp[])
+  >> ((* k = flip_operands orig *)
+      `orig.inst_id = j.inst_id` by simp[flip_operands_inst_id] >>
+      `orig = j` by metis_tac[all_distinct_map_mem_inj] >>
+      gvs[] >>
+      qexists `flip_operands j` >>
+      simp[flip_operands_inst_id, flip_operands_is_terminator])
+QED
+
+(* ALL_DISTINCT for permuted block's block_body *)
+Triviality block_body_all_distinct_perm:
+  !fn bb bb'.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) (block_body bb'))
+Proof
+  rpt strip_tac >>
+  drule_all block_perm_of_elim >> strip_tac >>
+  `ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions)` by
+    metis_tac[bb_inst_ids_distinct] >>
+  `ALL_DISTINCT (MAP (\i. i.inst_id)
+       (FILTER (\i. ~is_pseudo i.inst_opcode) bb.bb_instructions))` by
+    (irule all_distinct_map_filter >> simp[]) >>
+  `ALL_DISTINCT (MAP (\i. i.inst_id)
+       (FILTER (\i. ~is_pseudo i.inst_opcode) bb'.bb_instructions))` by
+    metis_tac[ALL_DISTINCT_PERM, PERM_SYM] >>
+  simp[block_body_def] >>
+  `FILTER (\i. ~is_pseudo i.inst_opcode /\ ~is_terminator i.inst_opcode)
+     bb'.bb_instructions =
+   FILTER (\i. ~is_terminator i.inst_opcode)
+     (FILTER (\i. ~is_pseudo i.inst_opcode) bb'.bb_instructions)` by
+    (rewrite_tac[FILTER_FILTER] >> AP_THM_TAC >> AP_TERM_TAC >>
+     simp[FUN_EQ_THM] >> metis_tac[CONJ_COMM]) >>
+  simp[] >> irule all_distinct_map_filter >> simp[]
+QED
+
+(* PERM of inst_ids at block_body level *)
+Triviality block_body_perm_inst_ids:
+  !fn bb bb'.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label /\
+    bb_well_formed bb /\ bb_well_formed bb' ==>
+    PERM (MAP (\i. i.inst_id) (block_body bb))
+         (MAP (\i. i.inst_id) (block_body bb'))
+Proof
+  rpt strip_tac >>
+  irule PERM_ALL_DISTINCT >>
+  conj_tac
+  >- (gen_tac >> simp[MEM_MAP] >> eq_tac >> strip_tac
+      >- (drule_all block_body_from_block_rev >> strip_tac >>
+          qexists `k` >> simp[])
+      >> (drule_all block_body_from_block >> strip_tac >>
+          qexists `j` >> simp[])) >>
+  metis_tac[block_body_all_distinct, block_body_all_distinct_perm]
+QED
+
+(* H3: PERM (block_body bb) (MAP (choose_original ...) (block_body bb')) *)
+Triviality block_body_choose_perm:
+  !fn bb bb'.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label /\
+    bb_well_formed bb /\ bb_well_formed bb' ==>
+    PERM (block_body bb)
+         (MAP (choose_original (block_body bb)) (block_body bb'))
+Proof
+  rpt strip_tac >>
+  irule map_choose_original_perm >>
+  rpt conj_tac
+  >- (rpt strip_tac >> metis_tac[block_body_from_block])
+  >- metis_tac[block_body_all_distinct]
+  >> metis_tac[block_body_perm_inst_ids]
+QED
+
+(* H4: topo_sorted for original block under full_dep eda (no TC needed).
+   full_dep = eda_dep ∨ uses/defs overlap ∨ defs/defs overlap.
+   Part 1 (eda_dep): from eda_topo_compatible_topo_sorted.
+   Part 2 (uses/defs): from def_dominates_uses — user at i, definer at j>i impossible.
+   Part 3 (defs/defs): from ssa_form — no two distinct instructions share outputs. *)
+(* Use ssa_unique_output / mem_fn_insts_intro from allocaRemapSSATheory *)
+
+(* If an instruction is MEM of two blocks, those blocks must be the same
+   (by fn_inst_ids_distinct). *)
+Triviality fn_inst_same_block:
+  !fn bb1 bb2 inst.
+    wf_function fn /\
+    MEM bb1 fn.fn_blocks /\ MEM bb2 fn.fn_blocks /\
+    MEM inst bb1.bb_instructions /\ MEM inst bb2.bb_instructions ==>
+    bb1 = bb2
+Proof
+  rpt strip_tac >> spose_not_then assume_tac >>
+  `fn_inst_ids_distinct fn` by fs[wf_function_def] >>
+  fs[fn_inst_ids_distinct_def] >>
+  `MEM inst.inst_id (MAP (\i. i.inst_id) bb2.bb_instructions)` by
+    (simp[MEM_MAP] >> metis_tac[]) >>
+  qspecl_then [`fn.fn_blocks`,
+    `\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
+    `bb1`, `bb2`, `inst.inst_id`] mp_tac all_distinct_flat_map_disjoint >>
+  simp[MEM_MAP] >> metis_tac[]
+QED
+
+(* In block_body, a later element cannot define a variable used by an earlier
+   element. This follows from def_dominates_uses + SSA uniqueness + filter
+   preserving order. *)
+Triviality block_body_defs_before_uses:
+  !fn bb i j v.
+    wf_ssa fn /\ wf_function fn /\
+    MEM bb fn.fn_blocks /\ bb_well_formed bb /\
+    i < j /\ j < LENGTH (block_body bb) /\
+    MEM v (inst_defs (EL j (block_body bb))) /\
+    MEM (Var v) (EL i (block_body bb)).inst_operands ==>
+    F
+Proof
+  rpt strip_tac >>
+  qabbrev_tac `bd = block_body bb` >>
+  (* Step 1: EL i bd and EL j bd are distinct *)
+  `ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions)` by
+    metis_tac[bb_inst_ids_distinct] >>
+  `ALL_DISTINCT bd` by
+    (simp[Abbr `bd`] >> metis_tac[block_body_all_distinct, ALL_DISTINCT_MAP]) >>
+  `i < LENGTH bd` by decide_tac >>
+  `EL i bd <> EL j bd` by
+    (`i <> j` by decide_tac >> metis_tac[ALL_DISTINCT_EL_IMP]) >>
+  (* Step 2: Both are MEM of bb.bb_instructions *)
+  `MEM (EL i bd) bb.bb_instructions /\ MEM (EL j bd) bb.bb_instructions` by
+    (`MEM (EL i bd) bd /\ MEM (EL j bd) bd` by
+       (simp[MEM_EL] >> metis_tac[]) >>
+     unabbrev_all_tac >>
+     fs[block_body_def, MEM_FILTER]) >>
+  (* Step 3: Both are in fn_insts *)
+  `MEM (EL i bd) (fn_insts fn) /\ MEM (EL j bd) (fn_insts fn)` by
+    (conj_tac >> irule mem_fn_insts_intro >> qexists `bb` >> simp[]) >>
+  (* Step 4: v is in inst_outputs of EL j bd *)
+  `MEM v (EL j bd).inst_outputs` by fs[inst_defs_def] >>
+  (* Step 5: def_dominates_uses gives us a defining instruction *)
+  gvs[wf_ssa_def] >>
+  qpat_x_assum `def_dominates_uses _`
+    (strip_assume_tac o REWRITE_RULE[def_dominates_uses_def]) >>
+  first_x_assum (qspecl_then [`bb`, `EL i bd`, `v`] mp_tac) >>
+  impl_tac >- simp[inst_uses_def, MEM_operand_vars_iff] >>
+  strip_tac >>
+  (* Step 6: def_inst = EL j bd, and def_bb = bb *)
+  `MEM def_inst (fn_insts fn)` by
+    (irule mem_fn_insts_intro >> qexists `def_bb` >> simp[]) >>
+  `MEM (EL j bd) (fn_insts fn)` by
+    (irule mem_fn_insts_intro >> qexists `bb` >> simp[]) >>
+  `def_inst = EL j bd` by metis_tac[ssa_unique_output] >>
+  (* def_bb = bb: def_inst is MEM of both def_bb and bb (since def_inst = bd[j]).
+     If def_bb ≠ bb, same inst_id in two blocks contradicts fn_inst_ids_distinct. *)
+  `def_bb = bb` by
+    metis_tac[fn_inst_same_block] >>
+  gvs[] >>
+  (* Now have: i' < j' with EL i' bb = definer (EL j bd),
+     EL j' bb = user (EL i bd). But filter_el_mono gives
+     fi < fj with EL fi bb = EL i bd, EL fj bb = EL j bd.
+     By ALL_DISTINCT: fi = j' and fj = i', so j' < i'.
+     Contradiction with i' < j'. *)
+  `ALL_DISTINCT bb.bb_instructions` by
+    metis_tac[ALL_DISTINCT_MAP] >>
+  `i < LENGTH bd` by decide_tac >>
+  `?fi fj. fi < fj /\ fj < LENGTH bb.bb_instructions /\
+           EL fi bb.bb_instructions = EL i bd /\
+           EL fj bb.bb_instructions = EL j bd` by
+    (qspecl_then [`\i. ~is_pseudo i.inst_opcode /\ ~is_terminator i.inst_opcode`,
+      `bb.bb_instructions`, `i`, `j`] mp_tac filter_el_mono >>
+     unabbrev_all_tac >> simp[GSYM block_body_def]) >>
+  `fi < LENGTH bb.bb_instructions` by decide_tac >>
+  `i' < LENGTH bb.bb_instructions` by decide_tac >>
+  `fi = j'` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+  `fj = i'` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+  decide_tac
+QED
+
+Theorem block_body_topo_sorted:
+  !fn bb.
+    wf_ssa fn /\ wf_function fn /\ MEM bb fn.fn_blocks /\
+    bb_well_formed bb ==>
+    topo_sorted (full_dep (build_full_eda bb.bb_instructions))
+      (block_body bb)
+Proof
+  rpt strip_tac >>
+  `ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions)` by
+    metis_tac[bb_inst_ids_distinct] >>
+  `topo_sorted (eda_dep (build_full_eda bb.bb_instructions)) (block_body bb)` by
+    suspend "eda_topo" >>
+  simp[topo_sorted_def, full_dep_def] >>
+  qabbrev_tac `bd = block_body bb` >>
+  `ALL_DISTINCT bd` by
+    (simp[Abbr `bd`] >> metis_tac[block_body_all_distinct, ALL_DISTINCT_MAP]) >>
+  rpt strip_tac
+  >- (gvs[topo_sorted_def] >> metis_tac[])
+  >- suspend "case1"
+  >> suspend "case2"
+QED
+
+Resume block_body_topo_sorted[eda_topo]:
+  rewrite_tac[block_body_def] >>
+  irule eda_topo_compatible_topo_sorted >>
+  simp[] >> conj_tac
+  >- metis_tac[build_full_eda_wf]
+  >> metis_tac[eda_topo_compatible_original]
+QED
+
+Resume block_body_topo_sorted[case1]:
+  (* DISJOINT (inst_uses bd[i]) (inst_defs bd[j]) when i < j *)
+  simp[pred_setTheory.DISJOINT_DEF, pred_setTheory.EXTENSION] >>
+  spose_not_then strip_assume_tac >> rename1 `MEM v _` >>
+  `MEM (Var v) (EL i bd).inst_operands` by
+    gvs[inst_uses_def, MEM_operand_vars_iff] >>
+  `bd = block_body bb` by fs[markerTheory.Abbrev_def] >>
+  metis_tac[block_body_defs_before_uses]
+QED
+
+Resume block_body_topo_sorted[case2]:
+  (* DISJOINT (inst_defs bd[i]) (inst_defs bd[j]) when i < j:
+     SSA says each var has one definer, so bd[i] = bd[j], contradicting ALL_DISTINCT *)
+  simp[pred_setTheory.DISJOINT_DEF, pred_setTheory.EXTENSION] >>
+  spose_not_then strip_assume_tac >> rename1 `MEM v _` >>
+  `i < LENGTH bd` by decide_tac >>
+  `MEM (EL i bd) bd /\ MEM (EL j bd) bd` by
+    (simp[MEM_EL] >> metis_tac[]) >>
+  `MEM (EL i bd) bb.bb_instructions /\ MEM (EL j bd) bb.bb_instructions` by
+    (fs[markerTheory.Abbrev_def] >>
+     metis_tac[MEM_FILTER, block_body_def]) >>
+  `MEM (EL i bd) (fn_insts fn) /\ MEM (EL j bd) (fn_insts fn)` by
+    (conj_tac >> irule mem_fn_insts_intro >> qexists `bb` >> simp[]) >>
+  `MEM v (EL i bd).inst_outputs /\ MEM v (EL j bd).inst_outputs` by
+    fs[inst_defs_def] >>
+  `ssa_form fn` by fs[wf_ssa_def] >>
+  `EL i bd = EL j bd` by
+    metis_tac[ssa_unique_output] >>
+  `i < LENGTH bd /\ i <> j` by decide_tac >>
+  metis_tac[ALL_DISTINCT_EL_IMP]
+QED
+
+Finalise block_body_topo_sorted
+
+(* flip_operands preserves set of inst_uses *)
+Triviality flip_operands_inst_uses_set:
+  !i. set (inst_uses (flip_operands i)) = set (inst_uses i)
+Proof
+  rw[inst_uses_def, flip_operands_def, pred_setTheory.EXTENSION] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[] >>
+  IF_CASES_TAC >> simp[] >>
+  simp[MEM_operand_vars_iff] >> metis_tac[]
+QED
+
+(* from_block source: unique original with inst_id, inst_outputs, ¬is_pseudo *)
+Triviality from_block_source:
+  !bi a.
+    from_block bi a /\ ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    ?j. MEM j bi /\ ~is_pseudo j.inst_opcode /\
+        j.inst_id = a.inst_id /\ j.inst_outputs = a.inst_outputs
+Proof
+  rw[from_block_def] >> gvs[]
+  >- (qexists `a` >> simp[])
+  >> qexists `j` >>
+     simp[flip_operands_inst_id, flip_operands_inst_outputs]
+QED
+
+(* from_block element preserves inst_uses set and inst_defs relative to source *)
+Triviality from_block_preserves_uses_defs:
+  !bi a.
+    from_block bi a ==>
+    ?j. MEM j bi /\ j.inst_id = a.inst_id /\
+        set (inst_uses a) = set (inst_uses j) /\
+        inst_defs a = inst_defs j
+Proof
+  rw[from_block_def] >> gvs[]
+  >- (qexists `a` >> simp[])
+  >> qexists `j` >>
+     simp[flip_operands_inst_id, flip_operands_inst_uses_set,
+          inst_defs_def, flip_operands_inst_outputs]
+QED
+
+(* from_block preserves full_dep (biconditional) *)
+Triviality from_block_full_dep:
+  !bi x y x' y'.
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    from_block bi x /\ from_block bi y /\
+    from_block bi x' /\ from_block bi y' /\
+    x.inst_id = x'.inst_id /\ y.inst_id = y'.inst_id ==>
+    (full_dep (build_full_eda bi) x y <=> full_dep (build_full_eda bi) x' y')
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `from_block _ x`
+    (qx_choose_then `jx` strip_assume_tac o MATCH_MP from_block_preserves_uses_defs) >>
+  qpat_x_assum `from_block _ y`
+    (qx_choose_then `jy` strip_assume_tac o MATCH_MP from_block_preserves_uses_defs) >>
+  qpat_x_assum `from_block _ x'`
+    (qx_choose_then `jx'` strip_assume_tac o MATCH_MP from_block_preserves_uses_defs) >>
+  qpat_x_assum `from_block _ y'`
+    (qx_choose_then `jy'` strip_assume_tac o MATCH_MP from_block_preserves_uses_defs) >>
+  `jx.inst_id = jx'.inst_id` by gvs[] >>
+  `jx = jx'` by
+    (qspecl_then [`\i. i.inst_id`, `bi`, `jx`, `jx'`]
+       mp_tac all_distinct_map_mem_inj >> simp[]) >>
+  `jy.inst_id = jy'.inst_id` by gvs[] >>
+  `jy = jy'` by
+    (qspecl_then [`\i. i.inst_id`, `bi`, `jy`, `jy'`]
+       mp_tac all_distinct_map_mem_inj >> simp[]) >>
+  simp[full_dep_def] >>
+  metis_tac[eda_dep_inst_id_only]
+QED
+
+(* Variant of map_choose_original_topo_sorted where condition 4
+   is restricted to elements of l1 and l2 *)
+Triviality map_choose_original_topo_sorted_restricted:
+  !l1 l2 dep.
+    ALL_DISTINCT (MAP (\i. i.inst_id) l1) /\
+    topo_sorted dep l2 /\
+    (!i. MEM i l2 ==> ?j. MEM j l1 /\ j.inst_id = i.inst_id) /\
+    (!x y x' y'. MEM x l2 /\ MEM y l2 /\ MEM x' l1 /\ MEM y' l1 /\
+       x.inst_id = x'.inst_id /\ y.inst_id = y'.inst_id ==>
+       (dep x y <=> dep x' y')) ==>
+    topo_sorted dep (MAP (choose_original l1) l2)
+Proof
+  rw[topo_sorted_def, LENGTH_MAP] >>
+  simp[EL_MAP] >>
+  `MEM (EL i l2) l2` by (simp[MEM_EL] >> qexists `i` >> simp[]) >>
+  `MEM (EL j l2) l2` by (simp[MEM_EL] >> qexists `j` >> simp[]) >>
+  `(choose_original l1 (EL i l2)).inst_id = (EL i l2).inst_id` by
+    (irule (cj 2 choose_original_correct) >> metis_tac[]) >>
+  `(choose_original l1 (EL j l2)).inst_id = (EL j l2).inst_id` by
+    (irule (cj 2 choose_original_correct) >> metis_tac[]) >>
+  `MEM (choose_original l1 (EL i l2)) l1` by
+    (irule (cj 1 choose_original_correct) >> metis_tac[]) >>
+  `MEM (choose_original l1 (EL j l2)) l1` by
+    (irule (cj 1 choose_original_correct) >> metis_tac[]) >>
+  metis_tac[]
+QED
+
+(* NOTE: block_body_topo_sorted_co (H5) was FALSE as stated — block_perm_of
+   does not carry ordering info. topo_sorted must come from the DFT pipeline
+   (schedule_output_eda_before + schedule_output_producer_before).
+   Now passed as hypothesis to block_body_ok_equiv. *)
+
+(* Convert output_eda_before + output_producer_before → topo_sorted (full_dep eda).
+   Key bridge from DFT topo sort results to the permutation simulation. *)
+(* Per-block SSA: no two instructions share an output variable *)
+Triviality schedule_topo_sorted_full_dep:
+  !bi eda output.
+    eda = build_full_eda bi /\
+    output_eda_before eda output /\
+    output_producer_before bi output /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) output) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    (!i. MEM i output ==> from_block bi i /\ ~is_pseudo i.inst_opcode) /\
+    ALL_DISTINCT (FLAT (MAP (\i. i.inst_outputs) bi)) ==>
+    topo_sorted (full_dep eda) output
+Proof
+  rw[topo_sorted_def, full_dep_def] >>
+  spose_not_then strip_assume_tac >>
+  gvs[]
+  >- suspend "eda_case"
+  >- suspend "uses_defs_case"
+  >> suspend "defs_defs_case"
+QED
+
+(* Case 1: eda_dep(EL i, EL j) with i < j contradicts output_eda_before *)
+Resume schedule_topo_sorted_full_dep[eda_case]:
+  fs[output_eda_before_def, eda_dep_def] >>
+  `eda_wf (build_full_eda bi) bi` by simp[build_full_eda_wf] >>
+  `~is_pseudo d.inst_opcode` by
+    (qpat_x_assum `eda_wf _ _` mp_tac >> rw[eda_wf_def] >>
+     Cases_on `FLOOKUP (build_full_eda bi) (EL i output).inst_id` >> gvs[] >>
+     res_tac >> simp[]) >>
+  (* Apply output_eda_before with k=i, witness d *)
+  first_x_assum (qspec_then `i` mp_tac) >> simp[] >>
+  qexists `d` >> simp[] >>
+  rpt strip_tac >>
+  (* m < i, (EL m output).inst_id = d.inst_id = (EL j output).inst_id *)
+  (* ALL_DISTINCT → m = j → j < i, contradicts i < j *)
+  `m < LENGTH output` by decide_tac >>
+  `EL m (MAP (\i. i.inst_id) output) = EL j (MAP (\i. i.inst_id) output)` by
+    simp[EL_MAP] >>
+  qspecl_then [`MAP (\i. i.inst_id) output`, `m`, `j`] mp_tac
+    ALL_DISTINCT_EL_IMP >> simp[]
+QED
+
+(* Case 2: uses(EL i) ∩ defs(EL j) with i < j contradicts output_producer_before *)
+Resume schedule_topo_sorted_full_dep[uses_defs_case]:
+  fs[pred_setTheory.IN_DISJOINT, inst_uses_def, inst_defs_def] >>
+  rename1 `MEM v (operand_vars _)` >>
+  `MEM (Var v) (EL i output).inst_operands` by metis_tac[MEM_operand_vars_iff] >>
+  `MEM (EL j output) output` by (simp[MEM_EL] >> metis_tac[]) >>
+  (* Get j_orig ∈ bi: inst_id, inst_outputs, ¬is_pseudo — no case split *)
+  `from_block bi (EL j output)` by metis_tac[] >>
+  `?j_orig. MEM j_orig bi /\ ~is_pseudo j_orig.inst_opcode /\
+            j_orig.inst_id = (EL j output).inst_id /\
+            j_orig.inst_outputs = (EL j output).inst_outputs` by
+    metis_tac[from_block_source] >>
+  `MEM v j_orig.inst_outputs` by gvs[] >>
+  (* producing_inst bi v = SOME j_orig (unique definer under SSA) *)
+  `producing_inst bi v = SOME j_orig` by
+    (qspecl_then [`bi`, `v`, `j_orig`] mp_tac producing_inst_unique_definer >>
+     simp[] >> disch_then irule >> rpt strip_tac >>
+     rename1 `MEM other bi` >>
+     qspecl_then [`bi`, `(\i. i.inst_outputs)`, `j_orig`, `other`, `v`]
+       mp_tac all_distinct_flat_map_disjoint >> simp[]) >>
+  (* Apply output_producer_before with k=i *)
+  fs[output_producer_before_def] >>
+  first_x_assum (qspecl_then [`i`, `v`, `j_orig`] mp_tac) >> simp[] >>
+  strip_tac >>
+  (* ALL_DISTINCT → m = j → j ≥ i, done *)
+  rpt strip_tac >>
+  spose_not_then assume_tac >> gvs[] >>
+  `m < LENGTH output` by decide_tac >>
+  `EL m (MAP (\i. i.inst_id) output) = EL j (MAP (\i. i.inst_id) output)` by
+    simp[EL_MAP] >>
+  qspecl_then [`MAP (\i. i.inst_id) output`, `m`, `j`] mp_tac
+    ALL_DISTINCT_EL_IMP >> simp[]
+QED
+
+(* Case 3: defs(EL i) ∩ defs(EL j) with i < j contradicts SSA unique outputs *)
+Resume schedule_topo_sorted_full_dep[defs_defs_case]:
+  fs[pred_setTheory.IN_DISJOINT, inst_defs_def] >>
+  rename1 `MEM v (EL j output).inst_outputs` >>
+  (* Get originals from bi for both EL i and EL j *)
+  `i < LENGTH output` by decide_tac >>
+  `MEM (EL i output) output` by metis_tac[MEM_EL] >>
+  `MEM (EL j output) output` by metis_tac[MEM_EL] >>
+  `from_block bi (EL i output) /\ from_block bi (EL j output)` by metis_tac[] >>
+  `?i_orig. MEM i_orig bi /\ i_orig.inst_id = (EL i output).inst_id /\
+            i_orig.inst_outputs = (EL i output).inst_outputs` by
+    metis_tac[from_block_source] >>
+  `?j_orig. MEM j_orig bi /\ j_orig.inst_id = (EL j output).inst_id /\
+            j_orig.inst_outputs = (EL j output).inst_outputs` by
+    metis_tac[from_block_source] >>
+  (* Both originals define v → must be same instruction under SSA *)
+  `MEM v i_orig.inst_outputs /\ MEM v j_orig.inst_outputs` by gvs[] >>
+  `i_orig = j_orig` by
+    (spose_not_then assume_tac >>
+     qspecl_then [`bi`, `(\i. i.inst_outputs)`, `i_orig`, `j_orig`, `v`]
+       mp_tac all_distinct_flat_map_disjoint >> simp[]) >>
+  (* Same original → same inst_id → i = j, contradicts i < j *)
+  `(EL i output).inst_id = (EL j output).inst_id` by
+    (qpat_x_assum `i_orig = j_orig` SUBST_ALL_TAC >> gvs[]) >>
+  qspecl_then [`MAP (\i. i.inst_id) output`, `i`, `j`] mp_tac
+    ALL_DISTINCT_EL_IMP >> simp[EL_MAP]
+QED
+
+Finalise schedule_topo_sorted_full_dep;
+
+(* H6: uncomparable under TC(full_dep eda) → ef_commutes *)
+(* Key lemma for H6: barriers are TC-connected to all other block_body elements.
+   If b is a barrier in block_body and y ≠ b is also in block_body,
+   then TC(full_dep(build_full_eda insts)) connects them. *)
+(* Helper: eda_dep from build_full_eda implies full_dep implies TC(full_dep) *)
+Triviality eda_dep_imp_tc_full_dep:
+  !bi x y. eda_dep (build_full_eda bi) x y ==>
+    TC (full_dep (build_full_eda bi)) x y
+Proof
+  rpt strip_tac >> irule TC_SUBSET >> simp[full_dep_def]
+QED
+
+(* Helper: from_barrier result lifts to eda_dep of build_full_eda.
+   If b is barrier at position after prefix in non_phis, and y is in prefix,
+   then eda_dep(build_full_eda bi) b y. *)
+Triviality from_barrier_to_eda_dep:
+  !bi prefix b suffix y.
+    FILTER (\i. ~is_pseudo i.inst_opcode) bi = prefix ++ [b] ++ suffix /\
+    is_barrier b /\ MEM y prefix /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    eda_dep (build_full_eda bi) b y
+Proof
+  rpt strip_tac >>
+  simp[eda_dep_def] >> qexists `y` >> simp[] >>
+  irule build_full_eda_mono_from_barrier >>
+  (* add_deps_from_barrier bi eda = FST(FOLDL ... (eda,[]) non_phis) *)
+  simp[add_deps_from_barrier_def, LET_THM] >>
+  qspecl_then [`prefix`, `b`, `suffix`,
+    `add_deps_on_barrier bi (add_abort_deps bi (build_eda bi))`, `[]`]
+    mp_tac add_deps_from_barrier_foldl_spec >>
+  simp[] >> disch_then irule >>
+  conj_tac
+  >- (`ALL_DISTINCT (MAP (\i. i.inst_id) (prefix ++ [b] ++ suffix))` by
+        (qpat_x_assum `FILTER _ _ = _` (SUBST1_TAC o SYM) >>
+         irule all_distinct_map_filter >> simp[]) >>
+      gvs[MAP_APPEND])
+  >> simp[]
+QED
+
+(* Helper: on_barrier result lifts to eda_dep of build_full_eda.
+   If y is non-barrier, and last barrier before y in non_phis is b',
+   then eda_dep(build_full_eda bi) y b'. *)
+Triviality on_barrier_to_eda_dep:
+  !bi prefix y suffix b.
+    FILTER (\i. ~is_pseudo i.inst_opcode) bi = prefix ++ [y] ++ suffix /\
+    ~is_barrier y /\
+    (case FILTER is_barrier prefix of
+       [] => F  (* no barrier before y — vacuous *)
+     | bs => LAST bs = b) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    eda_dep (build_full_eda bi) y b
+Proof
+  rpt strip_tac >>
+  simp[eda_dep_def] >> qexists `b` >> simp[] >>
+  irule build_full_eda_mono_on_barrier >>
+  (* add_deps_on_barrier operates on non_phis *)
+  simp[add_deps_on_barrier_def, LET_THM] >>
+  qspecl_then [`prefix`, `y`, `suffix`,
+    `add_abort_deps bi (build_eda bi)`, `NONE`, `b`]
+    mp_tac add_deps_on_barrier_foldl_spec >>
+  impl_tac
+  >- (`ALL_DISTINCT (MAP (\i. i.inst_id) (prefix ++ [y] ++ suffix))` by
+        (qpat_x_assum `FILTER _ _ = _` (SUBST1_TAC o SYM) >>
+         irule all_distinct_map_filter >> simp[]) >>
+      gvs[MAP_APPEND, ALL_DISTINCT_APPEND] >>
+      Cases_on `FILTER is_barrier prefix` >> gvs[])
+  >> simp[]
+QED
+
+(* Barriers are TC-connected to all body elements via the restricted dep
+   (full_dep restricted to block_body elements). Each eda_dep step in the
+   chain has both endpoints in block_body, so we get TC of the restricted dep. *)
+Theorem barrier_tc_connected:
+  !fn bb b y dep.
+    wf_function fn /\ MEM bb fn.fn_blocks /\ bb_well_formed bb /\
+    MEM b (block_body bb) /\ MEM y (block_body bb) /\ b <> y /\
+    is_barrier b /\
+    dep = (\a c. full_dep (build_full_eda bb.bb_instructions) a c /\
+                 MEM a (block_body bb) /\ MEM c (block_body bb)) ==>
+    TC dep b y \/ TC dep y b
+Proof
+  rpt strip_tac >> gvs[] >>
+  qabbrev_tac `bi = bb.bb_instructions` >>
+  qabbrev_tac `eda = build_full_eda bi` >>
+  `ALL_DISTINCT (MAP (\i. i.inst_id) bi)` by
+    metis_tac[bb_inst_ids_distinct] >>
+  `MEM b (FILTER (\i. ~is_pseudo i.inst_opcode) bi)` by
+    (fs[block_body_def, MEM_FILTER, Abbr `bi`] >> fs[]) >>
+  `MEM y (FILTER (\i. ~is_pseudo i.inst_opcode) bi)` by
+    (fs[block_body_def, MEM_FILTER, Abbr `bi`] >> fs[]) >>
+  qpat_x_assum `MEM b (FILTER _ _)`
+    (strip_assume_tac o MATCH_MP mem_split_append) >>
+  `MEM y (pfx ++ [b] ++ sfx)` by metis_tac[] >>
+  fs[MEM_APPEND, MEM]
+  >- suspend "y_before_b"
+  >- gvs[]
+  >> suspend "y_after_b"
+QED
+
+Resume barrier_tc_connected[y_before_b]:
+  (* y in pfx = before b. barrier b has eda_dep to all before it *)
+  disj1_tac >> irule TC_SUBSET >>
+  simp[full_dep_def] >> disj1_tac >>
+  simp[Abbr `eda`] >>
+  irule from_barrier_to_eda_dep >>
+  simp[] >> qexistsl [`pfx`, `sfx`] >> simp[]
+QED
+
+Resume barrier_tc_connected[y_after_b]:
+  (* y in sfx = after b *)
+  disj2_tac >>
+  qpat_x_assum `MEM y sfx` (strip_assume_tac o MATCH_MP mem_split_append) >>
+  qabbrev_tac `pre_y = pfx ++ [b] ++ pfx'` >>
+  `FILTER (\i. ~is_pseudo i.inst_opcode) bi = pre_y ++ [y] ++ sfx'` by
+    simp[Abbr `pre_y`] >>
+  `MEM b (FILTER is_barrier pre_y)` by
+    simp[Abbr `pre_y`, MEM_FILTER, MEM_APPEND] >>
+  Cases_on `is_barrier y`
+  >- suspend "y_barrier"
+  >> suspend "y_not_barrier"
+QED
+
+Resume barrier_tc_connected[y_barrier]:
+  (* y is also barrier — eda_dep from y to b, single step *)
+  irule TC_SUBSET >> simp[full_dep_def] >> disj1_tac >>
+  simp[Abbr `eda`] >>
+  irule from_barrier_to_eda_dep >>
+  simp[] >> qexistsl [`pre_y`, `sfx'`] >>
+  simp[Abbr `pre_y`, MEM_APPEND]
+QED
+
+Resume barrier_tc_connected[y_not_barrier]:
+  (* y not barrier — chain through last barrier b' in pre_y *)
+  (* Unfold eda early so irule can match *)
+  qpat_x_assum `Abbrev (eda = _)` (SUBST_ALL_TAC o
+    REWRITE_RULE [markerTheory.Abbrev_def]) >>
+  `FILTER is_barrier pre_y <> []` by (strip_tac >> fs[MEM]) >>
+  Cases_on `FILTER is_barrier pre_y` >- gvs[] >>
+  qabbrev_tac `b' = LAST (h::t)` >>
+  `eda_dep (build_full_eda bi) y b'` by
+    (irule on_barrier_to_eda_dep >>
+     simp[] >> qexistsl [`pre_y`, `sfx'`] >>
+     simp[Abbr `b'`]) >>
+  (* b' is in block_body: barrier in pre_y, not terminator *)
+  `MEM b' (block_body bb)` by suspend "mem_b'_body" >>
+  Cases_on `b' = b`
+  >- (gvs[] >> irule TC_SUBSET >>
+      simp[full_dep_def] >> disj1_tac >> simp[eda_dep_def] >>
+      first_x_assum (fn th => qexists `b` >> mp_tac th) >> simp[])
+  (* b' <> b: chain y -> b' -> b *)
+  >> `MEM b' (FILTER is_barrier pre_y)` by
+       (qpat_assum `FILTER is_barrier pre_y = h::t` SUBST1_TAC >>
+        simp[Abbr `b'`, MEM_LAST]) >>
+  `is_barrier b' /\ MEM b' pre_y` by fs[MEM_FILTER] >>
+  qpat_x_assum `MEM b' pre_y`
+    (CHOOSE_THEN (CHOOSE_THEN assume_tac) o MATCH_MP mem_split_append) >>
+  rename1 `pre_y = pre_b' ++ [b'] ++ suf_b'` >>
+  `FILTER is_barrier suf_b' = []` by
+    (`FILTER is_barrier pre_b' ++ [b'] ++ FILTER is_barrier suf_b' = h::t` by
+       (qpat_assum `pre_y = pre_b' ++ _ ++ _`
+          (fn th => RULE_ASSUM_TAC (REWRITE_RULE [th])) >>
+        gvs[FILTER_APPEND_DISTRIB]) >>
+     qpat_assum `ALL_DISTINCT (MAP _ bi)`
+       (assume_tac o MATCH_MP ALL_DISTINCT_MAP o
+        Q.SPEC `\i. ~is_pseudo i.inst_opcode` o
+        MATCH_MP all_distinct_map_filter) >>
+     `ALL_DISTINCT (pre_y ++ [y] ++ sfx')` by metis_tac[] >>
+     `ALL_DISTINCT pre_y` by fs[ALL_DISTINCT_APPEND] >>
+     `ALL_DISTINCT (h::t)` by
+       (qpat_assum `FILTER is_barrier pre_y = h::t` (SUBST1_TAC o SYM) >>
+        simp[FILTER_ALL_DISTINCT]) >>
+     irule last_split_sfx_nil >>
+     qexistsl [`FILTER is_barrier pre_b'`, `b'`] >>
+     simp[Abbr `b'`]) >>
+  `MEM b pre_b'` by
+    (`FILTER is_barrier pre_b' ++ [b'] = h::t` by
+       (qpat_assum `pre_y = pre_b' ++ _ ++ _`
+          (fn th => RULE_ASSUM_TAC (REWRITE_RULE [th])) >>
+        gvs[FILTER_APPEND_DISTRIB]) >>
+     `MEM b (FILTER is_barrier pre_b' ++ [b'])` by
+       (qpat_assum `FILTER is_barrier pre_b' ++ [b'] = h::t` SUBST1_TAC >>
+        simp[]) >>
+     `b <> b'` by metis_tac[] >>
+     fs[MEM_APPEND, MEM, MEM_FILTER]) >>
+  `eda_dep (build_full_eda bi) b' b` by
+    (irule from_barrier_to_eda_dep >>
+     simp[] >> qexistsl [`pre_b'`, `suf_b' ++ [y] ++ sfx'`] >>
+     simp[MEM_APPEND]) >>
+  (* Chain: TC dep y b via y -> b' -> b *)
+  irule (CONJUNCT2 (SPEC_ALL TC_RULES)) >>
+  qexists `b'` >> conj_tac >>
+  irule TC_SUBSET >> simp[full_dep_def] >> disj1_tac >> simp[]
+QED
+
+(* Helper: element in prefix of FILTER is not at last position of original list.
+   Used to show that a barrier appearing before y in the non-pseudo filter
+   cannot be the terminator (which is always last in bi). *)
+Triviality filter_prefix_not_last:
+  !P l pre y sfx e.
+    ALL_DISTINCT l /\ FILTER P l = pre ++ [y] ++ sfx /\
+    MEM e pre /\ P e /\ MEM e l /\
+    (!k. k < LENGTH l /\ is_terminator (EL k l).inst_opcode ==>
+         k = PRE (LENGTH l)) /\
+    l <> [] /\ is_terminator e.inst_opcode ==>
+    F
+Proof
+  rpt strip_tac >>
+  (* e is in pre, hence at index n < LENGTH pre in the filter *)
+  `?n. n < LENGTH pre /\ EL n pre = e` by metis_tac[MEM_EL] >>
+  (* y is at index LENGTH pre in the filter *)
+  `n < LENGTH (FILTER P l)` by
+    (pop_assum kall_tac >>
+     qpat_assum `FILTER P l = _` (fn th => rewrite_tac[th]) >>
+     rewrite_tac[LENGTH_APPEND, LENGTH] >> decide_tac) >>
+  `LENGTH pre < LENGTH (FILTER P l)` by
+    (qpat_assum `FILTER P l = _` (fn th => rewrite_tac[th]) >>
+     rewrite_tac[LENGTH_APPEND, LENGTH] >> decide_tac) >>
+  (* EL n (FILTER P l) = e, and EL (LENGTH pre) (FILTER P l) = y *)
+  `EL n (FILTER P l) = e /\
+   EL (LENGTH pre) (FILTER P l) = y` by
+    (asm_rewrite_tac[] >> conj_tac >>
+     simp[EL_APPEND_EQN]) >>
+  (* filter_el_mono: n < LENGTH pre, so positions in l satisfy i' < j' *)
+  drule_all filter_el_mono >>
+  disch_then (qx_choosel_then [`ne`, `ny`] strip_assume_tac) >>
+  (* ne is the position of e in l, ny is the position of y in l *)
+  (* l[ne] = e, so ne = PRE(LENGTH l) since e is terminator *)
+  `ne = PRE (LENGTH l)` by
+    (first_x_assum irule >> gvs[]) >>
+  (* But ny > ne and ny < LENGTH l => PRE(LENGTH l) < ny < LENGTH l.
+     That means LENGTH l <= ny, contradiction. *)
+  decide_tac
+QED
+
+Resume barrier_tc_connected[mem_b'_body]:
+  (* b' = LAST(h::t) is in FILTER is_barrier pre_y, hence in pre_y.
+     b' is not pseudo (from FILTER not_pseudo bi). Need: ~is_terminator.
+     Use filter_prefix_not_last for the contradiction. *)
+  `MEM b' (FILTER is_barrier pre_y)` by
+    (qpat_assum `FILTER is_barrier pre_y = h::t` SUBST1_TAC >>
+     simp[Abbr `b'`, MEM_LAST]) >>
+  `is_barrier b' /\ MEM b' pre_y` by fs[MEM_FILTER] >>
+  `MEM b' (FILTER (\i. ~is_pseudo i.inst_opcode) bi)` by
+    (qpat_assum `FILTER _ bi = pre_y ++ _ ++ _` SUBST1_TAC >>
+     simp[MEM_APPEND]) >>
+  `~is_pseudo b'.inst_opcode /\ MEM b' bi` by fs[MEM_FILTER] >>
+  `MEM y bi` by
+    (qpat_assum `MEM y (block_body bb)` mp_tac >>
+     rewrite_tac[block_body_def, MEM_FILTER] >> metis_tac[]) >>
+  simp[block_body_def, MEM_FILTER] >>
+  spose_not_then assume_tac >>
+  `bi = bb.bb_instructions` by fs[markerTheory.Abbrev_def] >>
+  `ALL_DISTINCT bi` by
+    (qpat_x_assum `ALL_DISTINCT (MAP _ bi)` mp_tac >>
+     metis_tac[ALL_DISTINCT_MAP]) >>
+  qpat_x_assum `bb_well_formed bb`
+    (strip_assume_tac o REWRITE_RULE [bb_well_formed_def]) >>
+  irule filter_prefix_not_last >>
+  qexistsl [`\i. ~is_pseudo i.inst_opcode`, `b'`, `bi`, `pre_y`, `sfx'`, `y`] >>
+  BETA_TAC >> asm_rewrite_tac[]
+QED
+
+Finalise barrier_tc_connected
+
+(* TC-uncomparable body elements (under restricted dep) commute.
+   Uses barrier_tc_connected for the barrier contradiction. *)
+Triviality block_body_uncomp_ef:
+  !fn bb x y dep.
+    wf_function fn /\ MEM bb fn.fn_blocks /\ bb_well_formed bb /\
+    MEM x (block_body bb) /\ MEM y (block_body bb) /\ x <> y /\
+    dep = (\a c. full_dep (build_full_eda bb.bb_instructions) a c /\
+                 MEM a (block_body bb) /\ MEM c (block_body bb)) /\
+    ~TC dep x y /\ ~TC dep y x ==>
+    ef_commutes x y
+Proof
+  rpt strip_tac >> gvs[] >>
+  (* Each is effect_free or barrier *)
+  `is_effect_free_op x.inst_opcode \/ is_barrier x` by
+    (fs[block_body_def, MEM_FILTER] >> metis_tac[effect_free_or_barrier]) >>
+  `is_effect_free_op y.inst_opcode \/ is_barrier y` by
+    (fs[block_body_def, MEM_FILTER] >> metis_tac[effect_free_or_barrier]) >>
+  (* If barrier, barrier_tc_connected gives TC connection — contradiction *)
+  `~is_barrier x` by
+    (strip_tac >>
+     qspecl_then [`fn`, `bb`, `x`, `y`,
+       `\a c. full_dep (build_full_eda bb.bb_instructions) a c /\
+              MEM a (block_body bb) /\ MEM c (block_body bb)`]
+       mp_tac barrier_tc_connected >>
+     simp[] >> metis_tac[]) >>
+  `~is_barrier y` by
+    (strip_tac >>
+     qspecl_then [`fn`, `bb`, `y`, `x`,
+       `\a c. full_dep (build_full_eda bb.bb_instructions) a c /\
+              MEM a (block_body bb) /\ MEM c (block_body bb)`]
+       mp_tac barrier_tc_connected >>
+     simp[] >> metis_tac[]) >>
+  (* Both effect_free. ~TC dep ==> ~dep ==> ~full_dep (since both in body). *)
+  `~full_dep (build_full_eda bb.bb_instructions) x y` by
+    (strip_tac >>
+     `TC (\a c. full_dep (build_full_eda bb.bb_instructions) a c /\
+                MEM a (block_body bb) /\ MEM c (block_body bb)) x y`
+       suffices_by metis_tac[] >>
+     irule TC_SUBSET >> simp[]) >>
+  `~full_dep (build_full_eda bb.bb_instructions) y x` by
+    (strip_tac >>
+     `TC (\a c. full_dep (build_full_eda bb.bb_instructions) a c /\
+                MEM a (block_body bb) /\ MEM c (block_body bb)) y x`
+       suffices_by metis_tac[] >>
+     irule TC_SUBSET >> simp[]) >>
+  fs[block_body_def, MEM_FILTER] >>
+  irule non_dep_non_barrier_ef_commutes >> simp[] >>
+  qexists `build_full_eda bb.bb_instructions` >> simp[]
+QED
+
+(* Unified step_inst idx-independence: OK result carries idx through.
+   For INVOKE: invoke_step_inst_idx_OK_only. For non-INVOKE: step_inst_idx_indep.
+   Both agree: step_inst OK s ⇒ step_inst (s with idx:=j) = OK (s' with idx:=j) *)
+Triviality step_inst_idx_ok_general:
+  !fuel ctx inst s j s'.
+    ~is_terminator inst.inst_opcode /\
+    step_inst fuel ctx inst s = OK s' ==>
+    step_inst fuel ctx inst (s with vs_inst_idx := j) =
+      OK (s' with vs_inst_idx := j)
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_opcode = INVOKE`
+  >- (simp[invoke_step_inst_idx_OK_only])
+  >> (`step_inst fuel ctx inst (s with vs_inst_idx := j) =
+       exec_result_map (\s'. s' with vs_inst_idx := j)
+         (step_inst fuel ctx inst s)` by
+        simp[step_inst_idx_indep] >>
+      gvs[instIdxIndepTheory.exec_result_map_def])
+QED
+
+(* exec_block_skip_prefix generalized to allow INVOKE instructions. *)
+(* exec_block_skip_prefix generalized to allow INVOKE instructions.
+   Uses step_inst_idx_ok_general — only the OK case matters since
+   run_insts OK forces all step_inst calls to be OK. *)
+Triviality exec_block_skip_prefix_general:
+  !prefix fuel ctx bb s j s'.
+    j + LENGTH prefix <= LENGTH bb.bb_instructions /\
+    EVERY (\i. ~is_terminator i.inst_opcode) prefix /\
+    (!k. k < LENGTH prefix ==> EL (j + k) bb.bb_instructions = EL k prefix) /\
+    run_insts fuel ctx prefix s = OK s'
+  ==>
+    exec_block fuel ctx bb (s with vs_inst_idx := j) =
+    exec_block fuel ctx bb (s' with vs_inst_idx := j + LENGTH prefix)
+Proof
+  Induct >> rw[run_insts_def] >>
+  rename1 `h :: prefix` >>
+  `j < LENGTH bb.bb_instructions` by simp[] >>
+  `EL j bb.bb_instructions = h` by
+    (first_x_assum (qspec_then `0` mp_tac) >> simp[]) >>
+  (* Since run_insts (h::prefix) s = OK s', the first step must be OK *)
+  Cases_on `step_inst fuel ctx h s` >> gvs[run_insts_def] >>
+  rename1 `step_inst _ _ h s = OK s1` >>
+  (* Use step_inst_idx_ok_general to handle both INVOKE and non-INVOKE *)
+  `step_inst fuel ctx h (s with vs_inst_idx := j) =
+     OK (s1 with vs_inst_idx := j)` by
+    (irule step_inst_idx_ok_general >> simp[]) >>
+  `s1.vs_inst_idx = s.vs_inst_idx` by
+    metis_tac[step_inst_preserves_inst_idx] >>
+  CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [exec_block_def])) >>
+  simp[get_instruction_def] >>
+  (* Now bb.bb_instructions[j] reappears — rewrite it to h *)
+  `bb.bb_instructions❲j❳ = h` by
+    (first_x_assum (qspec_then `0` mp_tac) >> simp[]) >>
+  asm_rewrite_tac[] >> simp[] >>
+  first_x_assum (qspecl_then [`fuel`, `ctx`, `bb`, `s1`, `SUC j`, `s'`]
+    mp_tac) >>
+  simp[arithmeticTheory.ADD_CLAUSES] >>
+  impl_tac
+  >- (rw[] >> first_x_assum (qspec_then `SUC k` mp_tac) >>
+      simp[arithmeticTheory.ADD_CLAUSES])
+  >> simp[]
+QED
+
+(* Non-barrier → non-INVOKE ∧ non-ext-call (needed for abort/returndata reasoning) *)
+Triviality not_barrier_not_invoke_ext:
+  !inst. ~is_barrier inst ==>
+    inst.inst_opcode <> INVOKE /\ ~is_ext_call_op inst.inst_opcode
+Proof
+  rpt strip_tac >> gvs[is_barrier_def] >>
+  Cases_on `inst.inst_opcode` >> gvs[is_volatile_def, is_ext_call_op_def,
+    is_alloca_op_def]
+QED
+
+(* In a topo_sorted ALL_DISTINCT list, for an element TC-connected to
+   all others, elements before it satisfy TC dep b y, and after don't. *)
+Triviality tc_connected_before_after:
+  !l dep b k.
+    ALL_DISTINCT l /\ topo_sorted (TC dep) l /\
+    k < LENGTH l /\ EL k l = b /\
+    (!y. MEM y l /\ y <> b ==> TC dep b y \/ TC dep y b) ==>
+    EVERY (\y. TC dep b y) (TAKE k l) /\
+    EVERY (\y. ~TC dep b y) (DROP (SUC k) l)
+Proof
+  rpt gen_tac >> strip_tac >> conj_tac
+  >- (simp[EVERY_EL, EL_TAKE] >> rpt strip_tac >>
+      `n < LENGTH l` by decide_tac >>
+      `EL n l <> b` by
+        (strip_tac >>
+         qspecl_then [`l`, `n`, `k`] mp_tac ALL_DISTINCT_EL_IMP >>
+         simp[]) >>
+      `~TC dep (EL n l) (EL k l)` by
+        (fs[topo_sorted_def] >> first_x_assum match_mp_tac >> decide_tac) >>
+      `MEM (EL n l) l` by metis_tac[MEM_EL] >>
+      gvs[] >> metis_tac[])
+  >> (simp[EVERY_EL, EL_DROP] >> rpt strip_tac >>
+      fs[topo_sorted_def] >>
+      first_x_assum (qspecl_then [`k`, `SUC k + n`] mp_tac) >>
+      simp[])
+QED
+
+(* Count of elements satisfying P in l, decomposed via TAKE/EL/DROP *)
+Triviality filter_count_decompose:
+  !P l k.
+    k < LENGTH l ==>
+    LENGTH (FILTER P l) =
+      LENGTH (FILTER P (TAKE k l)) +
+      (if P (EL k l) then 1 else 0) +
+      LENGTH (FILTER P (DROP (SUC k) l))
+Proof
+  rpt strip_tac >>
+  `l = TAKE k l ++ [EL k l] ++ DROP (SUC k) l` by
+    simp[TAKE_DROP_SUC] >>
+  pop_assum (fn th => CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [th]))) >>
+  simp[FILTER_APPEND_DISTRIB] >> IF_CASES_TAC >> simp[]
+QED
+
+(* Barriers are at the same positions in any two topo-sorted permutations.
+   Proof: count predecessors (TC dep b y) using PERM_FILTER. *)
+Triviality barriers_same_el:
+  !l1 l2 dep k.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted (TC dep) l1 /\ topo_sorted (TC dep) l2 /\
+    (!b y. MEM b l1 /\ MEM y l1 /\ b <> y /\ is_barrier b ==>
+           TC dep b y \/ TC dep y b) /\
+    k < LENGTH l1 /\ is_barrier (EL k l1) ==>
+    EL k l2 = EL k l1
+Proof
+  rpt strip_tac >>
+  qabbrev_tac `b = EL k l1` >>
+  qabbrev_tac `P = \y:instruction. TC dep b y` >>
+  `MEM b l2` by metis_tac[MEM_EL, PERM_MEM_EQ] >>
+  `?k'. k' < LENGTH l2 /\ EL k' l2 = b` by metis_tac[MEM_EL] >>
+  `ALL_DISTINCT l2` by metis_tac[ALL_DISTINCT_PERM] >>
+  `LENGTH l2 = LENGTH l1` by metis_tac[PERM_LENGTH] >>
+  `k = k'` suffices_by simp[] >>
+  `MEM b l1` by metis_tac[MEM_EL] >>
+  (* b is TC-connected to all other elements *)
+  `!y. MEM y l1 /\ y <> b ==> TC dep b y \/ TC dep y b` by
+    (rpt strip_tac >>
+     first_x_assum (qspecl_then [`b`, `y`] mp_tac) >> simp[]) >>
+  `EVERY P (TAKE k l1) /\ EVERY (\y. ~P y) (DROP (SUC k) l1)` by
+    (simp[Abbr `P`] >>
+     qspecl_then [`l1`, `dep`, `b`, `k`] mp_tac tc_connected_before_after >>
+     simp[Abbr `b`]) >>
+  `!y. MEM y l2 /\ y <> b ==> TC dep b y \/ TC dep y b` by
+    metis_tac[PERM_MEM_EQ] >>
+  `EVERY P (TAKE k' l2) /\ EVERY (\y. ~P y) (DROP (SUC k') l2)` by
+    (simp[Abbr `P`] >>
+     qspecl_then [`l2`, `dep`, `b`, `k'`] mp_tac tc_connected_before_after >>
+     simp[]) >>
+  (* Count P in l1: use decomposition + EVERY assumptions *)
+  `FILTER P (TAKE k l1) = TAKE k l1` by
+    simp[FILTER_EQ_ID] >>
+  `FILTER P (DROP (SUC k) l1) = []` by
+    (simp[FILTER_EQ_NIL] >> fs[EVERY_MEM] >> metis_tac[]) >>
+  `LENGTH (FILTER P l1) = k + (if P b then 1 else 0)` by
+    (qspecl_then [`P`, `l1`, `k`] mp_tac filter_count_decompose >>
+     simp[Abbr `b`]) >>
+  (* Count P in l2 *)
+  `FILTER P (TAKE k' l2) = TAKE k' l2` by
+    simp[FILTER_EQ_ID] >>
+  `FILTER P (DROP (SUC k') l2) = []` by
+    (simp[FILTER_EQ_NIL] >> fs[EVERY_MEM] >> metis_tac[]) >>
+  `LENGTH (FILTER P l2) = k' + (if P b then 1 else 0)` by
+    (qspecl_then [`P`, `l2`, `k'`] mp_tac filter_count_decompose >>
+     simp[]) >>
+  (* PERM preserves FILTER length *)
+  `LENGTH (FILTER P l1) = LENGTH (FILTER P l2)` by
+    metis_tac[PERM_FILTER, PERM_LENGTH] >>
+  fs[]
+QED
+
+(* If no barriers, both abort → returndata = [] → revert_equiv *)
+Triviality no_barrier_abort_revert:
+  !l1 l2 fuel ctx s a1 s1 a2 s2.
+    EVERY (\i. ~is_barrier i) l1 /\
+    EVERY (\i. ~is_barrier i) l2 /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l1 /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l2 /\
+    run_insts fuel ctx l1 s = Abort a1 s1 /\
+    run_insts fuel ctx l2 s = Abort a2 s2 ==>
+    revert_equiv s1 s2
+Proof
+  rpt strip_tac >> simp[revert_equiv_def] >>
+  `EVERY (\i. ~is_terminator i.inst_opcode /\ ~is_ext_call_op i.inst_opcode /\
+              i.inst_opcode <> INVOKE) l1` by
+    (fs[EVERY_MEM] >> rpt strip_tac >> metis_tac[not_barrier_not_invoke_ext]) >>
+  `EVERY (\i. ~is_terminator i.inst_opcode /\ ~is_ext_call_op i.inst_opcode /\
+              i.inst_opcode <> INVOKE) l2` by
+    (fs[EVERY_MEM] >> rpt strip_tac >> metis_tac[not_barrier_not_invoke_ext]) >>
+  metis_tac[run_insts_abort_clears_returndata]
+QED
+
+(* ===== Unified lift_result for topo-sorted permutations ===== *)
+
+(* run_insts_append: decompose run_insts over concatenation *)
+Triviality run_insts_append:
+  !xs ys fuel ctx s.
+    run_insts fuel ctx (xs ++ ys) s =
+    case run_insts fuel ctx xs s of
+      OK s' => run_insts fuel ctx ys s'
+    | Halt s' => Halt s'
+    | Abort a s' => Abort a s'
+    | IntRet v s' => IntRet v s'
+    | Error e => Error e
+Proof
+  Induct >> rw[run_insts_def] >>
+  Cases_on `step_inst fuel ctx h s` >> simp[run_insts_def]
+QED
+
+Triviality run_insts_error_append:
+  !fuel ctx l1 l2 s e.
+    run_insts fuel ctx l1 s = Error e ==>
+    run_insts fuel ctx (l1 ++ l2) s = Error e
+Proof
+  rpt strip_tac >> simp[run_insts_append]
+QED
+
+(* lift_result (=) (=) revert_equiv composes with identical continuations:
+   if r1 lift_result r2 and both OK with equal states, then applying
+   the same function f preserves lift_result. Non-OK propagates unchanged. *)
+Triviality lift_result_eq_bind:
+  !f r1 r2.
+    lift_result $= $= revert_equiv r1 r2 ==>
+    lift_result $= $= revert_equiv
+      (case r1 of OK s => f s | Halt s => Halt s
+       | Abort a s => Abort a s | IntRet v s => IntRet v s
+       | Error e => Error e)
+      (case r2 of OK s => f s | Halt s => Halt s
+       | Abort a s => Abort a s | IntRet v s => IntRet v s
+       | Error e => Error e)
+Proof
+  Cases_on `r1` >> Cases_on `r2` >> gvs[lift_result_def] >>
+  (* OK-OK: equal states → same continuation → lift_result by refl *)
+  rpt strip_tac >> gvs[] >>
+  irule (SRULE [] lift_result_refl_proof) >> simp[revert_equiv_def]
+QED
+
+(* run_insts of a pair = case on first step then second step *)
+Triviality run_insts_pair:
+  !fuel ctx a b s.
+    run_insts fuel ctx [a;b] s =
+    case step_inst fuel ctx a s of
+      OK sa => step_inst fuel ctx b sa
+    | Halt v => Halt v | Abort a' s' => Abort a' s'
+    | IntRet v s' => IntRet v s' | Error e => Error e
+Proof
+  rpt gen_tac >>
+  REWRITE_TAC [run_insts_def] >>
+  Cases_on `step_inst fuel ctx a s` >> simp[] >>
+  Cases_on `step_inst fuel ctx b v` >> simp[]
+QED
+
+(* lift_result (=)(=) revert_equiv threads through a suffix:
+   if the prefix produces lift_result, then appending the same suffix does too. *)
+Triviality run_insts_lift_result_append:
+  !fuel ctx l1 l2 suffix s.
+    lift_result $= $= revert_equiv
+      (run_insts fuel ctx l1 s) (run_insts fuel ctx l2 s) ==>
+    lift_result $= $= revert_equiv
+      (run_insts fuel ctx (l1 ++ suffix) s) (run_insts fuel ctx (l2 ++ suffix) s)
+Proof
+  rpt strip_tac >>
+  ONCE_REWRITE_TAC [run_insts_append] >>
+  Cases_on `run_insts fuel ctx l1 s` >>
+  Cases_on `run_insts fuel ctx l2 s` >>
+  gvs[lift_result_def] >>
+  (* OK-OK: equal states -> same continuation -> lift_result by refl *)
+  irule (SRULE [] lift_result_refl_proof) >> simp[revert_equiv_def]
+QED
+
+(* Swap adjacent bi_independent pair: lift_result.
+   Two-sided no-Error required (one-sided is FALSE: counterexample
+   a=ASSERT(abort), b=ADD(undef->Error)). *)
+Triviality adj_swap_lift:
+  !fuel ctx a b suffix s.
+    bi_independent a b /\
+    (!e. run_insts fuel ctx (a :: b :: suffix) s <> Error e) /\
+    (!e. run_insts fuel ctx (b :: a :: suffix) s <> Error e) ==>
+    lift_result $= $= revert_equiv
+      (run_insts fuel ctx (a :: b :: suffix) s)
+      (run_insts fuel ctx (b :: a :: suffix) s)
+Proof
+  rpt strip_tac >>
+  (* Rewrite a::b::suffix as [a;b] ++ suffix *)
+  `a :: b :: suffix = [a;b] ++ suffix` by simp[] >>
+  `b :: a :: suffix = [b;a] ++ suffix` by simp[] >>
+  pop_assum (fn th => REWRITE_TAC [th]) >>
+  pop_assum (fn th => REWRITE_TAC [th]) >>
+  irule run_insts_lift_result_append >>
+  (* Now show lift_result for just [a;b] vs [b;a] *)
+  REWRITE_TAC [run_insts_pair] >>
+  (* Extract step-level no-Error from run_insts-level no-Error *)
+  `!e. step_inst fuel ctx a s <> Error e` by
+    (CCONTR_TAC >> gvs[] >>
+     qpat_x_assum `!e. run_insts _ _ (a::_) _ <> _`
+       (qspec_then `e` mp_tac) >>
+     simp[Once run_insts_def]) >>
+  `!e. step_inst fuel ctx b s <> Error e` by
+    (CCONTR_TAC >> gvs[] >>
+     qpat_x_assum `!e. run_insts _ _ (b::_) _ <> _`
+       (qspec_then `e` mp_tac) >>
+     simp[Once run_insts_def]) >>
+  (* Use step_swap_lift *)
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`] mp_tac step_swap_lift >>
+  simp[]
+QED
+
+(* Specialized transitivity for lift_result (=)(=) revert_equiv *)
+Triviality lift_result_eq_revert_trans:
+  !r1 r2 r3.
+    lift_result $= $= revert_equiv r1 r2 /\
+    lift_result $= $= revert_equiv r2 r3 ==>
+    lift_result $= $= revert_equiv r1 r3
+Proof
+  rpt strip_tac >>
+  qspecl_then [`$=`, `$=`, `revert_equiv`] mp_tac lift_result_trans_proof >>
+  (impl_tac >- simp[revert_equiv_def]) >>
+  metis_tac[]
+QED
+
+(* If h::L1 and h::L2 are both no-Error, and step h gives OK s',
+   then L1 and L2 starting from s' are both no-Error *)
+Triviality cons_no_error_tail:
+  !fuel ctx h l s s'.
+    step_inst fuel ctx h s = OK s' /\
+    (!e. run_insts fuel ctx (h::l) s <> Error e) ==>
+    (!e. run_insts fuel ctx l s' <> Error e)
+Proof
+  rpt strip_tac >> CCONTR_TAC >> gvs[] >>
+  first_x_assum (qspec_then `e` mp_tac) >>
+  simp[Once run_insts_def]
+QED
+
+(* run_insts (h::l) not Error → step h not Error *)
+Triviality cons_no_error_head:
+  !fuel ctx h l s.
+    (!e. run_insts fuel ctx (h::l) s <> Error e) ==>
+    (!e. step_inst fuel ctx h s <> Error e)
+Proof
+  rpt strip_tac >> CCONTR_TAC >> gvs[] >>
+  first_x_assum (qspec_then `e` mp_tac) >> simp[Once run_insts_def]
+QED
+
+(* If step h s = OK v, and tails lift_result at v,
+   then h::tails lift_result at s *)
+Triviality cons_lift_result:
+  !fuel ctx h l1 l2 s v.
+    step_inst fuel ctx h s = OK v /\
+    lift_result $= $= revert_equiv
+      (run_insts fuel ctx l1 v) (run_insts fuel ctx l2 v) ==>
+    lift_result $= $= revert_equiv
+      (run_insts fuel ctx (h::l1) s) (run_insts fuel ctx (h::l2) s)
+Proof
+  rpt strip_tac >>
+  `run_insts fuel ctx (h::l1) s = run_insts fuel ctx l1 v` by
+    simp[Once run_insts_def] >>
+  `run_insts fuel ctx (h::l2) s = run_insts fuel ctx l2 v` by
+    simp[Once run_insts_def] >>
+  gvs[]
+QED
+
+(* lift_result no-Error propagation: if lift_result holds and
+   one side is not Error, the other is also not Error *)
+Triviality lift_result_no_error:
+  !r1 r2.
+    lift_result $= $= revert_equiv r1 r2 ==>
+    ((!e. r1 <> Error e) <=> (!e. r2 <> Error e))
+Proof
+  Cases >> Cases >> simp[lift_result_def]
+QED
+
+(* Diamond for bi_independent OK-OK: both cross-steps are OK (same result)
+   or both are Abort. Extracted from effects_independent_commute. *)
+Triviality bi_ind_ok_ok_cross:
+  !fuel ctx h x s v sx.
+    bi_independent h x /\
+    step_inst fuel ctx h s = OK v /\
+    step_inst fuel ctx x s = OK sx ==>
+    (?xv. step_inst fuel ctx x v = OK xv /\
+          step_inst fuel ctx h sx = OK xv) \/
+    (?a1 s1 a2 s2. step_inst fuel ctx x v = Abort a1 s1 /\
+                    step_inst fuel ctx h sx = Abort a2 s2)
+Proof
+  rpt gen_tac >> strip_tac >>
+  (* No Error for cross-steps *)
+  `!e. step_inst fuel ctx x v <> Error e` by (
+    qspecl_then [`fuel`,`ctx`,`h`,`x`,`s`,`v`] mp_tac
+      bi_ind_ok_no_error_iff >> simp[]) >>
+  `!e. step_inst fuel ctx h sx <> Error e` by (
+    qspecl_then [`fuel`,`ctx`,`x`,`h`,`s`,`sx`] mp_tac
+      bi_ind_ok_no_error_iff >>
+    simp[bi_independent_sym]) >>
+  (* No Halt/IntRet for cross-steps *)
+  `(!v'. step_inst fuel ctx x v <> Halt v') /\
+   (!v' s'. step_inst fuel ctx x v <> IntRet v' s')` by
+    metis_tac[bi_independent_no_halt_intret] >>
+  `(!v'. step_inst fuel ctx h sx <> Halt v') /\
+   (!v' s'. step_inst fuel ctx h sx <> IntRet v' s')` by
+    metis_tac[bi_independent_no_halt_intret, bi_independent_sym] >>
+  (* Case split on cross-steps *)
+  Cases_on `step_inst fuel ctx x v` >> gvs[] >>
+  Cases_on `step_inst fuel ctx h sx` >> gvs[]
+  (* Both OK: use independent_commute_eq for equality *)
+  >- metis_tac[independent_commute_eq, bi_independent_def]
+  (* OK,Abort: impossible by commute table *)
+  >- (qspecl_then [`fuel`,`ctx`,`h`,`x`,`s`] mp_tac
+        effects_independent_commute >>
+      fs[bi_independent_def, LET_THM])
+  (* Abort,OK: impossible by commute table *)
+  >> (qspecl_then [`fuel`,`ctx`,`h`,`x`,`s`] mp_tac
+        effects_independent_commute >>
+      fs[bi_independent_def, LET_THM])
+QED
+
+
+(* ===== Topo-sorted permutation lift_result ===== *)
+
+(* Strategy: Use run_insts_topo_lift for OK<=>OK and Abort=>revert_equiv,
+   then prove a1=a2 for the Abort case separately using:
+   1. FILTER equality: dep-chained P-elements have same FILTER in topo-sorted perms
+   2. bi_independent_cross_abort: abort type preserved through bi-ind OK steps
+   3. The first non-NoFail aborter is the same instruction in both orderings *)
+
+(* --- Helper: first P-element in topo-sorted list with pairwise-dep P-elements
+   is the same regardless of list ordering --- *)
+
+(* Helper: in a topo_sorted list, no P-element can appear before index i
+   if i is the minimal P-index in a permutation *)
+Triviality topo_sorted_no_earlier_P:
+  !l1 l2 dep P i1 b.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\ P x /\ P y ==>
+           dep x y \/ dep y x) /\
+    i1 < LENGTH l1 /\ b = EL i1 l1 /\ P b /\
+    (!j. j < i1 ==> ~P (EL j l1)) ==>
+    !i2 j. i2 < LENGTH l2 /\ b = EL i2 l2 /\
+           j < i2 ==> ~P (EL j l2)
+Proof
+  rpt gen_tac >> strip_tac >> rpt gen_tac >> strip_tac >>
+  spose_not_then assume_tac >>
+  `LENGTH l2 = LENGTH l1` by metis_tac[PERM_LENGTH] >>
+  `ALL_DISTINCT l2` by metis_tac[ALL_DISTINCT_PERM] >>
+  `j < LENGTH l2` by simp[] >>
+  `j <> i2` by simp[] >>
+  `EL j l2 <> b` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+  `MEM (EL j l2) l1` by metis_tac[MEM_EL, PERM_MEM_EQ] >>
+  `MEM b l1` by metis_tac[MEM_EL] >>
+  `dep (EL j l2) b \/ dep b (EL j l2)` by
+    (first_x_assum irule >> simp[]) >>
+  `~dep (EL j l2) (EL i2 l2)` by
+    (qpat_x_assum `topo_sorted dep l2` mp_tac >>
+     rewrite_tac[topo_sorted_def] >>
+     disch_then (qspecl_then [`j`, `i2`] mp_tac) >> simp[]) >>
+  `~dep (EL j l2) b` by gvs[] >>
+  `dep b (EL j l2)` by metis_tac[] >>
+  `?k. k < LENGTH l1 /\ EL j l2 = EL k l1` by metis_tac[MEM_EL] >>
+  `dep (EL i1 l1) (EL k l1)` by metis_tac[] >>
+  `~(i1 < k)` by
+    (strip_tac >>
+     `~dep (EL i1 l1) (EL k l1)` suffices_by metis_tac[] >>
+     qpat_x_assum `topo_sorted dep l1` mp_tac >>
+     rewrite_tac[topo_sorted_def] >>
+     disch_then (qspecl_then [`i1`, `k`] mp_tac) >> simp[]) >>
+  `k < i1 \/ k = i1` by simp[]
+  >- metis_tac[]
+  >> metis_tac[]
+QED
+
+(* If all P-satisfying pairs are dep-related, the first P-element in any
+   topo-sorted permutation is the same element. *)
+Triviality topo_first_P_element:
+  !l1 l2 dep P.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\ P x /\ P y ==>
+           dep x y \/ dep y x) /\
+    (?x. MEM x l1 /\ P x) ==>
+    ?pfx1 sfx1 pfx2 sfx2 x.
+      l1 = pfx1 ++ [x] ++ sfx1 /\ l2 = pfx2 ++ [x] ++ sfx2 /\
+      P x /\ EVERY ($~ o P) pfx1 /\ EVERY ($~ o P) pfx2
+Proof
+  rpt strip_tac >>
+  suspend "main"
+QED
+
+Resume topo_first_P_element[main]:
+  (* Use WOP to find minimal P-index in l1 *)
+  `?i1. i1 < LENGTH l1 /\ P (EL i1 l1) /\
+        !j. j < i1 ==> ~P (EL j l1)` by
+    (`?n. n < LENGTH l1 /\ P (EL n l1)` by metis_tac[MEM_EL] >>
+     qspecl_then [`\i. i < LENGTH l1 /\ P (EL i l1)`] mp_tac WOP >>
+     impl_tac >- metis_tac[] >>
+     disch_then (qx_choose_then `i1` (strip_assume_tac o BETA_RULE)) >>
+     qexists `i1` >> simp[] >>
+     rpt strip_tac >>
+     `j < LENGTH l1` suffices_by metis_tac[] >> simp[]) >>
+  (* b = first P-element in l1; find its index in l2 *)
+  `MEM (EL i1 l1) l2` by metis_tac[MEM_EL, PERM_MEM_EQ] >>
+  `?i2. i2 < LENGTH l2 /\ EL i1 l1 = EL i2 l2` by metis_tac[MEM_EL] >>
+  `LENGTH l2 = LENGTH l1` by metis_tac[PERM_LENGTH] >>
+  (* ~P before i2 in l2, using the extracted helper *)
+  `!i2' j'. i2' < LENGTH l2 /\ EL i1 l1 = EL i2' l2 /\
+            j' < i2' ==> ~P (EL j' l2)` by
+    (rpt gen_tac >> strip_tac >>
+     qspecl_then [`l1`, `l2`, `dep`, `P`, `i1`, `EL i1 l1`]
+       mp_tac topo_sorted_no_earlier_P >>
+     impl_tac >- simp[] >>
+     disch_then (qspecl_then [`i2'`, `j'`] mp_tac) >> simp[]) >>
+  (* Decompose both lists *)
+  qexistsl [`TAKE i1 l1`, `DROP (SUC i1) l1`,
+            `TAKE i2 l2`, `DROP (SUC i2) l2`, `EL i1 l1`] >>
+  simp[Once (GSYM TAKE_DROP_SUC)] >>
+  simp[Once (GSYM TAKE_DROP_SUC)] >>
+  simp[EVERY_EL, LENGTH_TAKE_EQ] >>
+  rpt strip_tac >> gvs[EL_TAKE] >> metis_tac[]
+QED
+
+Finalise topo_first_P_element;
+
+(* When run_insts on a non-terminator prefix aborts, exec_block at that
+   position also aborts with the same abort type and revert_equiv state.
+   The idx difference between run_insts (no idx) and exec_block (with idx)
+   is harmless since revert_equiv only checks returndata. *)
+(* Unified helper: non-terminator step with idx adjustment.
+   Covers both INVOKE and non-INVOKE via case split.
+   For non-OK: Abort state gets idx modified (non-INVOKE) or unchanged (INVOKE),
+   but returndata is preserved either way. *)
+(* Key property: for non-terminator instructions, step_inst with modified
+   vs_inst_idx gives results where:
+   - OK: mapped to OK with idx modified, and original preserves idx
+   - Abort: same abort type, revert_equiv state *)
+(* Non-terminator step with idx: OK case gives mapped OK + preserves idx.
+   Abort case gives same abort type with revert_equiv state. *)
+Triviality step_inst_idx_non_term_ok:
+  !fuel ctx inst s j s'.
+    ~is_terminator inst.inst_opcode /\
+    step_inst fuel ctx inst s = OK s' ==>
+    step_inst fuel ctx inst (s with vs_inst_idx := j) =
+      OK (s' with vs_inst_idx := j) /\
+    s'.vs_inst_idx = s.vs_inst_idx
+Proof
+  rpt strip_tac
+  >- (irule step_inst_idx_ok_general >> simp[])
+  >> metis_tac[step_inst_preserves_inst_idx]
+QED
+
+
+(* Unified: non-terminator step with idx adjustment preserves lift_result
+   for all non-OK results. Replaces step_inst_idx_non_term_{abort,error,halt,intret}. *)
+Triviality step_inst_idx_non_term_non_ok:
+  !fuel ctx inst s j.
+    ~is_terminator inst.inst_opcode /\
+    ~(?v. step_inst fuel ctx inst s = OK v) ==>
+    lift_result (\_ _. T) (execution_equiv {}) revert_equiv
+      (step_inst fuel ctx inst s)
+      (step_inst fuel ctx inst (s with vs_inst_idx := j))
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_opcode = INVOKE`
+  >- ((* INVOKE: invoke_step_inst_idx_OK_only + non-OK case gives same result *)
+      qspecl_then [`fuel`,`ctx`,`inst`,`s`,`j`] mp_tac
+        invoke_step_inst_idx_OK_only >> simp[] >>
+      Cases_on `step_inst fuel ctx inst s` >>
+      gvs[lift_result_def, execution_equiv_def, FDOM_FEMPTY, revert_equiv_def])
+  >> ((* Non-INVOKE: exec_result_map with idx *)
+      `step_inst fuel ctx inst (s with vs_inst_idx := j) =
+        exec_result_map (\s'. s' with vs_inst_idx := j)
+          (step_inst fuel ctx inst s)` by simp[step_inst_idx_indep] >>
+      Cases_on `step_inst fuel ctx inst s` >>
+      gvs[instIdxIndepTheory.exec_result_map_def, lift_result_def,
+          execution_equiv_def, FDOM_FEMPTY, revert_equiv_def, lookup_var_def])
+QED
+
+
+(* Unified: if run_insts on a prefix gives non-OK result, exec_block gives
+   lift_result-related result. Replaces the 4 per-constructor versions. *)
+Triviality exec_block_run_insts_lift:
+  !prefix fuel ctx bb s j.
+    j + LENGTH prefix <= LENGTH bb.bb_instructions /\
+    EVERY (\i. ~is_terminator i.inst_opcode) prefix /\
+    (!k. k < LENGTH prefix ==> EL (j + k) bb.bb_instructions = EL k prefix) /\
+    ~(?v. run_insts fuel ctx prefix s = OK v) ==>
+    lift_result (\_ _. T) (execution_equiv {}) revert_equiv
+      (run_insts fuel ctx prefix s)
+      (exec_block fuel ctx bb (s with vs_inst_idx := j))
+Proof
+  Induct >> rw[run_insts_def] >>
+  rename1 `_ :: prefix` >>
+  `j < LENGTH bb.bb_instructions` by simp[] >>
+  `h = EL j bb.bb_instructions` by
+    (first_x_assum (qspec_then `0` mp_tac) >> simp[]) >>
+  `~is_terminator h.inst_opcode` by gvs[] >>
+  Cases_on `step_inst fuel ctx h s` >> gvs[run_insts_def]
+  >- (* OK: head succeeds, tail is non-OK *)
+     (rename1 `step_inst _ _ _ s = OK s1` >>
+      `step_inst fuel ctx bb.bb_instructions❲j❳ (s with vs_inst_idx := j) =
+         OK (s1 with vs_inst_idx := j)` by
+        (irule step_inst_idx_ok_general >> simp[]) >>
+      `s1.vs_inst_idx = s.vs_inst_idx` by
+        metis_tac[step_inst_preserves_inst_idx] >>
+      first_x_assum (qspecl_then [`fuel`, `ctx`, `bb`, `s1`,
+        `SUC j`] mp_tac) >>
+      simp[arithmeticTheory.ADD_CLAUSES] >>
+      (impl_tac
+       >- (rw[] >> first_x_assum (qspec_then `SUC k` mp_tac) >>
+           simp[arithmeticTheory.ADD_CLAUSES]))
+      >> strip_tac >>
+      ONCE_REWRITE_TAC [exec_block_def] >>
+      simp[get_instruction_def])
+  >> (* Non-OK: head step is non-OK — use step_inst_idx_non_term_non_ok *)
+     (qspecl_then [`fuel`, `ctx`, `bb.bb_instructions❲j❳`, `s`, `j`]
+        mp_tac step_inst_idx_non_term_non_ok >> simp[] >>
+      Cases_on `step_inst fuel ctx bb.bb_instructions❲j❳
+                  (s with vs_inst_idx := j)` >>
+      gvs[lift_result_def, revert_equiv_def] >>
+      rpt strip_tac >> gvs[] >>
+      ONCE_REWRITE_TAC [exec_block_def] >>
+      simp[get_instruction_def, revert_equiv_def, lift_result_def,
+           execution_equiv_def, FDOM_FEMPTY])
+QED
+
+
+(* topo_sorted is preserved by TAKE *)
+Triviality topo_sorted_take:
+  !dep l n. topo_sorted dep l /\ n <= LENGTH l ==> topo_sorted dep (TAKE n l)
+Proof
+  rpt strip_tac >> simp[topo_sorted_def] >>
+  rpt strip_tac >>
+  `EL i (TAKE n l) = EL i l` by simp[EL_TAKE] >>
+  `EL j (TAKE n l) = EL j l` by simp[EL_TAKE] >>
+  gvs[] >>
+  qpat_x_assum `topo_sorted dep l` mp_tac >>
+  rewrite_tac[topo_sorted_def] >>
+  disch_then (qspecl_then [`i`, `j`] mp_tac) >> simp[]
+QED
+
+(* topo_sorted is preserved by DROP *)
+Triviality topo_sorted_drop:
+  !dep l n. topo_sorted dep l /\ n <= LENGTH l ==> topo_sorted dep (DROP n l)
+Proof
+  rpt strip_tac >> simp[topo_sorted_def] >>
+  rpt strip_tac >>
+  `EL i (DROP n l) = EL (i + n) l` by simp[EL_DROP] >>
+  `EL j (DROP n l) = EL (j + n) l` by simp[EL_DROP] >>
+  gvs[] >>
+  qpat_x_assum `topo_sorted dep l` mp_tac >>
+  rewrite_tac[topo_sorted_def] >>
+  disch_then (qspecl_then [`i + n`, `j + n`] mp_tac) >> simp[]
+QED
+
+(* Decompose run_insts abort into OK prefix + first aborting instruction *)
+Triviality run_insts_first_abort:
+  !fuel ctx l s a sa.
+    run_insts fuel ctx l s = Abort a sa ==>
+    ?k sk. k < LENGTH l /\
+           run_insts fuel ctx (TAKE k l) s = OK sk /\
+           ?sa'. step_inst fuel ctx (EL k l) sk = Abort a sa'
+Proof
+  gen_tac >> gen_tac >> Induct >> rpt strip_tac >>
+  gvs[run_insts_def] >>
+  Cases_on `step_inst fuel ctx h s` >> gvs[]
+  >- ((* head OKs, tail aborts *)
+      first_x_assum $ drule_then strip_assume_tac >>
+      qexists `SUC k` >> simp[run_insts_def] >> metis_tac[])
+  >> (* head aborts *)
+     (qexists `0` >> simp[run_insts_def])
+QED
+
+(* non-barrier + non-terminator + non-INVOKE + non-ext_call => NoFail *)
+Triviality not_barrier_nofail:
+  !inst. ~is_barrier inst /\
+         ~is_terminator inst.inst_opcode /\
+         ~is_ext_call_op inst.inst_opcode /\
+         inst.inst_opcode <> INVOKE ==>
+         opcode_fail_class inst.inst_opcode = NoFail
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_barrier_def, is_volatile_def, is_alloca_op_def,
+      is_terminator_def, is_ext_call_op_def, opcode_fail_class_def]
+QED
+
+(* ~is_barrier implies ~is_ext_call_op and <> INVOKE *)
+Triviality not_barrier_implies:
+  !inst. ~is_barrier inst ==>
+    ~is_ext_call_op inst.inst_opcode /\ inst.inst_opcode <> INVOKE
+Proof
+  rpt strip_tac >> Cases_on `inst.inst_opcode` >>
+  gvs[is_barrier_def, is_volatile_def, is_ext_call_op_def, is_alloca_op_def]
+QED
+
+(* Prefix before a barrier in topo-sorted list: same elements in both orderings.
+   By tc_connected_before_after, TAKE k l = FILTER (TC dep b) l for both lists.
+   Since PERM l1 l2, FILTER on a predicate gives PERM of the filtered lists. *)
+Triviality barrier_prefix_perm:
+  !l1 l2 dep k.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted (TC dep) l1 /\ topo_sorted (TC dep) l2 /\
+    (!b y. MEM b l1 /\ MEM y l1 /\ b <> y /\ is_barrier b ==>
+           TC dep b y \/ TC dep y b) /\
+    k < LENGTH l1 /\ is_barrier (EL k l1) ==>
+    PERM (TAKE k l1) (TAKE k l2)
+Proof
+  rpt strip_tac >>
+  qabbrev_tac `b = EL k l1` >>
+  `EL k l2 = b` by metis_tac[barriers_same_el] >>
+  `LENGTH l2 = LENGTH l1` by metis_tac[PERM_LENGTH] >>
+  `ALL_DISTINCT l2` by metis_tac[ALL_DISTINCT_PERM] >>
+  `MEM b l1` by metis_tac[MEM_EL] >>
+  `!y. MEM y l1 /\ y <> b ==> TC dep b y \/ TC dep y b` by
+    metis_tac[] >>
+  `!y. MEM y l2 /\ y <> b ==> TC dep b y \/ TC dep y b` by
+    metis_tac[PERM_MEM_EQ] >>
+  (* tc_connected_before_after for l1 *)
+  `EVERY (\y. TC dep b y) (TAKE k l1)` by
+    (qspecl_then [`l1`, `dep`, `b`, `k`] mp_tac tc_connected_before_after >>
+     simp[Abbr `b`]) >>
+  `EVERY (\y. ~TC dep b y) (DROP (SUC k) l1)` by
+    (qspecl_then [`l1`, `dep`, `b`, `k`] mp_tac tc_connected_before_after >>
+     simp[Abbr `b`]) >>
+  (* tc_connected_before_after for l2 *)
+  `k < LENGTH l2` by simp[] >>
+  `EVERY (\y. TC dep b y) (TAKE k l2)` by
+    (qspecl_then [`l2`, `dep`, `b`, `k`] mp_tac tc_connected_before_after >>
+     simp[]) >>
+  `EVERY (\y. ~TC dep b y) (DROP (SUC k) l2)` by
+    (qspecl_then [`l2`, `dep`, `b`, `k`] mp_tac tc_connected_before_after >>
+     simp[]) >>
+  (* Core: TC dep b x forces x to appear before k in any topo_sorted list *)
+  `!l' j'. topo_sorted (TC dep) l' /\ ALL_DISTINCT l' /\
+           k < LENGTH l' /\ EL k l' = b /\
+           j' < LENGTH l' /\ j' <> k /\ TC dep b (EL j' l') ==> j' < k` by
+    (rpt gen_tac >> strip_tac >>
+     spose_not_then assume_tac >>
+     `k < j'` by simp[] >>
+     qpat_assum `topo_sorted _ l'` mp_tac >>
+     rewrite_tac[topo_sorted_def] >>
+     disch_then (qspecl_then [`k`, `j'`] mp_tac) >> simp[]) >>
+  (* Subset direction 1: TAKE k l1 ⊆ TAKE k l2 *)
+  `!x. MEM x (TAKE k l1) ==> MEM x (TAKE k l2)` by
+    suspend "dir1" >>
+  (* Subset direction 2: TAKE k l2 ⊆ TAKE k l1 *)
+  `!x. MEM x (TAKE k l2) ==> MEM x (TAKE k l1)` by
+    suspend "dir2" >>
+  (* Both directions + same length + ALL_DISTINCT => PERM *)
+  irule PERM_ALL_DISTINCT >>
+  simp[ALL_DISTINCT_TAKE] >>
+  metis_tac[]
+QED
+
+(*
+ * Shared helper: EL k l is NOT in TAKE k l when ALL_DISTINCT
+ *)
+Triviality el_not_mem_take:
+  !l k. ALL_DISTINCT l /\ k < LENGTH l ==> ~MEM (EL k l) (TAKE k l)
+Proof
+  rpt strip_tac >>
+  `MEM (EL k l) (DROP k l)` by
+    (simp[MEM_DROP] >> qexists `0` >> simp[]) >>
+  metis_tac[ALL_DISTINCT_TAKE_DROP]
+QED
+
+Resume barrier_prefix_perm[dir1]:
+  rpt strip_tac >>
+  `TC dep b x` by fs[EVERY_MEM] >>
+  `x <> b` by
+    (strip_tac >> gvs[Abbr `b`] >> metis_tac[el_not_mem_take]) >>
+  `MEM x l2` by metis_tac[MEM_TAKE, PERM_MEM_EQ] >>
+  `?j'. j' < LENGTH l2 /\ EL j' l2 = x` by metis_tac[MEM_EL] >>
+  `j' <> k` by
+    (strip_tac >> gvs[] >> metis_tac[el_not_mem_take]) >>
+  `j' < k` by
+    (qpat_x_assum `!l' j'. topo_sorted _ l' /\ _ ==> _`
+       (qspecl_then [`l2`, `j'`] mp_tac) >> gvs[]) >>
+  simp[MEM_EL] >> qexists `j'` >> simp[LENGTH_TAKE_EQ, EL_TAKE]
+QED
+
+Resume barrier_prefix_perm[dir2]:
+  rpt strip_tac >>
+  `TC dep b x` by fs[EVERY_MEM] >>
+  `x <> b` by
+    (strip_tac >> gvs[] >> metis_tac[el_not_mem_take]) >>
+  `MEM x l1` by metis_tac[MEM_TAKE, PERM_MEM_EQ] >>
+  `?j'. j' < LENGTH l1 /\ EL j' l1 = x` by metis_tac[MEM_EL] >>
+  `j' <> k` by
+    (strip_tac >> gvs[Abbr `b`] >> metis_tac[el_not_mem_take]) >>
+  `j' < k` by
+    (qpat_x_assum `!l' j'. topo_sorted _ l' /\ _ ==> _`
+       (qspecl_then [`l1`, `j'`] mp_tac) >> gvs[Abbr `b`]) >>
+  simp[MEM_EL] >> qexists `j'` >> simp[LENGTH_TAKE_EQ, EL_TAKE]
+QED
+
+Finalise barrier_prefix_perm
+
+(* Bridge: non-barrier + non-term + non-ext + non-INVOKE => step_inst can't abort *)
+Triviality step_inst_nofail_no_abort:
+  !inst fuel ctx s a es.
+    ~is_barrier inst /\ ~is_terminator inst.inst_opcode /\
+    ~is_ext_call_op inst.inst_opcode /\ inst.inst_opcode <> INVOKE ==>
+    step_inst fuel ctx inst s <> Abort a es
+Proof
+  rpt strip_tac >>
+  `opcode_fail_class inst.inst_opcode = NoFail` by
+    metis_tac[not_barrier_nofail] >>
+  gvs[step_inst_non_invoke] >>
+  metis_tac[step_inst_nofail_not_halt_abort]
+QED
+
+(* If all instructions are non-barrier (NoFail), run_insts can't abort *)
+Triviality run_insts_nofail_no_abort:
+  !fuel ctx l s a sa.
+    run_insts fuel ctx l s = Abort a sa /\
+    EVERY (\i. ~is_terminator i.inst_opcode /\
+               ~is_ext_call_op i.inst_opcode /\ i.inst_opcode <> INVOKE) l /\
+    EVERY (\i. ~is_barrier i) l ==>
+    F
+Proof
+  rpt strip_tac >>
+  drule run_insts_first_abort >>
+  disch_then (qx_choose_then `k` strip_assume_tac) >>
+  `~is_barrier (EL k l)` by gvs[EVERY_EL] >>
+  `~is_terminator (EL k l).inst_opcode /\
+   ~is_ext_call_op (EL k l).inst_opcode /\
+   (EL k l).inst_opcode <> INVOKE` by gvs[EVERY_EL] >>
+  metis_tac[step_inst_nofail_no_abort]
+QED
+
+(* Barrier-free, non-terminator instructions can only produce OK or Error *)
+Triviality barrier_free_only_ok_or_error:
+  !l fuel ctx s.
+    EVERY (\i. ~is_barrier i) l /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l ==>
+    (?v. run_insts fuel ctx l s = OK v) \/
+    (?e. run_insts fuel ctx l s = Error e)
+Proof
+  rpt strip_tac >>
+  `EVERY (\i. ~is_terminator i.inst_opcode /\ i.inst_opcode <> INVOKE) l` by
+    (gvs[EVERY_MEM] >> metis_tac[not_barrier_implies]) >>
+  `EVERY (\i. ~is_ext_call_op i.inst_opcode) l` by
+    (gvs[EVERY_MEM] >> metis_tac[not_barrier_implies]) >>
+  `EVERY (\i. ~is_terminator i.inst_opcode /\
+               ~is_ext_call_op i.inst_opcode /\ i.inst_opcode <> INVOKE) l` by
+    (gvs[EVERY_MEM] >> metis_tac[not_barrier_implies]) >>
+  Cases_on `run_insts fuel ctx l s` >> gvs[]
+  >- metis_tac[run_insts_no_halt_intret]
+  >- metis_tac[run_insts_nofail_no_abort]
+  >> metis_tac[run_insts_no_halt_intret]
+QED
+
+(* Barrier-free topo-sorted perms produce identical OK or both Error *)
+Triviality barrier_free_topo_perm_result:
+  !l1 l2 dep fuel ctx s.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> bi_independent x y) /\
+    EVERY (\i. ~is_barrier i) l1 /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l1 ==>
+    (?e1 e2. run_insts fuel ctx l1 s = Error e1 /\
+             run_insts fuel ctx l2 s = Error e2) \/
+    run_insts fuel ctx l1 s = run_insts fuel ctx l2 s
+Proof
+  rpt strip_tac >>
+  `EVERY (\i. ~is_barrier i) l2 /\
+   EVERY (\i. ~is_terminator i.inst_opcode) l2` by
+    (gvs[EVERY_MEM] >> metis_tac[PERM_MEM_EQ]) >>
+  `(?v. run_insts fuel ctx l1 s = OK v) \/
+   (?e. run_insts fuel ctx l1 s = Error e)` by
+    metis_tac[barrier_free_only_ok_or_error]
+  >- (
+    (* l1 OK → l2 OK with same result *)
+    disj2_tac >>
+    `run_insts fuel ctx l2 s = OK v` by (
+      irule run_insts_topo_equiv >>
+      qexistsl [`dep`, `l1`] >> simp[]) >>
+    simp[]
+  )
+  >> (
+    (* l1 Error → l2 not OK (by contrapositive of reverse topo_equiv) → l2 Error *)
+    `!r. run_insts fuel ctx l2 s <> OK r` by (
+      rpt strip_tac >>
+      `run_insts fuel ctx l1 s = OK r` by (
+        irule run_insts_topo_equiv >>
+        qexistsl [`dep`, `l2`] >> simp[PERM_SYM] >>
+        conj_tac
+        >- (rpt strip_tac >>
+            `MEM x l1 /\ MEM y l1` by metis_tac[PERM_MEM_EQ] >>
+            first_x_assum irule >> simp[])
+        >> metis_tac[ALL_DISTINCT_PERM]) >>
+      gvs[]) >>
+    `(?e2. run_insts fuel ctx l2 s = Error e2)` by
+      metis_tac[barrier_free_only_ok_or_error] >>
+    metis_tac[]
+  )
+QED
+
+(* Like barrier_free_topo_perm_result but uses ef_commutes instead of
+   bi_independent. Needed for FRONT-level proof where Eff_MSIZE prevents
+   bi_independent for some effect_free pairs (MLOAD-MLOAD etc). *)
+(* Parameterized: barrier-free topo-sorted perms with custom P, Q predicates
+   produce identical OK or both Error. P = swap predicate, Q = element predicate. *)
+Triviality barrier_free_topo_perm_result_gen:
+  !P Q l1 l2 dep fuel ctx s.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!a b. P a b ==> P b a) /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> P x y) /\
+    (!a b s sa sab.
+       P a b /\ Q a /\ Q b /\
+       step_inst fuel ctx a s = OK sa /\
+       step_inst fuel ctx b sa = OK sab ==>
+       ?sb. step_inst fuel ctx b s = OK sb /\
+            step_inst fuel ctx a sb = OK sab) /\
+    EVERY Q l1 /\
+    EVERY (\i. ~is_barrier i) l1 /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l1 ==>
+    (?e1 e2. run_insts fuel ctx l1 s = Error e1 /\
+             run_insts fuel ctx l2 s = Error e2) \/
+    run_insts fuel ctx l1 s = run_insts fuel ctx l2 s
+Proof
+  rpt strip_tac >>
+  `EVERY (\i. ~is_barrier i) l2 /\
+   EVERY (\i. ~is_terminator i.inst_opcode) l2 /\
+   EVERY Q l2` by
+    (gvs[EVERY_MEM] >> metis_tac[PERM_MEM_EQ]) >>
+  `(?v. run_insts fuel ctx l1 s = OK v) \/
+   (?e. run_insts fuel ctx l1 s = Error e)` by
+    metis_tac[barrier_free_only_ok_or_error]
+  >- (
+    disj2_tac >>
+    `run_insts fuel ctx l2 s = OK v` by (
+      irule run_insts_topo_equiv_gen >>
+      qexistsl [`P`, `Q`, `dep`, `l1`] >> simp[]) >>
+    simp[])
+  >> (
+    `!r. run_insts fuel ctx l2 s <> OK r` by (
+      rpt strip_tac >>
+      `run_insts fuel ctx l1 s = OK r` by (
+        irule run_insts_topo_equiv_gen >>
+        qexistsl [`P`, `Q`, `dep`, `l2`] >> simp[PERM_SYM] >>
+        conj_tac
+        >- (rpt strip_tac >>
+            `MEM x l1 /\ MEM y l1` by metis_tac[PERM_MEM_EQ] >>
+            first_x_assum irule >> simp[])
+        >> metis_tac[ALL_DISTINCT_PERM]) >>
+      gvs[]) >>
+    `(?e2. run_insts fuel ctx l2 s = Error e2)` by
+      metis_tac[barrier_free_only_ok_or_error] >>
+    metis_tac[])
+QED
+
+(* ef_commutes instantiation *)
+Triviality ef_commutes_swap:
+  !fuel ctx a b s sa sab.
+    ef_commutes a b /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rw[ef_commutes_def] >> irule step_swap_ok_effect_free >> metis_tac[]
+QED
+
+Triviality barrier_free_topo_perm_result_ef:
+  !l1 l2 dep fuel ctx s.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> ef_commutes x y) /\
+    EVERY (\i. ~is_barrier i) l1 /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l1 ==>
+    (?e1 e2. run_insts fuel ctx l1 s = Error e1 /\
+             run_insts fuel ctx l2 s = Error e2) \/
+    run_insts fuel ctx l1 s = run_insts fuel ctx l2 s
+Proof
+  rpt strip_tac >>
+  mp_tac (SIMP_RULE (srw_ss()) [EVERY_MEM]
+    (ISPECL [``ef_commutes``, ``\i:instruction. T``]
+            barrier_free_topo_perm_result_gen)) >>
+  disch_then irule >>
+  rpt conj_tac
+  >- metis_tac[ef_commutes_swap]
+  >- metis_tac[ef_commutes_sym]
+  >- gvs[EVERY_MEM]
+  >- gvs[EVERY_MEM]
+  >- simp[]
+  >- simp[]
+  >> qexists `dep` >> simp[]
+QED
+
+(* Core theorem: two topo-sorted permutations that both abort produce the
+   same abort type. Direct argument (no induction needed):
+   1. run_insts_first_abort on l1 gives first aborting instruction at index k
+   2. That instruction must be a barrier (non-barriers are NoFail)
+   3. barriers_same_el: EL k l2 = EL k l1
+   4. barrier_prefix_perm + run_insts_topo_equiv: prefix in l2 also OKs to same state
+   5. Same barrier at same state → same step_inst result → same abort type *)
+Triviality barrier_induction_abort_type:
+  !l1 l2 dep fuel ctx s a1 s1 a2 s2.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted (TC dep) l1 /\ topo_sorted (TC dep) l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~TC dep x y /\ ~TC dep y x ==> bi_independent x y) /\
+    EVERY (\i. ~is_terminator i.inst_opcode /\
+               ~is_ext_call_op i.inst_opcode /\ i.inst_opcode <> INVOKE) l1 /\
+    (!b y. MEM b l1 /\ MEM y l1 /\ b <> y /\ is_barrier b ==>
+           TC dep b y \/ TC dep y b) /\
+    run_insts fuel ctx l1 s = Abort a1 s1 /\
+    run_insts fuel ctx l2 s = Abort a2 s2 ==>
+    a1 = a2
+Proof
+  rpt strip_tac >>
+  (* Step 1: First aborting instruction in l1 *)
+  qpat_x_assum `run_insts _ _ l1 _ = Abort a1 _` (strip_assume_tac o MATCH_MP run_insts_first_abort) >>
+  rename1 `step_inst fuel ctx (EL k l1) sk = Abort a1 _` >>
+  (* Step 2: Must be a barrier *)
+  `is_barrier (EL k l1)` by
+    (spose_not_then assume_tac >>
+     `~is_terminator (EL k l1).inst_opcode /\
+      ~is_ext_call_op (EL k l1).inst_opcode /\
+      (EL k l1).inst_opcode <> INVOKE` by gvs[EVERY_EL] >>
+     metis_tac[step_inst_nofail_no_abort]) >>
+  (* Step 3: Same barrier at same index in l2 *)
+  `EL k l2 = EL k l1` by metis_tac[barriers_same_el] >>
+  `LENGTH l2 = LENGTH l1` by metis_tac[PERM_LENGTH] >>
+  `k < LENGTH l2` by simp[] >>
+  (* Step 4: Prefix in l2 OKs to same state *)
+  `PERM (TAKE k l1) (TAKE k l2)` by metis_tac[barrier_prefix_perm] >>
+  `topo_sorted (TC dep) (TAKE k l1)` by (irule topo_sorted_take >> simp[]) >>
+  `topo_sorted (TC dep) (TAKE k l2)` by (irule topo_sorted_take >> simp[]) >>
+  `!x y. MEM x (TAKE k l1) /\ MEM y (TAKE k l1) /\ x <> y /\
+         ~TC dep x y /\ ~TC dep y x ==> bi_independent x y` by
+    (rpt strip_tac >>
+     qpat_x_assum `!x y. MEM x l1 /\ _ ==> bi_independent x y`
+       (fn th => irule th) >>
+     imp_res_tac MEM_TAKE >> simp[]) >>
+  `ALL_DISTINCT (TAKE k l1)` by simp[ALL_DISTINCT_TAKE] >>
+  `run_insts fuel ctx (TAKE k l2) s = OK sk` by
+    (irule run_insts_topo_equiv >>
+     qexistsl [`TC dep`, `TAKE k l1`] >> simp[]) >>
+  (* Step 5: Decompose l2 and use same barrier at same state *)
+  `step_inst fuel ctx (EL k l2) sk = Abort a1 sa'` by simp[] >>
+  (* l2's run_insts decomposes: prefix OK → barrier aborts *)
+  qpat_x_assum `run_insts _ _ l2 _ = Abort a2 _` mp_tac >>
+  `l2 = TAKE k l2 ++ [EL k l2] ++ DROP (SUC k) l2` by
+    simp[TAKE_DROP_SUC] >>
+  pop_assum (fn th => CONV_TAC (RATOR_CONV (RAND_CONV (ONCE_REWRITE_CONV [th])))) >>
+  once_rewrite_tac[GSYM APPEND_ASSOC] >>
+  rewrite_tac[run_insts_append] >> simp[run_insts_def]
+QED
+
+(* Sorted-by-predicate list decomposes as FILTER P ++ FILTER ~P *)
+Triviality sorted_pred_split:
+  !l P. (!i j. i < j /\ j < LENGTH l /\ P (EL j l) ==> P (EL i l)) ==>
+    FILTER P l ++ FILTER ($~ o P) l = l
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  Cases_on `P h` >> simp[]
+  >- (first_x_assum (qspec_then `P` mp_tac) >>
+      impl_tac >- (rpt strip_tac >> first_x_assum (qspecl_then [`SUC i`, `SUC j`] mp_tac) >> simp[]) >>
+      simp[])
+  >> (* h fails P. Then ALL elements fail P (if any passed, h would too) *)
+     `EVERY (\x. ~P x) l` by
+       (simp[EVERY_MEM, MEM_EL, PULL_EXISTS] >>
+        rpt strip_tac >> spose_not_then assume_tac >>
+        first_x_assum (qspecl_then [`0`, `SUC n`] mp_tac) >> simp[]) >>
+     `FILTER P l = []` by simp[FILTER_EQ_NIL] >>
+     `FILTER ($~ o P) l = l` by
+       (simp[FILTER_EQ_ID] >> fs[EVERY_MEM]) >>
+     simp[]
+QED
+
+(* ===== FRONT-based exec_block decomposition ===== *)
+
+(* For a well-formed block, FRONT has no terminators and LAST is the terminator.
+   exec_block = run_insts FRONT + step_inst LAST.
+   If run_insts FRONT produces OK, exec_block reduces to stepping the terminator.
+   If run_insts FRONT produces Abort/Error, exec_block propagates that. *)
+
+(* FRONT elements of a well-formed block are non-terminators *)
+Triviality front_no_terminators:
+  !bb. bb_well_formed bb ==>
+    EVERY (\i. ~is_terminator i.inst_opcode) (FRONT bb.bb_instructions)
+Proof
+  rpt strip_tac >>
+  `bb.bb_instructions <> []` by fs[bb_well_formed_def] >>
+  simp[EVERY_EL] >> rpt strip_tac >>
+  spose_not_then assume_tac >>
+  `~NULL bb.bb_instructions` by (Cases_on `bb.bb_instructions` >> gvs[]) >>
+  `EL n (FRONT bb.bb_instructions) = EL n bb.bb_instructions` by
+    simp[EL_FRONT] >>
+  `n < LENGTH bb.bb_instructions` by
+    (gvs[LENGTH_FRONT] >> Cases_on `bb.bb_instructions` >> gvs[]) >>
+  `n = PRE (LENGTH bb.bb_instructions)` by
+    (qpat_x_assum `bb_well_formed _` mp_tac >>
+     simp[bb_well_formed_def] >> strip_tac >>
+     first_x_assum irule >> gvs[]) >>
+  gvs[LENGTH_FRONT]
+QED
+
+(* block_body = non-pseudo elements of FRONT *)
+Triviality block_body_filter_front:
+  !bb. bb_well_formed bb ==>
+    block_body bb =
+      FILTER (\i. ~is_pseudo i.inst_opcode) (FRONT bb.bb_instructions)
+Proof
+  rpt strip_tac >>
+  `bb.bb_instructions <> []` by fs[bb_well_formed_def] >>
+  simp[block_body_def] >>
+  `bb.bb_instructions = FRONT bb.bb_instructions ++ [LAST bb.bb_instructions]` by
+    metis_tac[APPEND_FRONT_LAST] >>
+  pop_assum (fn th => CONV_TAC (LHS_CONV (ONCE_REWRITE_CONV [th]))) >>
+  simp[FILTER_APPEND_DISTRIB] >>
+  `is_terminator (LAST bb.bb_instructions).inst_opcode` by
+    fs[bb_well_formed_def] >>
+  `~is_pseudo (LAST bb.bb_instructions).inst_opcode` by
+    (Cases_on `(LAST bb.bb_instructions).inst_opcode` >>
+     gvs[is_pseudo_def, is_terminator_def]) >>
+  simp[] >>
+  drule front_no_terminators >> strip_tac >>
+  simp[FILTER_EQ] >> rpt strip_tac >>
+  res_tac >> gvs[EVERY_MEM]
+QED
+
+(* exec_block with run_insts FRONT producing OK: reduces to terminator step *)
+Triviality exec_block_front_ok:
+  !bb fuel ctx s s'.
+    bb_well_formed bb /\
+    run_insts fuel ctx (FRONT bb.bb_instructions) s = OK s' ==>
+    exec_block fuel ctx bb (s with vs_inst_idx := 0) =
+      (let r = step_inst fuel ctx (LAST bb.bb_instructions)
+                 (s' with vs_inst_idx := LENGTH (FRONT bb.bb_instructions)) in
+       case r of
+         OK s'' => if is_terminator (LAST bb.bb_instructions).inst_opcode
+                   then if s''.vs_halted then Halt s'' else OK s''
+                   else exec_block fuel ctx bb
+                          (s'' with vs_inst_idx :=
+                             SUC (LENGTH (FRONT bb.bb_instructions)))
+       | IntRet v s'' => IntRet v s''
+       | Halt s'' => Halt s''
+       | Abort a s'' => Abort a s''
+       | Error e => Error e)
+Proof
+  rpt strip_tac >>
+  `bb.bb_instructions <> []` by fs[bb_well_formed_def] >>
+  drule front_no_terminators >> strip_tac >>
+  (* Use exec_block_skip_prefix_general with prefix = FRONT *)
+  `exec_block fuel ctx bb (s with vs_inst_idx := 0) =
+   exec_block fuel ctx bb
+     (s' with vs_inst_idx := 0 + LENGTH (FRONT bb.bb_instructions))` by
+    (qspecl_then [`FRONT bb.bb_instructions`, `fuel`, `ctx`, `bb`, `s`,
+                   `0`, `s'`] mp_tac exec_block_skip_prefix_general >>
+     simp[EL_FRONT, NULL_EQ, listTheory.LENGTH_FRONT]) >>
+  simp[] >>
+  (* Now exec_block at position LENGTH FRONT: that's the LAST instruction *)
+  CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [exec_block_def])) >>
+  simp[get_instruction_def] >>
+  `LENGTH (FRONT bb.bb_instructions) < LENGTH bb.bb_instructions` by
+    (Cases_on `bb.bb_instructions` >> gvs[FRONT_DEF] >> simp[LENGTH_FRONT]) >>
+  simp[] >>
+  `bb.bb_instructions = FRONT bb.bb_instructions ++
+     [LAST bb.bb_instructions]` by metis_tac[APPEND_FRONT_LAST] >>
+  `EL (LENGTH (FRONT bb.bb_instructions)) bb.bb_instructions =
+     LAST bb.bb_instructions` by
+    (`LENGTH (FRONT bb.bb_instructions) =
+      PRE (LENGTH bb.bb_instructions)` by
+       (Cases_on `bb.bb_instructions` >> gvs[FRONT_DEF] >> simp[LENGTH_FRONT]) >>
+     simp[LAST_EL]) >>
+  simp[LET_THM]
+QED
+
+(* exec_block with run_insts FRONT producing non-OK: exec_block propagates.
+   Since FRONT has no terminators, each step either OKs and continues,
+   or produces the non-OK result. *)
+(* Unified: FRONT non-OK → exec_block gives lift_result-related result.
+   Replaces exec_block_front_{abort,error,halt,intret}. *)
+Triviality exec_block_front_non_ok:
+  !bb fuel ctx s.
+    bb_well_formed bb /\
+    ~(?v. run_insts fuel ctx (FRONT bb.bb_instructions) s = OK v) ==>
+    lift_result (\_ _. T) (execution_equiv {}) revert_equiv
+      (run_insts fuel ctx (FRONT bb.bb_instructions) s)
+      (exec_block fuel ctx bb (s with vs_inst_idx := 0))
+Proof
+  rpt strip_tac >>
+  `bb.bb_instructions <> []` by fs[bb_well_formed_def] >>
+  drule front_no_terminators >> strip_tac >>
+  irule exec_block_run_insts_lift >>
+  gvs[EL_FRONT, NULL_EQ, listTheory.LENGTH_FRONT]
+QED
+
+
+(* ===== FRONT-level PERM and topo_sorted for run_insts_topo_lift ===== *)
+
+(* PERM l (FILTER P l ++ FILTER ~P l) — standard list theory *)
+Triviality perm_filter_partition:
+  !l P. PERM l (FILTER P l ++ FILTER (\x. ~P x) l)
+Proof
+  Induct >> simp[] >> rpt gen_tac >>
+  Cases_on `P h` >> gvs[PERM_CONS_IFF] >>
+  irule CONS_PERM >> simp[]
+QED
+
+(* Pseudos (PHI/PARAM) are bi_independent of non-dep instructions.
+   Key facts: effect_free, NoFail, not terminator/alloca/ext/INVOKE,
+   and ssa_form prevents data/output overlap for non-dep pairs. *)
+Triviality pseudo_bi_independent:
+  !p i.
+    is_pseudo p.inst_opcode /\
+    ~is_terminator i.inst_opcode /\
+    ~is_alloca_op i.inst_opcode /\
+    ~is_ext_call_op i.inst_opcode /\
+    i.inst_opcode <> INVOKE /\
+    DISJOINT (set (inst_defs p)) (set (inst_uses i)) /\
+    DISJOINT (set (inst_defs i)) (set (inst_uses p)) /\
+    DISJOINT (set (inst_defs p)) (set (inst_defs i)) ==>
+    bi_independent p i
+Proof
+  rw[bi_independent_def] >>
+  Cases_on `p.inst_opcode` >> gvs[is_pseudo_def] >>
+  simp[effects_independent_def, abort_compatible_def,
+       is_effect_free_op_def, read_effects_def, write_effects_def,
+       is_terminator_def, is_alloca_op_def, is_ext_call_op_def,
+       opcode_fail_class_def, empty_effects_def]
+QED
+
+(* Two distinct instructions in fn_insts can't share an output variable *)
+Triviality ssa_no_shared_output:
+  !fn i1 i2 v.
+    ssa_form fn /\ MEM i1 (fn_insts fn) /\ MEM i2 (fn_insts fn) /\
+    i1 <> i2 /\ MEM v i1.inst_outputs /\ MEM v i2.inst_outputs ==>
+    F
+Proof
+  rw[ssa_form_def, fn_insts_def] >>
+  metis_tac[all_distinct_flat_map_disjoint]
+QED
+
+(* Consequence: distinct same-block instructions have disjoint defs *)
+Triviality ssa_disjoint_defs:
+  !fn bb i1 i2.
+    ssa_form fn /\ MEM bb fn.fn_blocks /\
+    MEM i1 bb.bb_instructions /\ MEM i2 bb.bb_instructions /\ i1 <> i2 ==>
+    DISJOINT (set (inst_defs i1)) (set (inst_defs i2))
+Proof
+  rpt strip_tac >>
+  simp[inst_defs_def, pred_setTheory.DISJOINT_DEF, pred_setTheory.EXTENSION] >>
+  metis_tac[ssa_no_shared_output, mem_fn_insts_blocks, fn_insts_def]
+QED
+
+(* Key: pseudo inst_id is not among non-pseudo inst_ids *)
+Triviality pseudo_id_not_in_nonpseudo:
+  !bi p.
+    is_pseudo p.inst_opcode /\ MEM p bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    ~MEM p.inst_id (MAP (\i. i.inst_id)
+      (FILTER (\i. ~is_pseudo i.inst_opcode) bi))
+Proof
+  rpt strip_tac >> gvs[MEM_MAP, MEM_FILTER] >>
+  (* y is non-pseudo, MEM y bi, y.inst_id = p.inst_id *)
+  (* By ALL_DISTINCT MAP inst_id, y = p. But y is non-pseudo, p is pseudo. *)
+  gvs[MEM_EL] >>
+  `EL n (MAP (\i. i.inst_id) bi) = EL n' (MAP (\i. i.inst_id) bi)` by
+    simp[EL_MAP] >>
+  `n < LENGTH (MAP (\i. i.inst_id) bi) /\
+   n' < LENGTH (MAP (\i. i.inst_id) bi)` by simp[] >>
+  metis_tac[ALL_DISTINCT_EL_IMP]
+QED
+
+(* Helper: FOLDL with |+ from list elements has FDOM ⊆ initial ∪ list_ids.
+   Stated without let to avoid IH matching issues. *)
+Triviality fdom_chain_foldl:
+  !l (eda:num |-> instruction list) prev.
+    FDOM (FST (FOLDL (\(acc,prev) (inst:instruction).
+      (acc |+ (inst.inst_id,
+        case prev of NONE =>
+          (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+        | SOME p =>
+          if MEM p (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+          then (case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)
+          else p::(case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds)),
+       SOME inst)) (eda,prev) l))
+    SUBSET (FDOM eda UNION set (MAP (\i. i.inst_id) l))
+Proof
+  Induct >> simp[] >> rpt gen_tac >>
+  qmatch_goalsub_abbrev_tac `FOLDL _ (eda',_) l` >>
+  first_x_assum (qspecl_then [`eda'`, `SOME h`] mp_tac) >>
+  `FDOM eda' = h.inst_id INSERT FDOM eda` by
+    simp[Abbr `eda'`, FDOM_FUPDATE] >>
+  strip_tac >> irule SUBSET_TRANS >> qexists `FDOM eda' UNION set (MAP (\i. i.inst_id) l)` >>
+  simp[] >> simp[SUBSET_DEF] >> metis_tac[]
+QED
+
+(* FDOM of build_eda FOLDL is subset of accumulator FDOM + list inst_ids *)
+Triviality fdom_build_eda_foldl:
+  !l (acc:num |-> instruction list) et.
+    FDOM (FST (FOLDL (\(acc_map,et) inst.
+      (\(deps,et'). (acc_map |+ (inst.inst_id, deps), et'))
+        (compute_effect_deps et inst)) (acc,et) l))
+    SUBSET (FDOM acc UNION set (MAP (\i. i.inst_id) l))
+Proof
+  Induct >> simp[] >> rpt gen_tac >>
+  Cases_on `compute_effect_deps et h` >>
+  first_x_assum (qspecl_then [`acc |+ (h.inst_id, q)`, `r`] mp_tac) >>
+  simp[FDOM_FUPDATE, SUBSET_DEF] >> metis_tac[]
+QED
+
+(* FDOM of build_eda is subset of non-pseudo inst_ids *)
+Triviality fdom_build_eda:
+  !bi. FDOM (build_eda bi) SUBSET
+       set (MAP (\i. i.inst_id) (FILTER (\i. ~is_pseudo i.inst_opcode) bi))
+Proof
+  gen_tac >> simp[build_eda_def, LET_THM] >>
+  qspecl_then [`FILTER (\i. ~is_pseudo i.inst_opcode) bi`,
+               `FEMPTY`, `empty_effect_track`]
+    mp_tac fdom_build_eda_foldl >>
+  simp[FDOM_FEMPTY]
+QED
+
+(* FDOM of add_deps_on_barrier: only adds keys from non-pseudo list *)
+Triviality fdom_on_barrier_foldl:
+  !l (eda:num |-> instruction list) lb.
+    FDOM (FST (FOLDL (\(acc,last_bar) inst.
+      let old_deps = case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds in
+      if is_barrier inst then (acc, SOME inst)
+      else let new_deps = case last_bar of NONE => old_deps
+           | SOME b => if MEM b old_deps then old_deps else b::old_deps
+           in (acc |+ (inst.inst_id, new_deps), last_bar))
+      (eda,lb) l))
+    SUBSET (FDOM eda UNION set (MAP (\i. i.inst_id) l))
+Proof
+  Induct >> simp[] >> rpt gen_tac >>
+  Cases_on `is_barrier h` >> simp[LET_THM]
+  >- (first_x_assum (qspecl_then [`eda`, `SOME h`] mp_tac) >>
+      simp[LET_THM, SUBSET_DEF] >> metis_tac[])
+  >> (qmatch_goalsub_abbrev_tac `FOLDL _ (eda',_) l` >>
+      first_x_assum (qspecl_then [`eda'`, `lb`] mp_tac) >>
+      simp[LET_THM] >>
+      `FDOM eda' = h.inst_id INSERT FDOM eda` by
+        simp[Abbr `eda'`, FDOM_FUPDATE] >>
+      simp[SUBSET_DEF] >> metis_tac[])
+QED
+
+Triviality fdom_add_deps_on_barrier:
+  !bi eda. FDOM (add_deps_on_barrier bi eda) SUBSET
+           FDOM eda UNION set (MAP (\i. i.inst_id) (FILTER (\i. ~is_pseudo i.inst_opcode) bi))
+Proof
+  rpt gen_tac >> simp[add_deps_on_barrier_def, LET_THM] >>
+  qspecl_then [`FILTER (\i. ~is_pseudo i.inst_opcode) bi`, `eda`, `NONE`]
+    mp_tac fdom_on_barrier_foldl >> simp[]
+QED
+
+(* FDOM of add_deps_from_barrier: only adds keys from non-pseudo list *)
+Triviality fdom_from_barrier_foldl:
+  !l (eda:num |-> instruction list) pi.
+    FDOM (FST (FOLDL (\(acc,prev_insts) inst.
+      if is_barrier inst then
+        let old_deps = case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds;
+            new_deps = FOLDL (\ds p. if MEM p ds then ds else p::ds)
+                       old_deps prev_insts
+        in (acc |+ (inst.inst_id, new_deps), prev_insts ++ [inst])
+      else (acc, prev_insts ++ [inst]))
+      (eda,pi) l))
+    SUBSET (FDOM eda UNION set (MAP (\i. i.inst_id) l))
+Proof
+  Induct >> simp[] >> rpt gen_tac >>
+  first_x_assum (mp_tac o SIMP_RULE (srw_ss()) [LET_THM]) >>
+  Cases_on `is_barrier h` >> simp[LET_THM]
+  >- (disch_then (qspecl_then
+        [`eda |+ (h.inst_id,
+            FOLDL (\ds p. if MEM p ds then ds else p::ds)
+              (case FLOOKUP eda h.inst_id of NONE => [] | SOME ds => ds) pi')`,
+         `pi' ++ [h]`] mp_tac) >>
+      simp[FDOM_FUPDATE, SUBSET_DEF] >> metis_tac[])
+  >> (disch_then (qspecl_then [`eda`, `pi' ++ [h]`] mp_tac) >>
+      simp[SUBSET_DEF] >> metis_tac[])
+QED
+
+Triviality fdom_add_deps_from_barrier:
+  !bi eda. FDOM (add_deps_from_barrier bi eda) SUBSET
+           FDOM eda UNION set (MAP (\i. i.inst_id) (FILTER (\i. ~is_pseudo i.inst_opcode) bi))
+Proof
+  rpt gen_tac >> simp[add_deps_from_barrier_def, LET_THM] >>
+  qspecl_then [`FILTER (\i. ~is_pseudo i.inst_opcode) bi`, `eda`, `[]`]
+    mp_tac fdom_from_barrier_foldl >> simp[]
+QED
+
+(* FDOM of add_chain_deps: only adds keys from non-pseudo list *)
+Triviality fdom_add_chain_deps:
+  !P' bi eda. FDOM (add_chain_deps P' bi eda) SUBSET
+              FDOM eda UNION set (MAP (\i. i.inst_id)
+                (FILTER (\i. ~is_pseudo i.inst_opcode) bi))
+Proof
+  rpt gen_tac >> simp[add_chain_deps_def, LET_THM] >>
+  irule SUBSET_TRANS >> irule_at Any fdom_chain_foldl >>
+  simp[UNION_SUBSET, SUBSET_DEF, MEM_MAP, MEM_FILTER] >> metis_tac[]
+QED
+
+(* FDOM of build_full_eda: only contains non-pseudo inst_ids *)
+Triviality fdom_build_full_eda:
+  !bi. FDOM (build_full_eda bi) SUBSET
+       set (MAP (\i. i.inst_id) (FILTER (\i. ~is_pseudo i.inst_opcode) bi))
+Proof
+  gen_tac >>
+  simp[build_full_eda_def, add_alloca_deps_def,
+       add_barrier_deps_def, add_abort_deps_def] >>
+  qabbrev_tac `ids = set (MAP (\i. i.inst_id)
+    (FILTER (\i. ~is_pseudo i.inst_opcode) bi))` >>
+  (* Helper: each layer preserves SUBSET ids *)
+  `!P eda. FDOM eda SUBSET ids ==> FDOM (add_chain_deps P bi eda) SUBSET ids` by
+    (rpt strip_tac >> irule SUBSET_TRANS >>
+     irule_at Any fdom_add_chain_deps >>
+     simp[Abbr `ids`, UNION_SUBSET]) >>
+  `!eda. FDOM eda SUBSET ids ==> FDOM (add_deps_on_barrier bi eda) SUBSET ids` by
+    (rpt strip_tac >> irule SUBSET_TRANS >>
+     irule_at Any fdom_add_deps_on_barrier >>
+     simp[Abbr `ids`, UNION_SUBSET]) >>
+  `!eda. FDOM eda SUBSET ids ==> FDOM (add_deps_from_barrier bi eda) SUBSET ids` by
+    (rpt strip_tac >> irule SUBSET_TRANS >>
+     irule_at Any fdom_add_deps_from_barrier >>
+     simp[Abbr `ids`, UNION_SUBSET]) >>
+  `FDOM (build_eda bi) SUBSET ids` by
+    (irule SUBSET_TRANS >> irule_at Any fdom_build_eda >>
+     simp[Abbr `ids`]) >>
+  metis_tac[]
+QED
+
+(* EDA has no entry for pseudo instruction ids *)
+Triviality build_full_eda_pseudo_none:
+  !bi p.
+    is_pseudo p.inst_opcode /\ MEM p bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    FLOOKUP (build_full_eda bi) p.inst_id = NONE
+Proof
+  rpt strip_tac >>
+  drule_all pseudo_id_not_in_nonpseudo >> strip_tac >>
+  simp[FLOOKUP_DEF] >> strip_tac >>
+  mp_tac (SPEC_ALL fdom_build_full_eda) >>
+  simp[SUBSET_DEF] >> metis_tac[]
+QED
+
+(* Helper: no forward data dependency in a well-formed SSA block.
+   If i < j in a block, EL i cannot use a variable defined by EL j. *)
+Triviality no_forward_data_dep:
+  !fn bb i j.
+    wf_ssa fn /\ wf_function fn /\ MEM bb fn.fn_blocks /\
+    i < j /\ j < LENGTH bb.bb_instructions ==>
+    DISJOINT (set (inst_uses (EL i bb.bb_instructions)))
+             (set (inst_defs (EL j bb.bb_instructions)))
+Proof
+  rpt strip_tac >>
+  qabbrev_tac `bi = bb.bb_instructions` >>
+  simp[pred_setTheory.DISJOINT_DEF, pred_setTheory.EXTENSION] >>
+  spose_not_then strip_assume_tac >> rename1 `MEM v _` >>
+  `MEM (Var v) (EL i bi).inst_operands` by
+    gvs[inst_uses_def, MEM_operand_vars_iff] >>
+  `MEM v (EL j bi).inst_outputs` by fs[inst_defs_def] >>
+  (* EL i and EL j are distinct *)
+  `ALL_DISTINCT (MAP (\i. i.inst_id) bi)` by
+    (simp[Abbr `bi`] >> metis_tac[bb_inst_ids_distinct]) >>
+  `i < LENGTH bi` by decide_tac >>
+  `EL i bi <> EL j bi` by
+    (`ALL_DISTINCT bi` by metis_tac[ALL_DISTINCT_MAP] >>
+     `i <> j` by decide_tac >> metis_tac[ALL_DISTINCT_EL_IMP]) >>
+  (* Both are MEM of bb.bb_instructions *)
+  `MEM (EL i bi) bi /\ MEM (EL j bi) bi` by metis_tac[MEM_EL] >>
+  (* Both are in fn_insts *)
+  `MEM (EL i bi) (fn_insts fn) /\ MEM (EL j bi) (fn_insts fn)` by
+    (simp[Abbr `bi`] >>
+     conj_tac >> irule mem_fn_insts_intro >> qexists `bb` >> simp[MEM_EL] >>
+     metis_tac[]) >>
+  (* def_dominates_uses gives us a defining instruction for v *)
+  `def_dominates_uses fn` by gvs[wf_ssa_def] >>
+  qpat_x_assum `def_dominates_uses _`
+    (strip_assume_tac o REWRITE_RULE[def_dominates_uses_def]) >>
+  first_x_assum (qspecl_then [`bb`, `EL i bi`, `v`] mp_tac) >>
+  impl_tac >- (simp[Abbr `bi`, MEM_EL] >> metis_tac[MEM_EL]) >>
+  strip_tac >>
+  (* def_inst = EL j bi by ssa_form uniqueness *)
+  `ssa_form fn` by gvs[wf_ssa_def] >>
+  `MEM def_inst (fn_insts fn)` by
+    (irule mem_fn_insts_intro >> qexists `def_bb` >> simp[]) >>
+  `def_inst = EL j bi` by
+    metis_tac[ssa_unique_output, inst_defs_def] >>
+  gvs[] >>
+  (* def_bb = bb: EL j bi is in both def_bb and bb.
+     By fn_inst_ids_distinct, instruction IDs are unique across all blocks,
+     so these must be the same block. *)
+  `def_bb = bb` by
+    (spose_not_then assume_tac >>
+     qspecl_then [`fn.fn_blocks`,
+       `\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
+       `def_bb`, `bb`, `(EL j bi).inst_id`]
+       mp_tac all_distinct_flat_map_disjoint >>
+     simp[MEM_MAP] >>
+     gvs[wf_function_def, fn_inst_ids_distinct_def] >>
+     conj_tac >> qexists `EL j bi` >>
+     simp[Abbr `bi`, MEM_EL] >> metis_tac[]) >>
+  gvs[] >>
+  (* Now: i' < j' < LENGTH bi, EL i' bi = EL j bi, EL j' bi = EL i bi
+     By ALL_DISTINCT: i' = j, j' = i. So j < i. But i < j. *)
+  `ALL_DISTINCT bi` by metis_tac[ALL_DISTINCT_MAP] >>
+  `i' < LENGTH bi /\ i < LENGTH bi` by decide_tac >>
+  `i' = j` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+  `j' = i` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+  gvs[]
+QED
+
+(* Reverse of filter_el_mono: positions in full list → positions in FILTER *)
+Triviality filter_el_mono_rev:
+  !P (l:'a list) i j. ALL_DISTINCT l /\ i < j /\ j < LENGTH l /\
+    P (EL i l) /\ P (EL j l) ==>
+    ?i' j'. i' < j' /\ j' < LENGTH (FILTER P l) /\
+            EL i' (FILTER P l) = EL i l /\
+            EL j' (FILTER P l) = EL j l
+Proof
+  rpt strip_tac >>
+  `i < LENGTH l` by decide_tac >>
+  qexistsl [`LENGTH (FILTER P (TAKE i l))`,
+            `LENGTH (FILTER P (TAKE j l))`] >>
+  `l = TAKE i l ++ EL i l :: DROP (SUC i) l` by
+    metis_tac[DROP_CONS_EL, TAKE_DROP, APPEND_ASSOC, CONS_APPEND] >>
+  `l = TAKE j l ++ EL j l :: DROP (SUC j) l` by
+    metis_tac[DROP_CONS_EL, TAKE_DROP, APPEND_ASSOC, CONS_APPEND] >>
+  rpt conj_tac
+  >- suspend "lt_ij"
+  >- suspend "lt_jl"
+  >- suspend "el_i"
+  >> suspend "el_j"
+QED
+
+Resume filter_el_mono_rev[lt_ij]:
+  (* LENGTH (FILTER P (TAKE i l)) < LENGTH (FILTER P (TAKE j l)) *)
+  `FILTER P (TAKE j l) = FILTER P (TAKE i l) ++
+     FILTER P (DROP i (TAKE j l))` by
+    (`TAKE j l = TAKE i (TAKE j l) ++ DROP i (TAKE j l)` by
+       metis_tac[TAKE_DROP] >>
+     `TAKE i (TAKE j l) = TAKE i l` by simp[TAKE_TAKE_T] >>
+     pop_assum (fn th => SUBST1_TAC (GSYM th)) >>
+     metis_tac[FILTER_APPEND_DISTRIB]) >>
+  simp[] >>
+  `DROP i (TAKE j l) = TAKE (j - i) (DROP i l)` by
+    simp[DROP_TAKE] >>
+  `DROP i l = EL i l :: DROP (SUC i) l` by simp[DROP_CONS_EL] >>
+  Cases_on `j - i` >> gvs[]
+QED
+
+Resume filter_el_mono_rev[lt_jl]:
+  (* LENGTH (FILTER P (TAKE j l)) < LENGTH (FILTER P l) *)
+  `FILTER P l = FILTER P (TAKE j l) ++ FILTER P (DROP j l)` by
+    metis_tac[TAKE_DROP, FILTER_APPEND_DISTRIB] >>
+  `DROP j l = EL j l :: DROP (SUC j) l` by simp[DROP_CONS_EL] >>
+  simp[]
+QED
+
+Resume filter_el_mono_rev[el_i]:
+  qspecl_then [`P`, `l`, `TAKE i l`, `DROP (SUC i) l`, `EL i l`]
+    mp_tac FILTER_EL_IMP >> simp[LET_THM]
+QED
+
+Resume filter_el_mono_rev[el_j]:
+  qspecl_then [`P`, `l`, `TAKE j l`, `DROP (SUC j) l`, `EL j l`]
+    mp_tac FILTER_EL_IMP >> simp[LET_THM]
+QED
+
+Finalise filter_el_mono_rev
+
+(* FRONT of a well-formed block is topo_sorted under full_dep *)
+Triviality front_topo_sorted:
+  !fn bb eda.
+    wf_ssa fn /\ wf_function fn /\
+    MEM bb fn.fn_blocks /\
+    eda = build_full_eda bb.bb_instructions ==>
+    topo_sorted (full_dep eda) (FRONT bb.bb_instructions)
+Proof
+  rpt strip_tac >>
+  simp[topo_sorted_def] >>
+  qx_gen_tac `p` >> qx_gen_tac `q` >> strip_tac >>
+  `bb_well_formed bb` by
+    (drule (iffLR wf_function_def) >> strip_tac >>
+     first_x_assum drule >> simp[]) >>
+  `bb.bb_instructions <> []` by fs[bb_well_formed_def] >>
+  drule_all bb_inst_ids_distinct >> strip_tac >>
+  qabbrev_tac `bi = bb.bb_instructions` >>
+  simp[EL_FRONT, NULL_EQ] >>
+  `q < LENGTH bi` by
+    (qpat_x_assum `q < LENGTH (FRONT bi)` mp_tac >>
+     simp[LENGTH_FRONT]) >>
+  `p < LENGTH bi` by simp[] >>
+  imp_res_tac ALL_DISTINCT_MAP >>
+  simp[full_dep_def] >>
+  rpt strip_tac
+  >- suspend "eda_dep"
+  >- suspend "data_dep"
+  >> suspend "output_alias"
+QED
+
+Resume front_topo_sorted[eda_dep]:
+  `MEM (EL p bi) bi /\ MEM (EL q bi) bi` by metis_tac[MEM_EL] >>
+  Cases_on `is_pseudo (EL p bi).inst_opcode`
+  >- (`FLOOKUP (build_full_eda bi) (EL p bi).inst_id = NONE` by
+        (irule build_full_eda_pseudo_none >> simp[]) >>
+      fs[eda_dep_def])
+  >> Cases_on `is_pseudo (EL q bi).inst_opcode`
+  >- (fs[eda_dep_def] >>
+      Cases_on `FLOOKUP (build_full_eda bi) (EL p bi).inst_id` >> fs[] >>
+      `eda_wf (build_full_eda bi) bi` by simp[build_full_eda_wf] >>
+      fs[eda_wf_def] >>
+      rename1 `FLOOKUP _ _ = SOME deps` >>
+      rename1 `MEM d0 deps` >>
+      `MEM d0 bi /\ ~is_pseudo d0.inst_opcode` by metis_tac[] >>
+      `d0 = EL q bi` by metis_tac[all_distinct_map_mem_inj] >>
+      fs[])
+  >> (* Both non-pseudo: reduce to block_body_topo_sorted *)
+  qabbrev_tac `bd = block_body bb` >>
+  `bd = FILTER (\x. ~is_pseudo x.inst_opcode /\ ~is_terminator x.inst_opcode) bi` by
+    simp[Abbr `bd`, block_body_def, Abbr `bi`] >>
+  (* Both EL p bi and EL q bi are non-terminators (in FRONT) *)
+  `~is_terminator (EL p bi).inst_opcode /\ ~is_terminator (EL q bi).inst_opcode` by
+    (`EVERY (\inst. ~is_terminator inst.inst_opcode) (FRONT bi)` by
+       (simp[Abbr `bi`] >> metis_tac[front_no_terminators]) >>
+     `p < LENGTH (FRONT bi)` by simp[] >>
+     qpat_x_assum `EVERY _ (FRONT bi)` mp_tac >>
+     simp[EVERY_EL, EL_FRONT, NULL_EQ]) >>
+  `?pp qq. pp < qq /\ qq < LENGTH bd /\
+           EL pp bd = EL p bi /\ EL qq bd = EL q bi` by
+    (qspecl_then [`\x. ~is_pseudo x.inst_opcode /\ ~is_terminator x.inst_opcode`,
+                  `bi`, `p`, `q`]
+       mp_tac filter_el_mono_rev >> simp[]) >>
+  `topo_sorted (full_dep (build_full_eda bi)) bd` by
+    (simp[Abbr `bd`, Abbr `bi`] >> metis_tac[block_body_topo_sorted]) >>
+  fs[topo_sorted_def] >>
+  first_x_assum (qspecl_then [`pp`, `qq`] mp_tac) >> simp[] >>
+  simp[full_dep_def]
+QED
+
+Resume front_topo_sorted[data_dep]:
+  qspecl_then [`fn`, `bb`, `p`, `q`] mp_tac no_forward_data_dep >>
+  simp[Abbr `bi`]
+QED
+
+Resume front_topo_sorted[output_alias]:
+  `EL p bi <> EL q bi` by
+    (strip_tac >> `p = q` suffices_by simp[] >>
+     metis_tac[ALL_DISTINCT_EL_IMP]) >>
+  `MEM (EL p bi) bi /\ MEM (EL q bi) bi` by metis_tac[MEM_EL] >>
+  `ssa_form fn` by fs[wf_ssa_def] >>
+  qspecl_then [`fn`, `bb`, `EL p bi`, `EL q bi`] mp_tac ssa_disjoint_defs >>
+  simp[Abbr `bi`]
+QED
+
+Finalise front_topo_sorted
+
+Triviality terminator_not_pseudo_not_flippable:
+  !op. is_terminator op ==> ~is_pseudo op /\ ~is_flippable op
+Proof
+  Cases >> simp[is_terminator_def, is_pseudo_def, is_flippable_def,
+                is_commutative_def, is_comparator_def]
+QED
+
+(* Helper: same terminator for block_perm_of blocks *)
+Triviality block_perm_of_same_last:
+  !fn bb bb'.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label /\
+    bb_well_formed bb /\ bb_well_formed bb' ==>
+    LAST bb'.bb_instructions = LAST bb.bb_instructions
+Proof
+  rpt strip_tac >>
+  (* 1. Get bb_orig = bb from block_perm_of *)
+  fs[block_perm_of_def] >>
+  `bb_orig = bb` by
+    (irule (GSYM wf_fn_same_label_eq) >> simp[] >> metis_tac[]) >>
+  gvs[] >>
+  (* 2. LAST bb is a terminator, hence non-pseudo, non-flippable *)
+  `bb.bb_instructions <> []` by fs[bb_well_formed_def] >>
+  `is_terminator (LAST bb.bb_instructions).inst_opcode` by
+    fs[bb_well_formed_def] >>
+  `~is_pseudo (LAST bb.bb_instructions).inst_opcode /\
+   ~is_flippable (LAST bb.bb_instructions).inst_opcode` by
+    metis_tac[terminator_not_pseudo_not_flippable] >>
+  (* 3. LAST bb is in non-pseudo filter → its inst_id in PERM *)
+  `MEM (LAST bb.bb_instructions)
+     (FILTER (\i. ~is_pseudo i.inst_opcode) bb.bb_instructions)` by
+    (simp[MEM_FILTER] >> irule MEM_LAST_NOT_NIL >> simp[]) >>
+  (* 4. By PERM, some instruction y' in bb' has same inst_id *)
+  `MEM (LAST bb.bb_instructions).inst_id
+     (MAP (\i. i.inst_id)
+       (FILTER (\i. ~is_pseudo i.inst_opcode) bb'.bb_instructions))` by
+    (imp_res_tac PERM_MEM_EQ >> gs[MEM_MAP] >> metis_tac[]) >>
+  gvs[MEM_MAP] >>
+  rename1 `MEM y' (FILTER _ bb'.bb_instructions)` >>
+  (* 5. y' comes from_block bb, so exists j in bb with y'=j or y'=flip j *)
+  `from_block bb.bb_instructions y'` by (gs[EVERY_MEM]) >>
+  `ALL_DISTINCT (MAP (\x. x.inst_id) bb.bb_instructions)` by
+    metis_tac[bb_inst_ids_distinct] >>
+  fs[from_block_def]
+  (* Case 1: y' = j (identity) *)
+  >- (
+    (* j.inst_id = (LAST bb).inst_id and both MEM in bb → j = LAST bb *)
+    `j = LAST bb.bb_instructions` by
+      metis_tac[all_distinct_map_mem_inj, MEM_LAST_NOT_NIL] >>
+    gvs[] >>
+    (* LAST bb is MEM in bb' (from MEM_FILTER), hence at LAST position *)
+    `MEM (LAST bb.bb_instructions) bb'.bb_instructions` by
+      fs[MEM_FILTER] >>
+    `bb'.bb_instructions <> []` by fs[bb_well_formed_def] >>
+    gs[MEM_EL] >>
+    rename1 `k < LENGTH bb'.bb_instructions` >>
+    `k = PRE (LENGTH bb'.bb_instructions)` by
+      (qpat_x_assum `bb_well_formed bb'` mp_tac >>
+       simp[bb_well_formed_def]) >>
+    gs[LAST_EL]
+  )
+  (* Case 2: y' = flip_operands j, is_flippable j *)
+  >> (
+    (* (flip_operands j).inst_id = j.inst_id = (LAST bb).inst_id *)
+    `j.inst_id = (LAST bb.bb_instructions).inst_id` by
+      metis_tac[flip_operands_inst_id] >>
+    `j = LAST bb.bb_instructions` by
+      metis_tac[all_distinct_map_mem_inj, MEM_LAST_NOT_NIL] >>
+    (* But is_flippable j contradicts ~is_flippable (LAST bb) *)
+    gs[]
+  )
+QED
+
+(* PERM of DROPs from PERM of full lists + PERM of TAKEs + same element at k *)
+Triviality perm_drop_from_take:
+  !l1 l2 k. PERM l1 l2 /\ PERM (TAKE k l1) (TAKE k l2) /\
+    k < LENGTH l1 /\ LENGTH l2 = LENGTH l1 /\ EL k l1 = EL k l2 ==>
+    PERM (DROP (SUC k) l1) (DROP (SUC k) l2)
+Proof
+  rpt strip_tac >>
+  `l1 = TAKE k l1 ++ [EL k l1] ++ DROP (SUC k) l1` by simp[TAKE_DROP_SUC] >>
+  `l2 = TAKE k l2 ++ [EL k l2] ++ DROP (SUC k) l2` by simp[TAKE_DROP_SUC] >>
+  `PERM (TAKE k l1 ++ [EL k l1] ++ DROP (SUC k) l1)
+        (TAKE k l2 ++ [EL k l2] ++ DROP (SUC k) l2)` by metis_tac[] >>
+  gvs[] >>
+  qabbrev_tac `tk1 = TAKE k l1` >>
+  qabbrev_tac `tk2 = TAKE k l2` >>
+  qabbrev_tac `dk1 = DROP (SUC k) l1` >>
+  qabbrev_tac `dk2 = DROP (SUC k) l2` >>
+  qabbrev_tac `b = EL k l2` >>
+  `PERM (tk1 ++ [b] ++ dk1) (tk2 ++ [b] ++ dk2)` by metis_tac[] >>
+  `PERM (tk2 ++ [b] ++ dk2) (tk1 ++ [b] ++ dk2)` by
+    (once_rewrite_tac[GSYM APPEND_ASSOC] >>
+     metis_tac[PERM_APPEND_IFF, PERM_SYM]) >>
+  `PERM (tk1 ++ [b] ++ dk1) (tk1 ++ [b] ++ dk2)` by
+    metis_tac[PERM_TRANS] >>
+  metis_tac[PERM_APPEND_IFF, APPEND_ASSOC, PERM_CONS_IFF]
+QED
+
+(* Split run_insts at position k into prefix, element k, suffix *)
+Triviality run_insts_split_at:
+  !l k fuel ctx s.
+    k < LENGTH l ==>
+    run_insts fuel ctx l s =
+      case run_insts fuel ctx (TAKE k l) s of
+        OK v => (case step_inst fuel ctx (EL k l) v of
+                   OK v' => run_insts fuel ctx (DROP (SUC k) l) v'
+                 | Halt h => Halt h
+                 | Abort a v2 => Abort a v2
+                 | IntRet ir v3 => IntRet ir v3
+                 | Error e => Error e)
+      | r => r
+Proof
+  rpt strip_tac >>
+  `l = TAKE k l ++ [EL k l] ++ DROP (SUC k) l` by simp[TAKE_DROP_SUC] >>
+  pop_assum (fn th => CONV_TAC (LHS_CONV (ONCE_REWRITE_CONV [th]))) >>
+  once_rewrite_tac[GSYM APPEND_ASSOC] >>
+  rewrite_tac[run_insts_append] >> simp[run_insts_def] >>
+  Cases_on `run_insts fuel ctx (TAKE k l) s` >> simp[] >>
+  Cases_on `step_inst fuel ctx (EL k l) v` >> simp[]
+QED
+
+(* ===== Core barrier-segmentation theorem =====
+   Two topo-sorted permutations of a non-terminator list produce either:
+   - Both Error (possibly different error strings), OR
+   - Identical run_insts results.
+   Uses barrier_free_topo_perm_result for each barrier-free segment. *)
+Triviality run_insts_topo_full_lift:
+  !l1 l2 dep fuel ctx s.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted (TC dep) l1 /\ topo_sorted (TC dep) l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~TC dep x y /\ ~TC dep y x ==> bi_independent x y) /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l1 /\
+    (!b y. MEM b l1 /\ MEM y l1 /\ b <> y /\ is_barrier b ==>
+           TC dep b y \/ TC dep y b) ==>
+    (?e1 e2. run_insts fuel ctx l1 s = Error e1 /\
+             run_insts fuel ctx l2 s = Error e2) \/
+    run_insts fuel ctx l1 s = run_insts fuel ctx l2 s
+Proof
+  measureInduct_on `LENGTH l1` >>
+  rpt strip_tac >>
+  Cases_on `l1 = []`
+  >- (gvs[] >> imp_res_tac PERM_NIL >> simp[run_insts_def])
+  >>
+  `LENGTH l2 = LENGTH l1` by metis_tac[PERM_LENGTH] >>
+  `ALL_DISTINCT l2` by metis_tac[ALL_DISTINCT_PERM] >>
+  `EVERY (\i. ~is_terminator i.inst_opcode) l2` by
+    (gvs[EVERY_MEM] >> metis_tac[PERM_MEM_EQ]) >>
+  Cases_on `EXISTS is_barrier l1`
+  >- (
+    (* === BARRIER CASE === *)
+    `?k. k < LENGTH l1 /\ is_barrier (EL k l1) /\
+         !m. m < k ==> ~is_barrier (EL m l1)` by
+      (gvs[EXISTS_MEM, MEM_EL] >>
+       rename1 `j < LENGTH l1` >>
+       qexists `LEAST n. n < LENGTH l1 /\ is_barrier (EL n l1)` >>
+       numLib.LEAST_ELIM_TAC >> conj_tac
+       >- (qexists `j` >> simp[])
+       >> rpt strip_tac >> gvs[] >>
+          spose_not_then strip_assume_tac >>
+          `m < LENGTH l1 /\ is_barrier (EL m l1)` suffices_by metis_tac[] >>
+          simp[] >> first_x_assum (qspec_then `m` mp_tac) >> simp[]) >>
+    `EL k l2 = EL k l1` by metis_tac[barriers_same_el] >>
+    `k < LENGTH l2` by simp[] >>
+    (* Barrier-free prefix: use barrier_free_topo_perm_result *)
+    `PERM (TAKE k l1) (TAKE k l2)` by metis_tac[barrier_prefix_perm] >>
+    `EVERY (\i. ~is_barrier i) (TAKE k l1)` by
+      (simp[EVERY_EL, EL_TAKE] >> metis_tac[]) >>
+    qspecl_then [`TAKE k l1`, `TAKE k l2`, `TC dep`, `fuel`, `ctx`, `s`]
+      mp_tac barrier_free_topo_perm_result >>
+    impl_tac >- (
+      simp[ALL_DISTINCT_TAKE, EVERY_TAKE] >>
+      rpt conj_tac
+      >- (irule topo_sorted_take >> simp[])
+      >- (irule topo_sorted_take >> simp[])
+      >> (rpt strip_tac >> first_x_assum irule >>
+          imp_res_tac MEM_TAKE >> simp[])) >>
+    strip_tac
+    >- (
+      (* Prefix Error: propagate to full lists via run_insts_error_append *)
+      disj1_tac >>
+      `run_insts fuel ctx (TAKE k l1 ++ DROP k l1) s = Error e1` by
+        (irule run_insts_error_append >> metis_tac[]) >>
+      `run_insts fuel ctx (TAKE k l2 ++ DROP k l2) s = Error e2` by
+        (irule run_insts_error_append >> metis_tac[]) >>
+      gvs[TAKE_DROP]
+    )
+    >> (
+      (* Prefix OK: split at barrier, use IH on suffix *)
+      `(?v. run_insts fuel ctx (TAKE k l1) s = OK v) \/
+       (?e. run_insts fuel ctx (TAKE k l1) s = Error e)` by
+        (irule barrier_free_only_ok_or_error >> simp[EVERY_TAKE]) >>
+      pop_assum strip_assume_tac
+      >- (
+        `run_insts fuel ctx (TAKE k l2) s = OK v` by fs[] >>
+        qspecl_then [`l1`, `k`, `fuel`, `ctx`, `s`] assume_tac run_insts_split_at >>
+        qspecl_then [`l2`, `k`, `fuel`, `ctx`, `s`] assume_tac run_insts_split_at >>
+        gvs[] >>
+        Cases_on `step_inst fuel ctx (EL k l1) v`
+        >- (
+          (* step_inst OK v' => IH on suffixes DROP (SUC k) *)
+          gvs[] >>
+          last_x_assum
+            (qspec_then `DROP (SUC k) l1` mp_tac) >>
+          (impl_tac >- simp[LENGTH_DROP]) >>
+          disch_then (qspecl_then [`DROP (SUC k) l2`,
+                                   `dep`, `fuel`, `ctx`, `v'`] mp_tac) >>
+          simp[ALL_DISTINCT_DROP, EVERY_DROP] >>
+          (impl_tac >- (
+            conj_tac >- (irule perm_drop_from_take >> simp[]) >>
+            conj_tac >- (irule topo_sorted_drop >> simp[]) >>
+            conj_tac >- (irule topo_sorted_drop >> simp[]) >>
+            conj_tac
+            >- (rpt strip_tac >>
+                qpat_x_assum `!x y. MEM x l1 /\ MEM y l1 /\ _ /\
+                  ~TC dep x y /\ ~TC dep y x ==> bi_independent x y` irule >>
+                imp_res_tac MEM_DROP_IMP >> simp[])
+            >> (rpt strip_tac >>
+                qpat_x_assum `!b y. MEM b l1 /\ MEM y l1 /\ _ /\ is_barrier b ==> _` irule >>
+                imp_res_tac MEM_DROP_IMP >> simp[])
+          )) >> simp[]
+        )
+        >> gvs[AllCaseEqs()] >> disj2_tac >> simp[]
+      )
+      >> (
+        `run_insts fuel ctx (TAKE k l2) s = Error e` by fs[] >>
+        disj1_tac >>
+        qspecl_then [`l1`, `k`, `fuel`, `ctx`, `s`] mp_tac run_insts_split_at >>
+        qspecl_then [`l2`, `k`, `fuel`, `ctx`, `s`] mp_tac run_insts_split_at >>
+        simp[]
+      )
+    )
+  )
+  (* === NO BARRIERS === *)
+  >> (
+    `EVERY (\i. ~is_barrier i) l1` by gvs[NOT_EXISTS, EVERY_MEM] >>
+    irule barrier_free_topo_perm_result >> simp[] >>
+    qexists `TC dep` >> simp[]
+  )
+QED
+
+(* Parameterized: topo-sorted perms with custom P, Q produce equal or both Error.
+   Handles barriers by induction on barrier positions. *)
+Triviality run_insts_topo_full_lift_gen:
+  !P Q l1 l2 dep fuel ctx s.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted (TC dep) l1 /\ topo_sorted (TC dep) l2 /\
+    (!a b. P a b ==> P b a) /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~TC dep x y /\ ~TC dep y x ==> P x y) /\
+    (!a b s sa sab.
+       P a b /\ Q a /\ Q b /\
+       step_inst fuel ctx a s = OK sa /\
+       step_inst fuel ctx b sa = OK sab ==>
+       ?sb. step_inst fuel ctx b s = OK sb /\
+            step_inst fuel ctx a sb = OK sab) /\
+    EVERY Q l1 /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l1 /\
+    (!b y. MEM b l1 /\ MEM y l1 /\ b <> y /\ is_barrier b ==>
+           TC dep b y \/ TC dep y b) ==>
+    (?e1 e2. run_insts fuel ctx l1 s = Error e1 /\
+             run_insts fuel ctx l2 s = Error e2) \/
+    run_insts fuel ctx l1 s = run_insts fuel ctx l2 s
+Proof
+  measureInduct_on `LENGTH l1` >>
+  rpt strip_tac >>
+  Cases_on `l1 = []`
+  >- (gvs[] >> imp_res_tac PERM_NIL >> simp[run_insts_def])
+  >>
+  `LENGTH l2 = LENGTH l1` by metis_tac[PERM_LENGTH] >>
+  `ALL_DISTINCT l2` by metis_tac[ALL_DISTINCT_PERM] >>
+  `EVERY (\i. ~is_terminator i.inst_opcode) l2 /\ EVERY Q l2` by
+    (gvs[EVERY_MEM] >> metis_tac[PERM_MEM_EQ]) >>
+  Cases_on `EXISTS is_barrier l1`
+  >- (
+    `?k. k < LENGTH l1 /\ is_barrier (EL k l1) /\
+         !m. m < k ==> ~is_barrier (EL m l1)` by
+      (gvs[EXISTS_MEM, MEM_EL] >>
+       rename1 `j < LENGTH l1` >>
+       qexists `LEAST n. n < LENGTH l1 /\ is_barrier (EL n l1)` >>
+       numLib.LEAST_ELIM_TAC >> conj_tac
+       >- (qexists `j` >> simp[])
+       >> rpt strip_tac >> gvs[] >>
+          spose_not_then strip_assume_tac >>
+          `m < LENGTH l1 /\ is_barrier (EL m l1)` suffices_by metis_tac[] >>
+          simp[] >> first_x_assum (qspec_then `m` mp_tac) >> simp[]) >>
+    `EL k l2 = EL k l1` by metis_tac[barriers_same_el] >>
+    `k < LENGTH l2` by simp[] >>
+    `PERM (TAKE k l1) (TAKE k l2)` by
+      (qspecl_then [`l1`, `l2`, `dep`, `k`] mp_tac barrier_prefix_perm >>
+       simp[]) >>
+    `EVERY (\i. ~is_barrier i) (TAKE k l1)` by
+      (simp[EVERY_EL, EL_TAKE] >> metis_tac[]) >>
+    qspecl_then [`P`, `Q`, `TAKE k l1`, `TAKE k l2`, `TC dep`,
+                 `fuel`, `ctx`, `s`]
+      mp_tac barrier_free_topo_perm_result_gen >>
+    impl_tac >- (
+      simp[ALL_DISTINCT_TAKE, EVERY_TAKE] >>
+      rpt conj_tac
+      >- (irule topo_sorted_take >> simp[])
+      >- (irule topo_sorted_take >> simp[])
+      >> (rpt strip_tac >> first_x_assum irule >>
+          imp_res_tac MEM_TAKE >> simp[])) >>
+    strip_tac
+    >- (
+      disj1_tac >>
+      `run_insts fuel ctx (TAKE k l1 ++ DROP k l1) s = Error e1` by
+        (irule run_insts_error_append >> metis_tac[]) >>
+      `run_insts fuel ctx (TAKE k l2 ++ DROP k l2) s = Error e2` by
+        (irule run_insts_error_append >> metis_tac[]) >>
+      gvs[TAKE_DROP])
+    >> (
+      `(?v. run_insts fuel ctx (TAKE k l1) s = OK v) \/
+       (?e. run_insts fuel ctx (TAKE k l1) s = Error e)` by
+        (irule barrier_free_only_ok_or_error >> simp[EVERY_TAKE]) >>
+      pop_assum strip_assume_tac
+      >- (
+        `run_insts fuel ctx (TAKE k l2) s = OK v` by fs[] >>
+        qspecl_then [`l1`, `k`, `fuel`, `ctx`, `s`] assume_tac run_insts_split_at >>
+        qspecl_then [`l2`, `k`, `fuel`, `ctx`, `s`] assume_tac run_insts_split_at >>
+        gvs[] >>
+        Cases_on `step_inst fuel ctx (EL k l1) v`
+        >- (
+          gvs[] >>
+          last_x_assum
+            (qspec_then `DROP (SUC k) l1` mp_tac) >>
+          (impl_tac >- simp[LENGTH_DROP]) >>
+          disch_then (qspecl_then [`P`, `Q`, `DROP (SUC k) l2`,
+                                   `dep`, `fuel`, `ctx`, `v'`] mp_tac) >>
+          simp[ALL_DISTINCT_DROP, EVERY_DROP] >>
+          (impl_tac >- (
+            conj_tac >- (irule perm_drop_from_take >> simp[]) >>
+            conj_tac >- (irule topo_sorted_drop >> simp[]) >>
+            conj_tac >- (irule topo_sorted_drop >> simp[]) >>
+            conj_tac
+            >- (rpt strip_tac >>
+                qpat_x_assum `!x y. MEM x l1 /\ MEM y l1 /\ _ /\
+                  ~TC dep x y /\ ~TC dep y x ==> P x y` irule >>
+                imp_res_tac MEM_DROP_IMP >> simp[])
+            >> (rpt strip_tac >>
+                qpat_x_assum `!b y. MEM b l1 /\ MEM y l1 /\ _ /\ is_barrier b ==> _` irule >>
+                imp_res_tac MEM_DROP_IMP >> simp[])
+          )) >> simp[])
+        >> gvs[AllCaseEqs()] >> disj2_tac >> simp[])
+      >> (
+        `run_insts fuel ctx (TAKE k l2) s = Error e` by fs[] >>
+        disj1_tac >>
+        qspecl_then [`l1`, `k`, `fuel`, `ctx`, `s`] mp_tac run_insts_split_at >>
+        qspecl_then [`l2`, `k`, `fuel`, `ctx`, `s`] mp_tac run_insts_split_at >>
+        simp[])))
+  >> (
+    `EVERY (\i. ~is_barrier i) l1` by gvs[NOT_EXISTS, EVERY_MEM] >>
+    qspecl_then [`P`, `Q`, `l1`, `l2`, `TC dep`, `fuel`, `ctx`, `s`]
+      mp_tac barrier_free_topo_perm_result_gen >>
+    simp[])
+QED
+
+(* ef_commutes instantiation *)
+Triviality run_insts_topo_full_lift_ef:
+  !l1 l2 dep fuel ctx s.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted (TC dep) l1 /\ topo_sorted (TC dep) l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~TC dep x y /\ ~TC dep y x ==> ef_commutes x y) /\
+    EVERY (\i. ~is_terminator i.inst_opcode) l1 /\
+    (!b y. MEM b l1 /\ MEM y l1 /\ b <> y /\ is_barrier b ==>
+           TC dep b y \/ TC dep y b) ==>
+    (?e1 e2. run_insts fuel ctx l1 s = Error e1 /\
+             run_insts fuel ctx l2 s = Error e2) \/
+    run_insts fuel ctx l1 s = run_insts fuel ctx l2 s
+Proof
+  rpt strip_tac >>
+  mp_tac (SIMP_RULE (srw_ss()) [EVERY_MEM]
+    (ISPECL [``ef_commutes``, ``\i:instruction. T``]
+            run_insts_topo_full_lift_gen)) >>
+  disch_then irule >>
+  rpt conj_tac
+  >- metis_tac[ef_commutes_swap]
+  >- metis_tac[ef_commutes_sym]
+  >- gvs[EVERY_MEM]
+  >- simp[]
+  >- simp[]
+  >> qexists `dep` >> simp[]
+QED
+
+(* block_body_full_equiv: two topologically-sorted permutations of a block's
+   body produce identical run_insts results, or both Error.
+   Supersedes block_body_ok_equiv (which only handled the OK case). *)
+Triviality block_body_full_equiv:
+  !fn bb bb' fuel ctx s.
+    wf_ssa fn /\ wf_function fn /\
+    MEM bb fn.fn_blocks /\ block_perm_of fn bb' /\
+    bb.bb_label = bb'.bb_label /\
+    bb_well_formed bb /\ bb_well_formed bb' /\
+    topo_sorted (full_dep (build_full_eda bb.bb_instructions))
+      (MAP (choose_original (block_body bb)) (block_body bb')) ==>
+    (?e1 e2. run_insts fuel ctx (block_body bb) s = Error e1 /\
+             run_insts fuel ctx (block_body bb') s = Error e2) \/
+    run_insts fuel ctx (block_body bb) s =
+    run_insts fuel ctx (block_body bb') s
+Proof
+  rpt strip_tac >>
+  qabbrev_tac `l1 = block_body bb` >>
+  qabbrev_tac `l2_raw = block_body bb'` >>
+  qabbrev_tac `l2 = MAP (choose_original l1) l2_raw` >>
+  (* Step 1: run_insts l2_raw = run_insts l2 (pointwise step_inst equiv) *)
+  `run_insts fuel ctx l2_raw s = run_insts fuel ctx l2 s` by
+    (simp[Abbr `l2`] >>
+     irule run_insts_pointwise_equiv >> simp[LENGTH_MAP] >>
+     rpt strip_tac >>
+     irule map_choose_original_step_equiv >>
+     simp[Abbr `l1`] >>
+     conj_asm1_tac
+     >- (rpt strip_tac >> simp[Abbr `l2_raw`] >>
+         metis_tac[block_body_from_block])
+     >> metis_tac[block_body_all_distinct]) >>
+  (* Step 2: apply run_insts_topo_full_lift_ef *)
+  qabbrev_tac `bi = bb.bb_instructions` >>
+  qabbrev_tac `eda = build_full_eda bi` >>
+  `PERM l1 l2` by
+    (simp[Abbr `l2`, Abbr `l1`] >> metis_tac[block_body_choose_perm]) >>
+  `ALL_DISTINCT l1` by
+    (simp[Abbr `l1`] >> metis_tac[block_body_all_distinct, ALL_DISTINCT_MAP]) >>
+  (* Use restricted dep: full_dep restricted to l1 elements *)
+  qabbrev_tac `dep = \x y. full_dep eda x y /\ MEM x l1 /\ MEM y l1` >>
+  `topo_sorted dep l1` by
+    (simp[Abbr `dep`, topo_sorted_def] >> rpt strip_tac >>
+     `~full_dep eda (EL i l1) (EL j l1)` suffices_by simp[] >>
+     `topo_sorted (full_dep eda) l1` by
+       (simp[Abbr `l1`, Abbr `bi`] >> metis_tac[block_body_topo_sorted]) >>
+     fs[topo_sorted_def]) >>
+  `topo_sorted dep l2` by
+    (simp[Abbr `dep`, topo_sorted_def] >> rpt strip_tac >>
+     `~full_dep eda (EL i l2) (EL j l2)` suffices_by
+       (strip_tac >> gvs[] >> metis_tac[PERM_MEM_EQ, MEM_EL]) >>
+     `topo_sorted (full_dep eda) l2` by
+       simp[Abbr `l2`, Abbr `l1`, Abbr `bi`] >>
+     fs[topo_sorted_def]) >>
+  `topo_sorted (TC dep) l1` by
+    (irule topo_sorted_tc_closed >> simp[Abbr `dep`]) >>
+  `topo_sorted (TC dep) l2` by
+    (irule topo_sorted_tc_closed >>
+     simp[Abbr `dep`] >>
+     `ALL_DISTINCT l2` by metis_tac[ALL_DISTINCT_PERM] >>
+     simp[] >> metis_tac[PERM_MEM_EQ]) >>
+  (* ef_commutes for TC-dep-uncomparable pairs via block_body_uncomp_ef *)
+  `!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+         ~TC dep x y /\ ~TC dep y x ==>
+         ef_commutes x y` by
+    (rpt strip_tac >>
+     qspecl_then [`fn`, `bb`, `x`, `y`,
+       `\a c. full_dep (build_full_eda bb.bb_instructions) a c /\
+              MEM a (block_body bb) /\ MEM c (block_body bb)`]
+       mp_tac block_body_uncomp_ef >>
+     simp[Abbr `l1`, Abbr `dep`, Abbr `eda`, Abbr `bi`]) >>
+  (* EVERY non-terminator: block_body has no terminators *)
+  `EVERY (\i. ~is_terminator i.inst_opcode) l1` by
+    simp[Abbr `l1`, block_body_def, EVERY_MEM, MEM_FILTER] >>
+  (* Barriers TC-comparable to all other block_body elements *)
+  `!b y. MEM b l1 /\ MEM y l1 /\ b <> y /\ is_barrier b ==>
+         TC dep b y \/ TC dep y b` by
+    (rpt strip_tac >>
+     qspecl_then [`fn`, `bb`, `b`, `y`, `dep`] mp_tac barrier_tc_connected >>
+     simp[Abbr `l1`, Abbr `dep`, Abbr `eda`, Abbr `bi`]) >>
+  (* Apply run_insts_topo_full_lift_ef *)
+  qspecl_then [`l1`, `l2`, `dep`, `fuel`, `ctx`, `s`]
+    mp_tac run_insts_topo_full_lift_ef >>
+  simp[]
+QED
+
+(* LENGTH l = LENGTH (FILTER P l) + LENGTH (FILTER (~P) l) *)
+Triviality length_filter_complement:
+  !P l. LENGTH l = LENGTH (FILTER P l) + LENGTH (FILTER ($~ o P) l)
+Proof
+  gen_tac >> Induct_on `l` >> simp[FILTER] >>
+  rpt strip_tac >> Cases_on `P h` >> simp[]
+QED
+
+(* block_perm_of implies same instruction count *)
+Triviality block_perm_of_same_length:
+  !fn bb bb'.
+    block_perm_of fn bb' /\ wf_function fn /\
+    MEM bb fn.fn_blocks /\
+    bb.bb_label = bb'.bb_label ==>
+    LENGTH bb'.bb_instructions = LENGTH bb.bb_instructions
+Proof
+  rw[block_perm_of_def] >>
+  `bb = bb_orig` by metis_tac[wf_fn_same_label_eq] >>
+  gvs[] >>
+  `LENGTH (FILTER (\i. ~is_pseudo i.inst_opcode) bb'.bb_instructions) =
+   LENGTH (FILTER (\i. ~is_pseudo i.inst_opcode) bb.bb_instructions)` by
+    metis_tac[PERM_LENGTH, LENGTH_MAP] >>
+  `LENGTH (FILTER (\i. is_pseudo i.inst_opcode) bb'.bb_instructions) =
+   LENGTH (FILTER (\i. is_pseudo i.inst_opcode) bb.bb_instructions)` by
+    simp[] >>
+  metis_tac[length_filter_complement]
+QED
+
+(* If FRONT both give same OK result and LAST is the same, exec_block equal *)
+Triviality exec_block_same_front_ok:
+  !bb bb' fuel ctx s v.
+    bb_well_formed bb /\ bb_well_formed bb' /\
+    LAST bb'.bb_instructions = LAST bb.bb_instructions /\
+    LENGTH bb'.bb_instructions = LENGTH bb.bb_instructions /\
+    run_insts fuel ctx (FRONT bb.bb_instructions) s = OK v /\
+    run_insts fuel ctx (FRONT bb'.bb_instructions) s = OK v ==>
+    exec_block fuel ctx bb (s with vs_inst_idx := 0) =
+    exec_block fuel ctx bb' (s with vs_inst_idx := 0)
+Proof
+  rpt strip_tac >>
+  `bb.bb_instructions <> [] /\ bb'.bb_instructions <> []` by
+    fs[bb_well_formed_def] >>
+  `LENGTH (FRONT bb'.bb_instructions) =
+   LENGTH (FRONT bb.bb_instructions)` by simp[LENGTH_FRONT] >>
+  qspecl_then [`bb`, `fuel`, `ctx`, `s`, `v`] mp_tac exec_block_front_ok >>
+  simp[] >> disch_then (fn th => once_rewrite_tac[th]) >>
+  qspecl_then [`bb'`, `fuel`, `ctx`, `s`, `v`] mp_tac exec_block_front_ok >>
+  simp[] >> disch_then (fn th => once_rewrite_tac[th]) >>
+  `is_terminator (LAST bb.bb_instructions).inst_opcode` by
+    fs[bb_well_formed_def] >>
+  Cases_on `step_inst fuel ctx (LAST bb.bb_instructions)
+              (v with vs_inst_idx := LENGTH (FRONT bb.bb_instructions))` >>
+  simp[]
+QED
+
+(* For each instruction in FRONT bb', there's an instruction in FRONT bb
+   with the same inst_id and same step_inst behavior *)
+Triviality front_mem_step_equiv:
+  !fn bb bb' i.
+    wf_function fn /\ MEM bb fn.fn_blocks /\
+    block_perm_of fn bb' /\ bb.bb_label = bb'.bb_label /\
+    bb_well_formed bb /\ bb_well_formed bb' /\
+    MEM i (FRONT bb'.bb_instructions) ==>
+    ?j. MEM j (FRONT bb.bb_instructions) /\ j.inst_id = i.inst_id /\
+        !fuel ctx s. step_inst fuel ctx i s = step_inst fuel ctx j s
+Proof
+  rpt strip_tac >>
+  fs[block_perm_of_def] >>
+  rename1 `MEM bb_orig fn.fn_blocks` >>
+  `bb_orig = bb` by (irule wf_fn_same_label_eq >> metis_tac[]) >> gvs[] >>
+  `bb.bb_instructions <> []` by fs[bb_well_formed_def] >>
+  `bb'.bb_instructions <> []` by fs[bb_well_formed_def] >>
+  `~is_terminator i.inst_opcode` by
+    (drule_at (Pos last) front_no_terminators >> simp[EVERY_MEM]) >>
+  `is_terminator (LAST bb.bb_instructions).inst_opcode` by
+    fs[bb_well_formed_def] >>
+  `MEM i bb'.bb_instructions` by metis_tac[MEM_FRONT_NOT_NIL] >>
+  Cases_on `is_pseudo i.inst_opcode`
+  >- (
+    qexists `i` >> simp[] >>
+    `MEM i (FILTER (\i'. is_pseudo i'.inst_opcode) bb'.bb_instructions)` by
+      simp[MEM_FILTER] >>
+    `MEM i (FILTER (\i'. is_pseudo i'.inst_opcode) bb.bb_instructions)` by
+      metis_tac[] >>
+    fs[MEM_FILTER] >>
+    `bb.bb_instructions = FRONT bb.bb_instructions ++ [LAST bb.bb_instructions]`
+      by simp[APPEND_FRONT_LAST] >>
+    `MEM i (FRONT bb.bb_instructions) \/ i = LAST bb.bb_instructions`
+      by metis_tac[MEM_APPEND, MEM] >>
+    gvs[])
+  >>
+  `from_block bb.bb_instructions i` by
+    (qpat_x_assum `EVERY _ (FILTER _ _)` mp_tac >>
+     simp[EVERY_MEM, MEM_FILTER]) >>
+  gvs[from_block_def]
+  >- (
+    (* Identity case: i = j *)
+    rename1 `MEM j bb.bb_instructions` >>
+    qexists `j` >> simp[] >>
+    `bb.bb_instructions = FRONT bb.bb_instructions ++ [LAST bb.bb_instructions]`
+      by simp[APPEND_FRONT_LAST] >>
+    `MEM j (FRONT bb.bb_instructions) \/ j = LAST bb.bb_instructions`
+      by metis_tac[MEM_APPEND, MEM] >>
+    gvs[])
+  >>
+  (* Flip case: i = flip_operands j *)
+  rename1 `MEM j bb.bb_instructions` >>
+  qexists `j` >> simp[flip_operands_inst_id] >>
+  conj_tac
+  >- (`~is_terminator j.inst_opcode` by gvs[flip_operands_is_terminator] >>
+      `bb.bb_instructions = FRONT bb.bb_instructions ++
+                            [LAST bb.bb_instructions]`
+        by simp[APPEND_FRONT_LAST] >>
+      `MEM j (FRONT bb.bb_instructions) \/ j = LAST bb.bb_instructions`
+        by metis_tac[MEM_APPEND, MEM] >>
+      gvs[])
+  >>
+  rpt strip_tac >> metis_tac[flip_operands_step_inst]
+QED
+
+(* Pseudo OK result is always update_var with one output. *)
+Triviality pseudo_step_is_update_var:
+  !fuel ctx a s sa.
+    is_pseudo a.inst_opcode /\
+    step_inst fuel ctx a s = OK sa ==>
+    ?out val. a.inst_outputs = [out] /\ sa = update_var out val s
+Proof
+  rpt strip_tac >>
+  `a.inst_opcode <> INVOKE` by
+    (Cases_on `a.inst_opcode` >> gvs[is_pseudo_def]) >>
+  gvs[step_inst_non_invoke] >>
+  Cases_on `a.inst_opcode` >> gvs[is_pseudo_def] >>
+  gvs[Once step_inst_base_def, AllCaseEqs()] >> metis_tac[]
+QED
+
+(* Pseudo swap: if pseudo a is data-independent from b, and a->b both OK,
+   then b->a both OK with same result. Uses step_inst_ok_frame (works for
+   all opcodes including ALLOCA/INVOKE). *)
+Triviality step_swap_ok_pseudo:
+  !fuel ctx a b s sa sab.
+    is_pseudo a.inst_opcode /\
+    ~is_terminator b.inst_opcode /\
+    DISJOINT (set (inst_defs a)) (set (inst_uses b)) /\
+    DISJOINT (set (inst_defs b)) (set (inst_uses a)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  (* Step 1: sa = update_var out val s *)
+  drule_all pseudo_step_is_update_var >> strip_tac >> gvs[] >>
+  rename1 `update_var out val s` >>
+  (* Step 2: frame — b commutes past update_var *)
+  `!y. MEM (Var y) b.inst_operands ==> out <> y` by
+    (gvs[inst_defs_def, inst_uses_def,
+         DISJOINT_DEF, EXTENSION] >>
+     metis_tac[mem_var_operand_vars, MEM]) >>
+  `~MEM out b.inst_outputs` by
+    (gvs[inst_defs_def, DISJOINT_DEF, EXTENSION]) >>
+  (* Use step_inst_frame (equality) for non-INVOKE, step_inst_invoke_frame for INVOKE *)
+  `?sb. step_inst fuel ctx b s = OK sb /\
+        sab = update_var out val sb` by
+    (Cases_on `b.inst_opcode = INVOKE`
+     >- (qspecl_then [`fuel`,`ctx`,`b`,`s`,`out`,`val`] mp_tac
+           dftCommutationTheory.step_inst_invoke_frame >> simp[] >>
+         strip_tac >> gvs[] >>
+         Cases_on `step_inst fuel ctx b s` >> gvs[])
+     >> (qspecl_then [`fuel`,`ctx`,`b`,`s`,`out`,`val`] mp_tac
+           dftCommutationTheory.step_inst_frame >> simp[] >>
+         strip_tac >> gvs[dftCommutationTheory.map_result_state_def] >>
+         Cases_on `step_inst fuel ctx b s` >>
+         gvs[dftCommutationTheory.map_result_state_def])) >>
+  qexists `sb` >> simp[] >>
+  (* Step 3: a on sb produces same update_var *)
+  (* Field preservation from step b *)
+  `sb.vs_labels = s.vs_labels` by
+    metis_tac[step_preserves_labels] >>
+  (* Operands of a evaluate the same on s and sb *)
+  `sb.vs_prev_bb = s.vs_prev_bb` by
+    metis_tac[step_preserves_control_flow] >>
+  `sb.vs_params = s.vs_params` by metis_tac[step_preserves_params] >>
+  `!v. ~MEM v b.inst_outputs ==>
+       lookup_var v sb = lookup_var v s` by
+    metis_tac[step_preserves_non_output_vars] >>
+  (* Step 3: replay pseudo a on sb *)
+  `a.inst_opcode <> INVOKE` by
+    (Cases_on `a.inst_opcode` >> gvs[is_pseudo_def]) >>
+  `step_inst_base a s = OK (update_var out val s)` by
+    gvs[step_inst_non_invoke] >>
+  (* Show operands of a evaluate the same on sb and s *)
+  `!op. MEM op a.inst_operands ==>
+        eval_operand op sb = eval_operand op s` by
+    (rpt strip_tac >> Cases_on `op` >> simp[eval_operand_def]
+     >- (rename1 `Var vv` >> first_x_assum irule >>
+         gvs[inst_defs_def, inst_uses_def,
+             DISJOINT_DEF, EXTENSION] >>
+         metis_tac[mem_var_operand_vars, MEM])
+     >> gvs[]) >>
+  simp[step_inst_non_invoke] >>
+  Cases_on `a.inst_opcode` >> gvs[is_pseudo_def]
+  (* PHI case *)
+  >- (gvs[Once step_inst_base_def, AllCaseEqs()] >>
+      (* Derive val from eval_operand: v = val *)
+      `v = val` by
+        gvs[update_var_def, venom_state_component_equality,
+            FUPD11_SAME_KEY_AND_BASE] >>
+      gvs[] >>
+      ONCE_REWRITE_TAC[step_inst_base_def] >> simp[] >>
+      imp_res_tac dftCommutationTheory.resolve_phi_MEM >>
+      first_x_assum drule >> simp[])
+  (* PARAM case *)
+  >> (gvs[Once step_inst_base_def, AllCaseEqs()] >>
+      `EL (w2n idx) s.vs_params = val` by
+        (fs[update_var_def, venom_state_component_equality] >>
+         metis_tac[FUPD11_SAME_KEY_AND_BASE]) >>
+      ONCE_REWRITE_TAC[step_inst_base_def] >> simp[])
+QED
+
+(* Reverse direction of step_swap_ok_pseudo: given b (non-term) THEN a (pseudo)
+   both OK, then a THEN b both OK with same result. *)
+Triviality step_swap_ok_pseudo_rev:
+  !fuel ctx a b s sb sba.
+    is_pseudo a.inst_opcode /\
+    ~is_terminator b.inst_opcode /\
+    DISJOINT (set (inst_defs a)) (set (inst_uses b)) /\
+    DISJOINT (set (inst_defs b)) (set (inst_uses a)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    step_inst fuel ctx b s = OK sb /\
+    step_inst fuel ctx a sb = OK sba ==>
+    ?sa. step_inst fuel ctx a s = OK sa /\
+         step_inst fuel ctx b sa = OK sba
+Proof
+  rpt strip_tac >>
+  (* Step 1: sba = update_var out val sb *)
+  drule_all pseudo_step_is_update_var >>
+  strip_tac >> rename1 `update_var out val sb` >>
+  (* Step 2: data independence *)
+  `~MEM out b.inst_outputs` by
+    (fs[inst_defs_def, DISJOINT_DEF, EXTENSION, MEM_MAP] >>
+     metis_tac[MEM]) >>
+  `!y. MEM (Var y) b.inst_operands ==> out <> y` by
+    (fs[inst_defs_def, inst_uses_def, DISJOINT_DEF, EXTENSION] >>
+     metis_tac[mem_var_operand_vars, MEM]) >>
+  (* Step 3: frame — step b on (update_var out val s) *)
+  `step_inst fuel ctx b (update_var out val s) =
+   OK (update_var out val sb)` by
+    (irule dftCommutationTheory.step_inst_ok_frame >> metis_tac[]) >>
+  (* Step 4: replay pseudo a on s *)
+  `a.inst_opcode <> INVOKE` by
+    (Cases_on `a.inst_opcode` >> gvs[is_pseudo_def]) >>
+  (* Operands of a evaluate the same on s and sb *)
+  `sb.vs_prev_bb = s.vs_prev_bb` by
+    metis_tac[step_preserves_control_flow] >>
+  `sb.vs_params = s.vs_params` by
+    metis_tac[step_preserves_params] >>
+  `sb.vs_labels = s.vs_labels` by
+    metis_tac[step_preserves_labels] >>
+  `!v. ~MEM v b.inst_outputs ==>
+       lookup_var v sb = lookup_var v s` by
+    metis_tac[step_preserves_non_output_vars] >>
+  `!op. MEM op a.inst_operands ==>
+        eval_operand op sb = eval_operand op s` by
+    (rpt strip_tac >> Cases_on `op` >>
+     simp[eval_operand_def] >>
+     (* Only Var case remains *)
+     rename1 `MEM (Var vn) _` >>
+     `~MEM vn b.inst_outputs` by
+       (fs[inst_defs_def, inst_uses_def,
+           DISJOINT_DEF, EXTENSION] >>
+        metis_tac[mem_var_operand_vars, MEM]) >>
+     metis_tac[]) >>
+  (* Now case-split PHI/PARAM and replay *)
+  fs[step_inst_non_invoke] >>
+  Cases_on `a.inst_opcode` >> gvs[is_pseudo_def]
+  (* PHI case *)
+  >- (gvs[Once step_inst_base_def, AllCaseEqs()] >>
+      (* eval_operand val_op s = eval_operand val_op sb *)
+      `eval_operand val_op s = SOME v` by
+        (imp_res_tac dftCommutationTheory.resolve_phi_MEM >>
+         `MEM val_op a.inst_operands` by metis_tac[] >>
+         metis_tac[]) >>
+      qexists `update_var out v s` >>
+      conj_tac
+      >- (ONCE_REWRITE_TAC[step_inst_base_def] >> simp[])
+      >> fs[update_var_def, venom_state_component_equality,
+            FUPD11_SAME_KEY_AND_BASE])
+  (* PARAM case *)
+  >> (gvs[Once step_inst_base_def, AllCaseEqs()] >>
+      qexists `update_var out (EL (w2n idx) s.vs_params) s` >>
+      conj_tac
+      >- (ONCE_REWRITE_TAC[step_inst_base_def] >> simp[])
+      >> fs[update_var_def, venom_state_component_equality,
+            FUPD11_SAME_KEY_AND_BASE])
+QED
+
+(* Non-terminator non-INVOKE: can't produce Halt or IntRet from step_inst *)
+Triviality non_term_non_invoke_not_halt_intret:
+  !fuel ctx inst s.
+    ~is_terminator inst.inst_opcode /\ inst.inst_opcode <> INVOKE ==>
+    (!v. step_inst fuel ctx inst s <> Halt v) /\
+    (!vals v. step_inst fuel ctx inst s <> IntRet vals v)
+Proof
+  rpt strip_tac >> gvs[step_inst_non_invoke] >>
+  metis_tac[step_inst_base_not_halt_intret]
+QED
+
+(* Deriving frame conditions from inst_defs/inst_uses DISJOINT *)
+Triviality frame_conds_from_disjoint:
+  !h p.
+    DISJOINT (set (inst_defs p)) (set (inst_uses h)) /\
+    DISJOINT (set (inst_defs h)) (set (inst_defs p)) ==>
+    !out. MEM out p.inst_outputs ==>
+      (!y. MEM (Var y) h.inst_operands ==> out <> y) /\
+      ~MEM out h.inst_outputs
+Proof
+  rw[inst_defs_def, inst_uses_def] >>
+  fs[DISJOINT_DEF, EXTENSION, MEM_operand_vars_iff] >>
+  metis_tac[]
+QED
+
+(* Key single-swap: h (non-pseudo, non-term) past p (pseudo).
+   p always gives OK (update_var). On the p-first side, h runs on
+   update_var state. Frame relates this to h on original state.
+   OK-OK: step_swap_ok_pseudo_rev commutes. Non-OK h:
+   INVOKE → non-OK unchanged. Non-INVOKE → map_result_state preserves
+   revert_equiv (update_var preserves vs_returndata). *)
+(* Frame property for run_insts over a list of pseudos:
+   update_var x v commutes through a sequence of pseudo instructions,
+   provided x is not read or written by any pseudo in the list.
+   Non-INVOKE follows from step_inst_frame; pseudos are never INVOKE. *)
+Triviality run_insts_pseudo_frame:
+  !ps fuel ctx s x v.
+    EVERY (\i. is_pseudo i.inst_opcode) ps /\
+    (!p. MEM p ps ==>
+         ~MEM x p.inst_outputs /\
+         !y. MEM (Var y) p.inst_operands ==> x <> y) ==>
+    run_insts fuel ctx ps (update_var x v s) =
+    map_result_state (update_var x v) (run_insts fuel ctx ps s)
+Proof
+  Induct >> simp[run_insts_def, dftCommutationTheory.map_result_state_def] >>
+  rpt strip_tac >>
+  `h.inst_opcode <> INVOKE` by
+    (fs[EVERY_MEM] >> Cases_on `h.inst_opcode` >>
+     gvs[is_pseudo_def]) >>
+  `step_inst fuel ctx h (update_var x v s) =
+   map_result_state (update_var x v) (step_inst fuel ctx h s)` by
+    (irule dftCommutationTheory.step_inst_frame >> fs[EVERY_MEM]) >>
+  Cases_on `step_inst fuel ctx h s` >>
+  gvs[dftCommutationTheory.map_result_state_def, run_insts_def] >>
+  first_x_assum irule >> fs[EVERY_MEM]
+QED
+
+Triviality lift_result_refl:
+  !x. lift_result (state_equiv {}) (execution_equiv {}) revert_equiv x x
+Proof
+  Cases >> simp[lift_result_def, state_equiv_refl, execution_equiv_refl,
+                revert_equiv_def]
+QED
+
+(* Key single-swap: h (non-pseudo, non-term) past p (pseudo).
+   Assumes p succeeds on s. *)
+Triviality swap_nonpseudo_pseudo_lr:
+  !fuel ctx h p rest s out val'.
+    ~is_terminator h.inst_opcode /\ ~is_pseudo h.inst_opcode /\
+    is_pseudo p.inst_opcode /\
+    DISJOINT (set (inst_defs h)) (set (inst_defs p)) /\
+    DISJOINT (set (inst_defs h)) (set (inst_uses p)) /\
+    DISJOINT (set (inst_defs p)) (set (inst_uses h)) /\
+    step_inst fuel ctx p s = OK (update_var out val' s) /\
+    MEM out p.inst_outputs ==>
     lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
-      (exec_block fuel ctx bb s)
-      (exec_block fuel ctx (dft_block order bb) s)
+      (run_insts fuel ctx (h :: p :: rest) s)
+      (run_insts fuel ctx (p :: h :: rest) s)
+Proof
+  rpt strip_tac >>
+  simp[run_insts_def] >>
+  qspecl_then [`h`,`p`] mp_tac frame_conds_from_disjoint >>
+  (impl_tac >- simp[]) >>
+  disch_then (qspec_then `out` mp_tac) >>
+  (impl_tac >- simp[]) >> strip_tac >>
+  Cases_on `step_inst fuel ctx h s`
+  >- (
+    rename1 `OK s1` >> simp[] >>
+    drule_all dftCommutationTheory.step_inst_ok_frame >>
+    disch_then (qspec_then `val'` assume_tac) >>
+    simp[] >>
+    (* Now apply step_swap_ok_pseudo to get step_inst p s1 *)
+    qspecl_then [`fuel`,`ctx`,`p`,`h`,`s`,`update_var out val' s`,
+                  `update_var out val' s1`]
+      mp_tac step_swap_ok_pseudo >>
+    impl_tac
+    >- (fs[] >> once_rewrite_tac[DISJOINT_SYM] >> fs[]) >>
+    strip_tac >> gvs[] >> simp[] >>
+    MATCH_ACCEPT_TAC lift_result_refl
+  )
+  (* Non-OK: split INVOKE vs non-INVOKE *)
+  >> (
+    Cases_on `h.inst_opcode = INVOKE`
+    >- (
+      qspecl_then [`fuel`,`ctx`,`h`,`s`,`out`,`val'`] mp_tac
+        dftCommutationTheory.step_inst_invoke_frame >>
+      impl_tac >- fs[] >> strip_tac >>
+      (* Invoke frame: non-OK result unchanged *)
+      gvs[lift_result_def, execution_equiv_def, revert_equiv_def]
+    )
+    >> (
+      qspecl_then [`fuel`,`ctx`,`h`,`s`,`out`,`val'`] mp_tac
+        dftCommutationTheory.step_inst_frame >>
+      impl_tac >- fs[] >> strip_tac >>
+      gvs[dftCommutationTheory.map_result_state_def] >>
+      TRY (qspecl_then [`fuel`,`ctx`,`h`,`s`] mp_tac
+             non_term_non_invoke_not_halt_intret >> simp[] >> NO_TAC) >>
+      simp[lift_result_def, revert_equiv_def,
+           dftCommutationTheory.update_var_fields]
+    )
+  )
+QED
+
+(* lift_result lifted through a common prefix step:
+   if for all s', A s' ≡_lr B s', then step;A ≡_lr step;B *)
+Triviality lift_result_step_prefix:
+  !fuel ctx inst s rest1 rest2.
+    (!s'. lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+            (run_insts fuel ctx rest1 s')
+            (run_insts fuel ctx rest2 s')) ==>
+    lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+      (run_insts fuel ctx (inst :: rest1) s)
+      (run_insts fuel ctx (inst :: rest2) s)
+Proof
+  rpt strip_tac >>
+  simp[run_insts_def] >>
+  Cases_on `step_inst fuel ctx inst s` >> simp[] >>
+  MATCH_ACCEPT_TAC lift_result_refl
+QED
+
+(* Push a non-pseudo past a list of pseudos. Induction on ps. *)
+(* OBSOLETE: push_nonpseudo_past_pseudos — approach doesn't work without
+   pseudos_prefix fix. Kept as cheat for now. *)
+Triviality push_nonpseudo_past_pseudos:
+  !ps fuel ctx h rest s.
+    ~is_terminator h.inst_opcode /\ ~is_pseudo h.inst_opcode /\
+    EVERY (\p. is_pseudo p.inst_opcode) ps /\
+    EVERY (\p. DISJOINT (set (inst_defs h)) (set (inst_defs p)) /\
+               DISJOINT (set (inst_defs h)) (set (inst_uses p)) /\
+               DISJOINT (set (inst_defs p)) (set (inst_uses h))) ps ==>
+    lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+      (run_insts fuel ctx (h :: (ps ++ rest)) s)
+      (run_insts fuel ctx (ps ++ (h :: rest)) s)
 Proof
   cheat
 QED
 
-(* ===== Helper lemmas ===== *)
-
-Theorem dft_block_label[simp]:
-  !order bb. (dft_block order bb).bb_label = bb.bb_label
+(* Partition a mixed list into pseudos ++ non-pseudos.
+   Under SSA data-independence, this preserves run_insts up to lift_result. *)
+Triviality run_insts_partition_pseudo:
+  !l fuel ctx s.
+    EVERY (\h. ~is_pseudo h.inst_opcode ==>
+              ~is_terminator h.inst_opcode /\
+              EVERY (\p. MEM p l /\ is_pseudo p.inst_opcode ==>
+                DISJOINT (set (inst_defs h)) (set (inst_defs p)) /\
+                DISJOINT (set (inst_defs h)) (set (inst_uses p)) /\
+                DISJOINT (set (inst_defs p)) (set (inst_uses h))) l) l ==>
+    lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+      (run_insts fuel ctx l s)
+      (run_insts fuel ctx
+        (FILTER (\i. is_pseudo i.inst_opcode) l ++
+         FILTER (\i. ~is_pseudo i.inst_opcode) l) s)
 Proof
-  rw[dft_block_def]
+  cheat
 QED
 
-(* ===== Function-level correctness ===== *)
+(* FRONT full equivalence: lift_result on FRONTs.
+   Strategy: partition both FRONTs as phis ++ body, show bodies equiv
+   via block_body_full_equiv, compose via run_insts_append.
+   Pseudos (update_var) commute with non-pseudos via frame property.
+   OK case: final states identical (all effects commute).
+   Abort case: revert_equiv holds because all abort-producing instructions
+   set vs_returndata := [] (ASSERT, ASSERT_UNREACHABLE, INVALID).
+   INVOKE abort returns callee state unchanged by caller pseudos. *)
+Triviality front_full_equiv:
+  !fn bb bb' fuel ctx s.
+    wf_ssa fn /\ wf_function fn /\
+    MEM bb fn.fn_blocks /\ block_perm_of fn bb' /\
+    bb.bb_label = bb'.bb_label /\
+    bb_well_formed bb /\ bb_well_formed bb' /\
+    pseudos_prefix bb /\ pseudos_prefix bb' /\
+    topo_sorted (full_dep (build_full_eda bb.bb_instructions))
+      (MAP (choose_original (block_body bb)) (block_body bb')) ==>
+    lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+      (run_insts fuel ctx (FRONT bb.bb_instructions) s)
+      (run_insts fuel ctx (FRONT bb'.bb_instructions) s)
+Proof
+  cheat
+QED
 
-(* CHEATED: dft_fn now includes StackOrderAnalysis convergence loop.
-   Correctness proof must account for the iterative scheduling. *)
-Theorem dft_function_correct:
-  !fn fuel ctx s.
-    (!bb order. MEM bb fn.fn_blocks ==>
-      !fuel ctx s.
-        s.vs_inst_idx = 0 ==>
-        lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
-          (exec_block fuel ctx bb s)
-          (exec_block fuel ctx (dft_block order bb) s)) /\
-    s.vs_inst_idx = 0 ==>
+(* When FRONTs are lift_result-related (not necessarily equal),
+   exec_blocks are also lift_result-related.
+   OK case: state_equiv {} = equality → same terminator from same state.
+   Non-OK case: chain FRONT1↔EXEC1, FRONT1↔FRONT2, FRONT2↔EXEC2. *)
+Triviality exec_block_front_lr_lift:
+  !bb bb' fuel ctx s.
+    bb_well_formed bb /\ bb_well_formed bb' /\
+    LAST bb'.bb_instructions = LAST bb.bb_instructions /\
+    LENGTH bb'.bb_instructions = LENGTH bb.bb_instructions /\
+    lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+      (run_insts fuel ctx (FRONT bb.bb_instructions) s)
+      (run_insts fuel ctx (FRONT bb'.bb_instructions) s) ==>
+    (?e. exec_block fuel ctx bb (s with vs_inst_idx := 0) = Error e) /\
+    (?e. exec_block fuel ctx bb' (s with vs_inst_idx := 0) = Error e) \/
+    lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+      (exec_block fuel ctx bb (s with vs_inst_idx := 0))
+      (exec_block fuel ctx bb' (s with vs_inst_idx := 0))
+Proof
+  rpt strip_tac >>
+  Cases_on `run_insts fuel ctx (FRONT bb.bb_instructions) s` >>
+  Cases_on `run_insts fuel ctx (FRONT bb'.bb_instructions) s` >>
+  gvs[lift_result_def]
+  (* OK-OK case: state_equiv {} = equality → identical exec_block *)
+  >- (disj2_tac >>
+      imp_res_tac state_equiv_empty_eq >> gvs[] >>
+      drule_all exec_block_same_front_ok >>
+      disch_then (fn th => rewrite_tac[th]) >>
+      MATCH_ACCEPT_TAC lift_result_refl)
+  (* All non-OK cases (Halt, Abort, IntRet, Error):
+     exec_block_front_non_ok lifts each FRONT to its exec_block,
+     then case-split on both exec_blocks and chain via transitivity *)
+  >> (
+    `lift_result (\_ _. T) (execution_equiv {}) revert_equiv
+       (run_insts fuel ctx (FRONT bb.bb_instructions) s)
+       (exec_block fuel ctx bb (s with vs_inst_idx := 0))` by
+       (irule exec_block_front_non_ok >> gs[]) >>
+    `lift_result (\_ _. T) (execution_equiv {}) revert_equiv
+       (run_insts fuel ctx (FRONT bb'.bb_instructions) s)
+       (exec_block fuel ctx bb' (s with vs_inst_idx := 0))` by
+       (irule exec_block_front_non_ok >> gs[]) >>
+    Cases_on `exec_block fuel ctx bb (s with vs_inst_idx := 0)` >>
+    Cases_on `exec_block fuel ctx bb' (s with vs_inst_idx := 0)` >>
+    gvs[lift_result_def, revert_equiv_def, execution_equiv_def])
+QED
+
+Theorem block_perm_of_exec_block_lift:
+  !fn bb bb' fuel ctx s.
+    wf_ssa fn /\ wf_function fn /\
+    MEM bb fn.fn_blocks /\ block_perm_of fn bb' /\
+    bb.bb_label = bb'.bb_label /\
+    bb_well_formed bb' /\
+    pseudos_prefix bb /\ pseudos_prefix bb' /\
+    topo_sorted (full_dep (build_full_eda bb.bb_instructions))
+      (MAP (choose_original (block_body bb)) (block_body bb')) ==>
+    ((?e. exec_block fuel ctx bb (s with vs_inst_idx := 0) = Error e) /\
+     (?e. exec_block fuel ctx bb' (s with vs_inst_idx := 0) = Error e)) \/
+    lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+      (exec_block fuel ctx bb (s with vs_inst_idx := 0))
+      (exec_block fuel ctx bb' (s with vs_inst_idx := 0))
+Proof
+  rpt strip_tac >>
+  `bb_well_formed bb` by
+    (qpat_assum `wf_function _`
+       (strip_assume_tac o REWRITE_RULE[wf_function_def]) >>
+     res_tac) >>
+  drule_all block_perm_of_same_last >> strip_tac >>
+  drule_all block_perm_of_same_length >> strip_tac >>
+  drule_all front_full_equiv >>
+  disch_then (qspecl_then [`fuel`, `ctx`, `s`] assume_tac) >>
+  irule exec_block_front_lr_lift >> asm_rewrite_tac[]
+QED
+
+(* Original blocks satisfy block_perm_of *)
+Triviality original_block_perm_of:
+  !fn bb. MEM bb fn.fn_blocks ==> block_perm_of fn bb
+Proof
+  rpt strip_tac >> simp[block_perm_of_def] >>
+  qexists_tac `bb` >> simp[from_block_def] >>
+  simp[EVERY_FILTER, EVERY_MEM] >> rpt strip_tac >>
+  qexists_tac `i` >> simp[]
+QED
+
+(* from_block preserves inst_id *)
+Triviality from_block_inst_id:
+  !bi i. from_block bi i ==> ?j. MEM j bi /\ i.inst_id = j.inst_id
+Proof
+  rw[from_block_def] >> metis_tac[flip_operands_inst_id]
+QED
+
+(* dft_block produces a PERM of inst_ids of non-pseudo instructions *)
+Triviality dft_block_perm_ids:
+  !order bb.
+    bb_well_formed bb /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions) /\
+    non_pseudo_defs_before_uses bb.bb_instructions ==>
+    PERM (MAP (\i. i.inst_id)
+            (FILTER (\i. ~is_pseudo i.inst_opcode)
+               (dft_block order bb).bb_instructions))
+         (MAP (\i. i.inst_id)
+            (FILTER (\i. ~is_pseudo i.inst_opcode) bb.bb_instructions))
+Proof
+  rpt strip_tac >>
+  simp[dft_block_def, LET_THM] >>
+  qabbrev_tac `bi = bb.bb_instructions` >>
+  qabbrev_tac `eda = build_full_eda bi` >>
+  qabbrev_tac `om = build_offspring_map bi order` >>
+  qabbrev_tac `entries = entry_instructions bi order eda` >>
+  qabbrev_tac `sched = schedule_from_entries bi order eda om entries` >>
+  (* Standard preamble *)
+  `eda_wf eda bi` by simp[Abbr `eda`, build_full_eda_wf] >>
+  `eda_topo_compatible bi eda order` by
+    (simp[Abbr `eda`] >>
+     qspecl_then [`bi`, `order`] mp_tac eda_topo_compatible_gen_weak >>
+     simp[] >> disch_then irule >>
+     fs[bb_well_formed_def, Abbr `bi`]) >>
+  `bi <> []` by fs[bb_well_formed_def, Abbr `bi`] >>
+  `np_defs_before_uses bi` by
+    gvs[non_pseudo_defs_before_uses_def, Abbr `bi`] >>
+  `EVERY (\i. MEM i bi) entries` by
+    simp[Abbr `entries`, Abbr `bi`, entry_instructions_mem] >>
+  `!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+       k = PRE (LENGTH bi)` by fs[bb_well_formed_def, Abbr `bi`] >>
+  `EVERY (\i. ~is_pseudo i.inst_opcode) sched` by
+    (simp[EVERY_MEM, Abbr `sched`] >> rpt strip_tac >>
+     metis_tac[schedule_output_from_block]) >>
+  `ALL_DISTINCT (MAP (\j. j.inst_id) sched)` by
+    (simp[Abbr `sched`] >>
+     irule schedule_output_all_distinct >> simp[Abbr `entries`]) >>
+  (* non-pseudo of (phis ++ sched) = sched *)
+  `FILTER (\i. ~is_pseudo i.inst_opcode)
+     (FILTER (\i. is_pseudo i.inst_opcode) bi ++ sched) = sched` by
+    (once_rewrite_tac[FILTER_APPEND_DISTRIB] >>
+     (`FILTER (\i. ~is_pseudo i.inst_opcode)
+         (FILTER (\i. is_pseudo i.inst_opcode) bi) = []` by
+        simp[FILTER_EQ_NIL, EVERY_MEM, MEM_FILTER]) >>
+     simp[FILTER_EQ_ID]) >>
+  simp[] >>
+  MATCH_MP_TAC PERM_ALL_DISTINCT >>
+  conj_tac >- simp[] >>
+  conj_tac
+  >- (irule dftPipelineInvarTheory.all_distinct_map_filter >> simp[]) >>
+  rpt strip_tac >> eq_tac >> strip_tac
+  (* → : from sched to bb — via from_block *)
+  >- (gvs[MEM_MAP, MEM_FILTER] >>
+      rename1 `MEM j sched` >>
+      `from_block bi j` by
+        (qspecl_then [`bi`,`order`,`eda`,`om`,`entries`,`j`]
+           mp_tac (cj 1 schedule_output_from_block) >>
+         simp[Abbr `sched`]) >>
+      gvs[from_block_def] >>
+      simp[MEM_MAP, MEM_FILTER, flip_operands_inst_id] >>
+      metis_tac[])
+  (* ← : from bb to sched — completeness *)
+  >> (gvs[MEM_MAP, MEM_FILTER] >>
+      `MEM i.inst_id (MAP (\j. j.inst_id) sched)` by
+        (qspecl_then [`bi`,`order`,`eda`,`om`] mp_tac
+           schedule_output_complete >>
+         simp[Abbr `sched`, Abbr `entries`] >>
+         disch_then (qspec_then `i` mp_tac) >> simp[Abbr `bi`]) >>
+      gvs[MEM_MAP] >>
+      metis_tac[])
+QED
+
+(* dft_block preserves block_perm_of, given dft_inv conditions *)
+Triviality dft_block_preserves_perm_of:
+  !order fn bb.
+    block_perm_of fn bb /\
+    bb_well_formed bb /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions) /\
+    non_pseudo_defs_before_uses bb.bb_instructions ==>
+    block_perm_of fn (dft_block order bb)
+Proof
+  rw[block_perm_of_def] >>
+  qexists_tac `bb_orig` >> simp[dft_block_phis] >>
+  conj_tac
+  (* from_block transitivity *)
+  >- (fs[EVERY_MEM, listTheory.MEM_FILTER] >> rpt strip_tac >>
+      `from_block bb.bb_instructions i` by
+        (mp_tac (Q.SPECL [`order`, `bb`, `i`] dft_block_from_orig) >>
+         simp[listTheory.MEM_FILTER]) >>
+      irule from_block_trans >> qexists_tac `bb.bb_instructions` >> simp[])
+  (* PERM: PERM_TRANS through bb *)
+  >> irule PERM_TRANS >>
+  qexists_tac `MAP (\i. i.inst_id)
+                 (FILTER (\i. ~is_pseudo i.inst_opcode) bb.bb_instructions)` >>
+  simp[dft_block_perm_ids]
+QED
+
+
+(* ===== dft_fn preserves bb_well_formed ===== *)
+
+(* dft_block preserves bb_well_formed: terminator stays at end,
+   phis stay as prefix, non-empty *)
+(* dft_block preserves bb_well_formed when terminator isn't a dep target.
+   wf_ssa ensures terminators have empty outputs (via def_dominates_uses),
+   hence no instruction within the block depends on them. *)
+(*  Helper: terminator is an entry instruction (has no dependents) *)
+Triviality terminator_is_entry:
+  !bi order eda.
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\ ~is_pseudo (LAST bi).inst_opcode /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    MEM (LAST bi) (entry_instructions bi order eda)
+Proof
+  rpt strip_tac >>
+  simp[entry_instructions_def, LET_THM, MEM_FILTER] >>
+  conj_tac
+  (* LAST bi's inst_id is not in any dep list *)
+  >- (simp[MEM_FLAT, MEM_MAP, PULL_EXISTS] >>
+      rpt strip_tac >> rename1 `MEM instr (FILTER _ bi)` >>
+      qspecl_then [`bi`, `eda`, `order`, `instr`] mp_tac
+        terminator_not_dep_target >>
+      gvs[MEM_FILTER, MEM_MAP] >> metis_tac[])
+  (* LAST bi is in bi *)
+  >> imp_res_tac (DB.fetch "rich_list" "MEM_LAST_NOT_NIL")
+QED
+
+(* Helper: terminator is last among entries (FILTER preserves order) *)
+Triviality filter_last_when_last_passes:
+  !P l. l <> [] /\ P (LAST l) ==> FILTER P l <> [] /\ LAST (FILTER P l) = LAST l
+Proof
+  gen_tac >> Induct_on `l` >> simp[] >> rpt strip_tac >>
+  Cases_on `l = []`
+  >- (gvs[LAST_DEF] >> simp[FILTER])
+  >> (gvs[LAST_DEF] >>
+      `FILTER P l <> [] /\ LAST (FILTER P l) = LAST l` by simp[] >>
+      Cases_on `P h` >> gvs[FILTER, LAST_DEF])
+QED
+
+Triviality terminator_last_entry:
+  !bi order eda.
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\ ~is_pseudo (LAST bi).inst_opcode /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    let entries = entry_instructions bi order eda in
+    entries <> [] /\ LAST entries = LAST bi
+Proof
+  rpt strip_tac >> simp[LET_THM] >>
+  `MEM (LAST bi) (entry_instructions bi order eda)` by
+    (irule terminator_is_entry >> simp[]) >>
+  simp[entry_instructions_def, LET_THM] >>
+  qabbrev_tac `nps = FILTER (\i. ~is_pseudo i.inst_opcode) bi` >>
+  (* Establish: nps <> [] /\ LAST nps = LAST bi *)
+  `nps <> [] /\ LAST nps = LAST bi` by
+    (simp[Abbr `nps`] >> irule filter_last_when_last_passes >> simp[]) >>
+  (* Establish: LAST bi passes the dep filter *)
+  `~MEM (LAST bi).inst_id
+     (FLAT (MAP (\i. MAP (\d. d.inst_id) (inst_all_deps bi order eda i)) nps))` by
+    (simp[MEM_FLAT, MEM_MAP, PULL_EXISTS] >> rpt strip_tac >>
+     rename1 `MEM instr nps` >>
+     qspecl_then [`bi`, `eda`, `order`, `instr`] mp_tac terminator_not_dep_target >>
+     gvs[Abbr `nps`, MEM_FILTER, MEM_MAP] >> metis_tac[]) >>
+  (* Now apply filter_last_when_last_passes *)
+  qabbrev_tac `Q = \i:instruction. ~MEM i.inst_id
+     (FLAT (MAP (\i. MAP (\d. d.inst_id) (inst_all_deps bi order eda i)) nps))` >>
+  `Q (LAST nps)` by simp[Abbr `Q`] >>
+  drule_all filter_last_when_last_passes >>
+  simp[Abbr `Q`]
+QED
+
+(* Helper: ALL_DISTINCT preserved by MAP over FILTER *)
+Triviality all_distinct_map_filter:
+  !f P l. ALL_DISTINCT (MAP f l) ==> ALL_DISTINCT (MAP f (FILTER P l))
+Proof
+  gen_tac >> gen_tac >> Induct >> simp[] >> rpt strip_tac >>
+  rw[] >> gvs[MEM_MAP, MEM_FILTER]
+QED
+
+(* Helper: terminator id not in FRONT entries' process stack *)
+Triviality id_not_in_map_process:
+  !l tid.
+    id_not_in_stack tid (MAP DfsProcess l) <=>
+    ~MEM tid (MAP (\i. i.inst_id) l)
+Proof
+  Induct >> simp[id_not_in_stack_def] >> metis_tac[]
+QED
+
+Triviality terminator_not_in_front_entries:
+  !bi order eda.
+    eda_wf eda bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\ ~is_pseudo (LAST bi).inst_opcode /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    let entries = entry_instructions bi order eda in
+    entries <> [] ==>
+    LAST entries = LAST bi ==>
+    id_not_in_stack (LAST bi).inst_id (MAP DfsProcess (FRONT entries))
+Proof
+  rpt strip_tac >> simp[LET_THM] >>
+  qabbrev_tac `entries = entry_instructions bi order eda` >>
+  rpt strip_tac >>
+  (* entries is FILTER of FILTER of bi, so ALL_DISTINCT (MAP inst_id entries) *)
+  `ALL_DISTINCT (MAP (\i. i.inst_id) entries)` by
+    (simp[Abbr `entries`, entry_instructions_def, LET_THM] >>
+     irule all_distinct_map_filter >> irule all_distinct_map_filter >> simp[]) >>
+  (* Use MEM_FRONT_NOT_LAST on MAP inst_id entries *)
+  `~MEM (LAST entries).inst_id
+        (MAP (\i. i.inst_id) (FRONT entries))` by
+    (qspecl_then [`MAP (\i. i.inst_id) entries`] mp_tac
+       (DB.fetch "rich_list" "MEM_FRONT_NOT_LAST") >>
+     simp[LAST_MAP, MAP_FRONT]) >>
+  gvs[] >>
+  simp[id_not_in_map_process]
+QED
+
+(* If from_block bi i and i.inst_id matches some unique element j,
+   then i = j or i = flip_operands j *)
+Triviality from_block_id_unique:
+  !bi i j.
+    from_block bi i /\ MEM j bi /\ ~is_pseudo j.inst_opcode /\
+    i.inst_id = j.inst_id /\ ALL_DISTINCT (MAP (\x. x.inst_id) bi) ==>
+    i = j \/ i = flip_operands j
+Proof
+  rw[from_block_def] >> gvs[flip_operands_inst_id] >>
+  gvs[MEM_EL] >>
+  `n = n'` by
+    (`fEL (MAP (\x. x.inst_id) bi) n = fEL (MAP (\x. x.inst_id) bi) n'` by
+       simp[EL_MAP] >>
+     metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP]) >>
+  gvs[]
+QED
+
+Triviality from_block_terminator_id:
+  !bi i.
+    from_block bi i /\ is_terminator i.inst_opcode /\
+    bi <> [] /\
+    ALL_DISTINCT (MAP (\x. x.inst_id) bi) /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    i.inst_id = (LAST bi).inst_id
+Proof
+  rpt strip_tac >>
+  fs[from_block_def] >> (
+    (* Both subgoals: i = j or i = flip_operands j, MEM j bi, ¬is_pseudo j.
+       In the i=j case: is_terminator i = is_terminator j, direct.
+       In the flip case: is_terminator (flip_operands j) = is_terminator j.
+       Either way j is a terminator, hence j = LAST bi. *)
+    `is_terminator j.inst_opcode` by gvs[flip_operands_is_terminator] >>
+    `?n. n < LENGTH bi /\ EL n bi = j` by metis_tac[MEM_EL] >>
+    `n = PRE (LENGTH bi)` by metis_tac[] >>
+    `j = LAST bi` by
+      (simp[LAST_EL] >> `0 < LENGTH bi` by (Cases_on `bi` >> gvs[]) >> gvs[]) >>
+    gvs[flip_operands_inst_id])
+QED
+
+(* Generalized: dft_block preserves invariant triple.
+   No dependency on fn or MEM bb fn.fn_blocks. *)
+Theorem dft_block_well_formed_gen:
+  !order bb.
+    bb_well_formed bb /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions) /\
+    non_pseudo_defs_before_uses bb.bb_instructions ==>
+    bb_well_formed (dft_block order bb) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) (dft_block order bb).bb_instructions) /\
+    non_pseudo_defs_before_uses (dft_block order bb).bb_instructions
+Proof
+  rpt strip_tac >>
+  simp[dft_block_def, LET_THM] >>
+  qabbrev_tac `bi = bb.bb_instructions` >>
+  qabbrev_tac `phis = FILTER (\i. is_pseudo i.inst_opcode) bi` >>
+  qabbrev_tac `eda = build_full_eda bi` >>
+  qabbrev_tac `om = build_offspring_map bi order` >>
+  qabbrev_tac `entries = entry_instructions bi order eda` >>
+  qabbrev_tac `sched = schedule_from_entries bi order eda om entries` >>
+  (* Prerequisites — shared preamble *)
+  `eda_wf eda bi` by simp[Abbr `eda`, build_full_eda_wf] >>
+  `eda_topo_compatible bi eda order` by
+    (simp[Abbr `eda`] >>
+     qspecl_then [`bi`, `order`] mp_tac eda_topo_compatible_gen_weak >>
+     simp[] >> disch_then irule >>
+     fs[bb_well_formed_def, Abbr `bi`]) >>
+  `bi <> []` by (fs[bb_well_formed_def, Abbr `bi`]) >>
+  `is_terminator (LAST bi).inst_opcode` by
+    fs[bb_well_formed_def, Abbr `bi`] >>
+  `~is_pseudo (LAST bi).inst_opcode` by
+    (fs[bb_well_formed_def, Abbr `bi`] >>
+     Cases_on `(LAST bb.bb_instructions).inst_opcode` >>
+     gs[is_terminator_def, is_pseudo_def]) >>
+  `!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+       k = PRE (LENGTH bi)` by
+    fs[bb_well_formed_def, Abbr `bi`] >>
+  `entries <> [] /\ LAST entries = LAST bi` by
+    (mp_tac (Q.SPECL [`bi`, `order`, `eda`] terminator_last_entry) >>
+     simp[LET_THM, Abbr `entries`]) >>
+  `id_not_in_stack (LAST bi).inst_id (MAP DfsProcess (FRONT entries))` by
+    (mp_tac (Q.SPECL [`bi`, `order`, `eda`] terminator_not_in_front_entries) >>
+     simp[LET_THM, Abbr `entries`]) >>
+  `!i'. MEM i' bi /\ ~is_pseudo i'.inst_opcode ==>
+       ~MEM (LAST bi).inst_id
+         (MAP (\d. d.inst_id) (inst_all_deps bi order eda i'))` by
+    (rpt strip_tac >>
+     qspecl_then [`bi`, `eda`, `order`, `i'`] mp_tac terminator_not_dep_target >>
+     simp[]) >>
+  `sched <> [] /\ (LAST sched).inst_id = (LAST bi).inst_id` by
+    (qspecl_then [`bi`, `order`, `eda`, `om`] mp_tac
+       (SIMP_RULE std_ss [LET_THM] schedule_terminator_last) >>
+     simp[Abbr `entries`, Abbr `sched`]) >>
+  `EVERY (\i. MEM i bi) entries` by
+    simp[Abbr `entries`, Abbr `bi`, entry_instructions_mem] >>
+  `!i. MEM i sched ==> from_block bi i /\ ~is_pseudo i.inst_opcode` by
+    (rpt strip_tac >>
+     qspecl_then [`bi`, `order`, `eda`, `om`, `entries`, `i`] mp_tac
+       schedule_output_from_block >> simp[Abbr `sched`]) >>
+  `MEM (LAST bi) bi` by
+    (imp_res_tac (DB.fetch "rich_list" "MEM_LAST_NOT_NIL")) >>
+  `np_defs_before_uses bi` by
+    gvs[non_pseudo_defs_before_uses_def, Abbr `bi`] >>
+  `ALL_DISTINCT (MAP (\j. j.inst_id) sched)` by
+    (simp[Abbr `sched`] >>
+     irule schedule_output_all_distinct >> simp[Abbr `entries`]) >>
+  `ALL_DISTINCT (MAP (\i. i.inst_id) phis)` by
+    (simp[Abbr `phis`] >> irule all_distinct_map_filter >> simp[]) >>
+  `output_producer_before bi sched` by
+    (simp[Abbr `sched`] >>
+     irule schedule_output_producer_before >> simp[Abbr `entries`]) >>
+  rpt conj_tac
+  (* ===== Part 1: bb_well_formed ===== *)
+  >- suspend "wf"
+  (* ===== Part 2: ALL_DISTINCT inst_ids ===== *)
+  >- suspend "all_distinct"
+  (* ===== Part 3: non_pseudo_defs_before_uses ===== *)
+  >> suspend "np_defs_before"
+QED
+
+(* --- Part 1: bb_well_formed --- *)
+
+Resume dft_block_well_formed_gen[wf]:
+  CONV_TAC (REWRITE_CONV [bb_well_formed_def]) >> simp[] >>
+  rpt conj_tac
+  (* nonempty *)
+  >> TRY (strip_tac >> gvs[] >> NO_TAC)
+  (* LAST is terminator *)
+  >> TRY (
+    simp[rich_listTheory.LAST_APPEND_NOT_NIL] >>
+    `from_block bi (LAST sched)` by
+      (first_x_assum (qspec_then `LAST sched` mp_tac) >>
+       impl_tac >> TRY (imp_res_tac (DB.fetch "rich_list" "MEM_LAST_NOT_NIL") >> NO_TAC) >>
+       strip_tac) >>
+    drule from_block_id_unique >>
+    disch_then (qspec_then `LAST bi` mp_tac) >> simp[] >>
+    strip_tac >> gvs[flip_operands_is_terminator] >> NO_TAC)
+  (* unique terminator position *)
+  >> TRY (
+    rpt strip_tac >>
+    Cases_on `i < LENGTH phis` >> gvs[]
+    >- (
+      `EL i (phis ++ sched) = EL i phis` by simp[EL_APPEND1] >>
+      `MEM (EL i phis) phis` by metis_tac[MEM_EL] >>
+      `is_pseudo (EL i phis).inst_opcode` by gvs[Abbr `phis`, MEM_FILTER] >>
+      Cases_on `(EL i phis).inst_opcode` >>
+      gvs[is_pseudo_def, is_terminator_def])
+    >> (
+      `i - LENGTH phis < LENGTH sched` by simp[] >>
+      `EL i (phis ++ sched) = EL (i - LENGTH phis) sched`
+        by simp[EL_APPEND2] >>
+      qabbrev_tac `k = i - LENGTH phis` >>
+      `MEM (EL k sched) sched` by metis_tac[MEM_EL] >>
+      `from_block bi (EL k sched)` by metis_tac[] >>
+      `(EL k sched).inst_id = (LAST bi).inst_id` by
+        (irule from_block_terminator_id >> simp[] >> gvs[]) >>
+      `0 < LENGTH sched` by (Cases_on `sched` >> gvs[]) >>
+      `PRE (LENGTH sched) < LENGTH sched` by simp[] >>
+      `EL k (MAP (\x. x.inst_id) sched) =
+       EL (PRE (LENGTH sched)) (MAP (\x. x.inst_id) sched)` by
+        (simp[EL_MAP] >> gvs[LAST_EL]) >>
+      `k = PRE (LENGTH sched)` by
+        (qspecl_then [`MAP (\x. x.inst_id) sched`, `k`, `PRE (LENGTH sched)`]
+          mp_tac ALL_DISTINCT_EL_IMP >> simp[]) >>
+      gvs[Abbr `k`]) >> NO_TAC)
+  (* PHI prefix *)
+  >> (
+    rpt strip_tac >>
+    Cases_on `j < LENGTH phis`
+    >- (
+      `i < LENGTH phis` by simp[] >>
+      simp[EL_APPEND1] >>
+      qspecl_then [`\i. is_pseudo i.inst_opcode`, `bi`, `i`, `j`]
+        mp_tac filter_el_mono >>
+      simp[Abbr `phis`] >> strip_tac >>
+      `(!i'' j''.
+          i'' < j'' /\ j'' < LENGTH bi /\
+          (EL j'' bi).inst_opcode = PHI ==>
+          (EL i'' bi).inst_opcode = PHI)` by
+        fs[bb_well_formed_def, Abbr `bi`] >>
+      `(EL j (FILTER (\i. is_pseudo i.inst_opcode) bi ++ sched)).inst_opcode = PHI`
+        by gvs[] >>
+      `(EL j (FILTER (\i. is_pseudo i.inst_opcode) bi)).inst_opcode = PHI`
+        by gvs[EL_APPEND1] >>
+      `(EL j' bi).inst_opcode = PHI` by gvs[] >>
+      `(EL i' bi).inst_opcode = PHI` by metis_tac[] >>
+      gvs[])
+    >> (
+      `j - LENGTH phis < LENGTH sched` by simp[] >>
+      `EL j (phis ++ sched) = EL (j - LENGTH phis) sched` by simp[EL_APPEND2] >>
+      `MEM (EL (j - LENGTH phis) sched) sched` by metis_tac[MEM_EL] >>
+      `~is_pseudo (EL (j - LENGTH phis) sched).inst_opcode` by metis_tac[] >>
+      `(EL (j - LENGTH phis) sched).inst_opcode = PHI` by gvs[] >>
+      fs[is_pseudo_def]))
+QED
+
+(* --- Part 2: ALL_DISTINCT inst_ids --- *)
+
+Resume dft_block_well_formed_gen[all_distinct]:
+  simp[ALL_DISTINCT_APPEND, MAP_MAP_o] >>
+  rpt strip_tac >>
+  rename1 `MEM eid _` >>
+  `?p. MEM p phis /\ p.inst_id = eid` by
+    (gvs[MEM_MAP] >> metis_tac[]) >>
+  `?s. MEM s sched /\ s.inst_id = eid` by
+    (gvs[MEM_MAP] >> metis_tac[]) >>
+  `is_pseudo p.inst_opcode` by gvs[Abbr `phis`, MEM_FILTER] >>
+  `~is_pseudo s.inst_opcode` by metis_tac[] >>
+  `from_block bi s` by metis_tac[] >>
+  `?j. MEM j bi /\ ~is_pseudo j.inst_opcode /\ s.inst_id = j.inst_id` by
+    (gvs[from_block_def] >> metis_tac[flip_operands_inst_id]) >>
+  `MEM p bi` by gvs[Abbr `phis`, MEM_FILTER] >>
+  `j.inst_id = p.inst_id` by gvs[] >>
+  `?n1. n1 < LENGTH bi /\ EL n1 bi = p` by metis_tac[MEM_EL] >>
+  `?n2. n2 < LENGTH bi /\ EL n2 bi = j` by metis_tac[MEM_EL] >>
+  `EL n1 (MAP (\i. i.inst_id) bi) = EL n2 (MAP (\i. i.inst_id) bi)` by
+    simp[EL_MAP] >>
+  `n1 = n2` by
+    (qspecl_then [`MAP (\i. i.inst_id) bi`, `n1`, `n2`]
+      mp_tac ALL_DISTINCT_EL_IMP >> simp[]) >>
+  gvs[]
+QED
+
+(* --- Part 3: defs_before_uses --- *)
+
+(* Helper: producing_inst on append *)
+Triviality producing_inst_append:
+  !l1 l2 var inst. producing_inst (l1 ++ l2) var = SOME inst ==>
+    producing_inst l1 var = SOME inst \/
+    (producing_inst l1 var = NONE /\ producing_inst l2 var = SOME inst)
+Proof
+  Induct_on `l1` >> simp[producing_inst_def] >> rpt strip_tac >>
+  Cases_on `MEM var h.inst_outputs` >> gvs[producing_inst_def]
+QED
+
+(* Helper: reverse direction of producing_inst_append *)
+Triviality producing_inst_append_none_some:
+  !l1 l2 var inst.
+    producing_inst l1 var = NONE /\ producing_inst l2 var = SOME inst ==>
+    producing_inst (l1 ++ l2) var = SOME inst
+Proof
+  Induct_on `l1` >> simp[producing_inst_def] >> rpt strip_tac >>
+  Cases_on `MEM var h.inst_outputs` >> gvs[producing_inst_def]
+QED
+
+(* Helper: producing_inst gives an index *)
+Triviality producing_inst_index:
+  !insts var inst. producing_inst insts var = SOME inst ==>
+    ?p. p < LENGTH insts /\ EL p insts = inst /\ MEM var inst.inst_outputs
+Proof
+  Induct_on `insts` >> simp[producing_inst_def] >> rpt strip_tac >>
+  Cases_on `MEM var h.inst_outputs` >> gvs[]
+  >- (qexists `0` >> simp[])
+  >> (res_tac >> qexists `SUC p` >> simp[])
+QED
+
+(* Helper: producing_inst finds earliest, so any earlier definer
+   implies the result is at or before that position *)
+Triviality producing_inst_earliest:
+  !insts var inst p.
+    producing_inst insts var = SOME inst /\
+    p < LENGTH insts /\ MEM var (EL p insts).inst_outputs ==>
+    ?q. q <= p /\ q < LENGTH insts /\ EL q insts = inst
+Proof
+  Induct_on `insts` >> simp[producing_inst_def] >> rpt strip_tac >>
+  Cases_on `MEM var h.inst_outputs` >> gvs[]
+  >- (qexists `0` >> simp[])
+  >> (Cases_on `p` >> gvs[] >>
+      first_x_assum drule_all >> strip_tac >>
+      qexists `SUC q` >> simp[])
+QED
+
+(* Helper: if a definer is in the list, producing_inst is not NONE *)
+Triviality producing_inst_not_none:
+  !insts var x. MEM x insts /\ MEM var x.inst_outputs ==>
+    ?y. producing_inst insts var = SOME y
+Proof
+  Induct >> simp[producing_inst_def] >> rpt strip_tac >>
+  Cases_on `MEM var h.inst_outputs` >> simp[] >>
+  gvs[] >> metis_tac[]
+QED
+
+(* Helper: producing_inst NONE means no definer in list *)
+Triviality producing_inst_none_no_def:
+  !insts var. producing_inst insts var = NONE ==>
+    !x. MEM x insts ==> ~MEM var x.inst_outputs
+Proof
+  Induct >> simp[producing_inst_def] >> rpt strip_tac >>
+  Cases_on `MEM var h.inst_outputs` >> gvs[]
+QED
+
+(* Helper: from_block preserves inst_outputs *)
+Triviality from_block_inst_outputs:
+  !bi i. from_block bi i ==>
+    ?j. MEM j bi /\ i.inst_outputs = j.inst_outputs /\
+        i.inst_id = j.inst_id
+Proof
+  rw[from_block_def] >> gvs[] >> metis_tac[flip_operands_inst_outputs,
+    flip_operands_inst_id]
+QED
+
+Resume dft_block_well_formed_gen[np_defs_before]:
+  CONV_TAC (REWRITE_CONV [non_pseudo_defs_before_uses_def]) >>
+  CONV_TAC (REWRITE_CONV [np_defs_before_uses_def]) >> simp[] >>
+  rpt strip_tac >>
+  (* User at index j is non-pseudo, so NOT in phis (phis only contain pseudos) *)
+  `~(j < LENGTH phis)` by
+    (spose_not_then assume_tac >>
+     `EL j (phis ++ sched) = EL j phis` by simp[EL_APPEND1] >>
+     `MEM (EL j phis) phis` by metis_tac[MEM_EL] >>
+     `is_pseudo (EL j phis).inst_opcode` by fs[Abbr `phis`, MEM_FILTER] >>
+     gvs[]) >>
+  (* User is in sched at position k = j - LENGTH phis *)
+  drule producing_inst_append >> strip_tac >>
+  `j - LENGTH phis < LENGTH sched` by simp[] >>
+  qabbrev_tac `k = j - LENGTH phis` >>
+  Cases_on `producing_inst phis var` >> gvs[]
+  >- (
+    (* Sub-case a: producer in phis -> witness at position p *)
+    drule producing_inst_index >> strip_tac >>
+    qexists `p` >> simp[EL_APPEND1])
+  >> (
+    (* Sub-case b: producer in sched, use output_producer_before *)
+    `producing_inst sched var = SOME prod` by gvs[] >>
+    `EL j (phis ++ sched) = EL k sched` by simp[Abbr `k`, EL_APPEND2] >>
+    `MEM (Var var) (EL k sched).inst_operands` by metis_tac[] >>
+    `MEM (EL k sched) sched` by metis_tac[MEM_EL] >>
+    imp_res_tac producing_inst_unique >>
+    `MEM prod sched` by metis_tac[] >>
+    `from_block bi prod` by metis_tac[] >>
+    drule from_block_inst_outputs >> strip_tac >>
+    rename1 `MEM j_orig bi` >>
+    `MEM var j_orig.inst_outputs` by metis_tac[] >>
+    `?prod_bi. producing_inst bi var = SOME prod_bi` by
+      metis_tac[producing_inst_not_none] >>
+    (* prod_bi is non-pseudo: if pseudo, it'd be in phis, contradicting
+       producing_inst phis var = NONE *)
+    `~is_pseudo prod_bi.inst_opcode` by
+      (spose_not_then assume_tac >>
+       imp_res_tac producing_inst_unique >>
+       `MEM prod_bi phis` by fs[Abbr `phis`, MEM_FILTER] >>
+       `?z. producing_inst phis var = SOME z` by
+         metis_tac[producing_inst_not_none] >>
+       gvs[]) >>
+    (* output_producer_before gives exists m < k with matching inst_id *)
+    qpat_x_assum `output_producer_before _ _`
+      (fn th => assume_tac (REWRITE_RULE [output_producer_before_def] th)) >>
+    first_x_assum (qspecl_then [`k`, `var`, `prod_bi`] mp_tac) >>
+    (impl_tac >- simp[]) >> strip_tac >>
+    rename1 `m < k` >>
+    `m < LENGTH sched` by simp[] >>
+    `MEM (EL m sched) sched` by metis_tac[MEM_EL] >>
+    `from_block bi (EL m sched)` by metis_tac[] >>
+    drule from_block_inst_outputs >> strip_tac >>
+    rename1 `MEM j2 bi` >>
+    `j2.inst_id = prod_bi.inst_id` by metis_tac[] >>
+    `MEM prod_bi bi` by (imp_res_tac producing_inst_unique >> simp[]) >>
+    (* ALL_DISTINCT inst_ids: j2 = prod_bi *)
+    `?n1. n1 < LENGTH bi /\ EL n1 bi = j2` by metis_tac[MEM_EL] >>
+    `?n2. n2 < LENGTH bi /\ EL n2 bi = prod_bi` by metis_tac[MEM_EL] >>
+    `EL n1 (MAP (\i. i.inst_id) bi) = EL n2 (MAP (\i. i.inst_id) bi)` by
+      simp[EL_MAP] >>
+    `n1 = n2` by metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP] >>
+    `j2 = prod_bi` by gvs[] >>
+    `MEM var (EL m sched).inst_outputs` by
+      (imp_res_tac producing_inst_unique >> gvs[]) >>
+    drule_all producing_inst_earliest >>
+    strip_tac >> rename1 `q <= m` >>
+    qexists `LENGTH phis + q` >> simp[EL_APPEND2, Abbr `k`])
+QED
+
+Finalise dft_block_well_formed_gen
+
+(* Original: dft_block preserves well-formedness for original blocks *)
+Theorem dft_block_well_formed:
+  !fn order bb.
+    wf_ssa fn /\ wf_function fn /\ MEM bb fn.fn_blocks ==>
+    bb_well_formed (dft_block order bb)
+Proof
+  rpt strip_tac >>
+  `bb_well_formed bb` by (gvs[wf_function_def, EVERY_MEM]) >>
+  `ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions)` by
+    (irule wf_fn_block_inst_ids_distinct >> metis_tac[]) >>
+  `non_pseudo_defs_before_uses bb.bb_instructions` by
+    (simp[non_pseudo_defs_before_uses_def] >>
+     irule defs_before_implies_np >>
+     irule wf_ssa_defs_before_uses >> metis_tac[]) >>
+  metis_tac[dft_block_well_formed_gen]
+QED
+
+(* Helper: MAP with conditional replacement preserves EVERY *)
+Triviality every_map_replace:
+  !P bbs lbl bb'.
+    EVERY P bbs /\ P bb' ==>
+    EVERY P (MAP (\b. if b.bb_label = lbl then bb' else b) bbs)
+Proof
+  Induct_on `bbs` >> simp[] >> rpt strip_tac >> rw[]
+QED
+
+(* FUNPOW invariant predicate *)
+Definition dft_inv_def:
+  dft_inv bbs <=>
+    EVERY (\bb. bb_well_formed bb /\
+                ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions) /\
+                non_pseudo_defs_before_uses bb.bb_instructions) bbs
+End
+
+(* dft_process_one preserves dft_inv *)
+Triviality dft_process_one_preserves_inv:
+  !cfg lr fn st lbl.
+    dft_inv st.dls_blocks ==>
+    dft_inv (FST (dft_process_one cfg lr fn st lbl)).dls_blocks
+Proof
+  rw[dft_process_one_def, LET_THM] >>
+  Cases_on `lookup_block lbl st.dls_blocks` >> simp[] >>
+  pairarg_tac >> simp[] >> pairarg_tac >> simp[] >>
+  IF_CASES_TAC >> simp[] >>
+  simp[dft_inv_def] >>
+  irule every_map_replace >> simp[] >>
+  fs[dft_inv_def] >>
+  `MEM x st.dls_blocks` by
+    (fs[lookup_block_def] >> imp_res_tac venomExecPropsTheory.FIND_MEM) >>
+  `bb_well_formed x /\ ALL_DISTINCT (MAP (\i. i.inst_id) x.bb_instructions) /\
+   non_pseudo_defs_before_uses x.bb_instructions` by fs[EVERY_MEM] >>
+  metis_tac[dft_block_well_formed_gen]
+QED
+
+(* dft_loop_step preserves dft_inv *)
+Triviality dft_loop_step_preserves_inv:
+  !cfg lr fn trip.
+    dft_inv (FST trip).dls_blocks ==>
+    dft_inv (FST (dft_loop_step cfg lr fn trip)).dls_blocks
+Proof
+  rpt gen_tac >> PairCases_on `trip` >>
+  simp[dft_loop_step_def, LET_THM] >>
+  IF_CASES_TAC >> simp[] >>
+  Cases_on `trip1` >> simp[] >> strip_tac >>
+  Cases_on `dft_process_one cfg lr fn trip0 h` >>
+  Cases_on `r` >> simp[] >>
+  qspecl_then [`cfg`,`lr`,`fn`,`trip0`,`h`]
+    mp_tac dft_process_one_preserves_inv >>
+  simp[] >> strip_tac >>
+  IF_CASES_TAC >> simp[]
+QED
+
+(* FUNPOW preserves dft_inv *)
+Triviality funpow_dft_loop_preserves_inv:
+  !n cfg lr fn trip.
+    dft_inv (FST trip).dls_blocks ==>
+    dft_inv (FST (FUNPOW (dft_loop_step cfg lr fn) n trip)).dls_blocks
+Proof
+  Induct >> simp[FUNPOW_SUC] >> rpt strip_tac >>
+  irule dft_loop_step_preserves_inv >>
+  first_x_assum irule >> simp[]
+QED
+
+(* Core: dft_fn preserves dft_inv *)
+(* Original blocks satisfy dft_inv *)
+Triviality wf_fn_initial_dft_inv:
+  !fn. wf_ssa fn /\ wf_function fn ==> dft_inv fn.fn_blocks
+Proof
+  rpt strip_tac >> simp[dft_inv_def, EVERY_MEM] >> rpt strip_tac
+  >- (gvs[wf_function_def, EVERY_MEM])
+  >- (irule wf_fn_block_inst_ids_distinct >> metis_tac[])
+  >> (simp[non_pseudo_defs_before_uses_def] >>
+      irule defs_before_implies_np >>
+      irule wf_ssa_defs_before_uses >> metis_tac[])
+QED
+
+(* dft_fn output satisfies dft_inv *)
+Triviality dft_fn_dft_inv:
+  !fn. wf_ssa fn /\ wf_function fn ==> dft_inv (dft_fn fn).fn_blocks
+Proof
+  rpt strip_tac >>
+  simp[dft_fn_def, LET_THM] >>
+  CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV) >>
+  simp[] >>
+  MATCH_MP_TAC funpow_dft_loop_preserves_inv >>
+  drule_all wf_fn_initial_dft_inv >> simp[]
+QED
+
+(* ===== FUNPOW invariant: blocks maintain block_perm_of ===== *)
+
+(* Predicate: every block in bbs is block_perm_of fn *)
+Definition all_blocks_perm_of_def:
+  all_blocks_perm_of fn bbs <=>
+    EVERY (block_perm_of fn) bbs
+End
+
+(* dft_process_one preserves all_blocks_perm_of, given dft_inv *)
+Triviality dft_process_one_preserves_perm:
+  !cfg lr fn st lbl.
+    all_blocks_perm_of fn st.dls_blocks /\ dft_inv st.dls_blocks ==>
+    all_blocks_perm_of fn (FST (dft_process_one cfg lr fn st lbl)).dls_blocks
+Proof
+  rw[dft_process_one_def, LET_THM] >>
+  Cases_on `lookup_block lbl st.dls_blocks` >> simp[] >>
+  pairarg_tac >> simp[] >> pairarg_tac >> simp[] >>
+  IF_CASES_TAC >> simp[] >>
+  simp[all_blocks_perm_of_def] >>
+  irule every_map_replace >> simp[] >>
+  fs[all_blocks_perm_of_def, dft_inv_def] >>
+  irule dft_block_preserves_perm_of >>
+  fs[lookup_block_def] >>
+  imp_res_tac venomExecPropsTheory.FIND_MEM >>
+  fs[EVERY_MEM]
+QED
+
+(* FUNPOW lifting: dft_loop_step preserves all_blocks_perm_of *)
+Triviality dft_loop_step_preserves_perm:
+  !cfg lr fn trip.
+    all_blocks_perm_of fn (FST trip).dls_blocks /\
+    dft_inv (FST trip).dls_blocks ==>
+    all_blocks_perm_of fn (FST (dft_loop_step cfg lr fn trip)).dls_blocks
+Proof
+  rpt gen_tac >> PairCases_on `trip` >>
+  simp[dft_loop_step_def, LET_THM] >>
+  IF_CASES_TAC >> simp[] >>
+  Cases_on `trip1` >> simp[] >> strip_tac >>
+  Cases_on `dft_process_one cfg lr fn trip0 h` >>
+  Cases_on `r` >> simp[] >>
+  qspecl_then [`cfg`,`lr`,`fn`,`trip0`,`h`]
+    mp_tac dft_process_one_preserves_perm >>
+  simp[] >> strip_tac >>
+  IF_CASES_TAC >> simp[]
+QED
+
+Triviality funpow_dft_loop_preserves_perm:
+  !n cfg lr fn trip.
+    all_blocks_perm_of fn (FST trip).dls_blocks /\
+    dft_inv (FST trip).dls_blocks ==>
+    all_blocks_perm_of fn
+      (FST (FUNPOW (dft_loop_step cfg lr fn) n trip)).dls_blocks
+Proof
+  Induct >> simp[FUNPOW_SUC] >> rpt strip_tac >>
+  MATCH_MP_TAC (SRULE [] dft_loop_step_preserves_perm) >>
+  conj_tac
+  >- (first_x_assum MATCH_MP_TAC >> simp[] >>
+      MATCH_MP_TAC funpow_dft_loop_preserves_inv >> simp[])
+  >> (MATCH_MP_TAC funpow_dft_loop_preserves_inv >> simp[])
+QED
+
+(* Core: dft_fn blocks are all block_perm_of fn *)
+Triviality dft_fn_all_perm_of:
+  !fn.
+    wf_ssa fn /\ wf_function fn ==>
+    all_blocks_perm_of fn (dft_fn fn).fn_blocks
+Proof
+  rpt strip_tac >> simp[dft_fn_def, LET_THM] >>
+  rewrite_tac[LET_THM] >>
+  CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV) >>
+  simp[] >>
+  irule funpow_dft_loop_preserves_perm >>
+  simp[all_blocks_perm_of_def, EVERY_MEM, original_block_perm_of] >>
+  irule wf_fn_initial_dft_inv >> simp[]
+QED
+
+(* Key bridge: lookup in dft_fn blocks gives a block_perm_of fn *)
+Triviality dft_fn_lookup_perm_of:
+  !fn lbl bb'.
+    wf_ssa fn /\ wf_function fn /\
+    lookup_block lbl (dft_fn fn).fn_blocks = SOME bb' ==>
+    block_perm_of fn bb'
+Proof
+  rpt strip_tac >>
+  `MEM bb' (dft_fn fn).fn_blocks` by
+    (fs[lookup_block_def] >>
+     imp_res_tac venomExecPropsTheory.FIND_MEM) >>
+  `all_blocks_perm_of fn (dft_fn fn).fn_blocks` by
+    (irule dft_fn_all_perm_of >> simp[]) >>
+  fs[all_blocks_perm_of_def, EVERY_MEM]
+QED
+
+
+(* All blocks in dft_fn are well-formed *)
+Triviality dft_fn_blocks_well_formed:
+  !fn bb'.
+    wf_ssa fn /\ wf_function fn /\ MEM bb' (dft_fn fn).fn_blocks ==>
+    bb_well_formed bb'
+Proof
+  rpt strip_tac >>
+  drule_all dft_fn_dft_inv >> strip_tac >>
+  gvs[dft_inv_def, EVERY_MEM]
+QED
+
+(* lookup_block NONE is preserved by dft_fn *)
+Triviality dft_fn_lookup_block_none:
+  !fn lbl.
+    lookup_block lbl fn.fn_blocks = NONE ==>
+    lookup_block lbl (dft_fn fn).fn_blocks = NONE
+Proof
+  spose_not_then strip_assume_tac >>
+  Cases_on `lookup_block lbl (dft_fn fn).fn_blocks` >> gvs[] >>
+  fs[lookup_block_def] >>
+  imp_res_tac venomExecPropsTheory.FIND_MEM >>
+  imp_res_tac venomExecPropsTheory.FIND_P >> gvs[] >>
+  drule dft_fn_labels >> strip_tac >>
+  `?y. FIND (\bb. bb.bb_label = x.bb_label) fn.fn_blocks = SOME y` by
+    (irule MEM_P_FIND >> qexists_tac `bb'` >> simp[]) >>
+  gvs[]
+QED
+
+(* ===== DFT output topo_sorted w.r.t. original deps ===== *)
+
+(* topo_sorted_map: subsumed by map_choose_original_topo_sorted_restricted *)
+
+(* flip_operands_inst_outputs: already in dftStructuralTheory *)
+
+(* flip_operands preserves set of operand_vars *)
+Triviality flip_operands_operand_vars_set:
+  !i. set (operand_vars (flip_operands i).inst_operands) =
+      set (operand_vars i.inst_operands)
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  TRY (IF_CASES_TAC >> simp[]) >>
+  (* Two-operand case: [a; b] → [b; a] *)
+  simp[operand_vars_def] >>
+  every_case_tac >> gvs[EXTENSION] >> metis_tac[]
+QED
+
+(* full_dep only depends on inst_id for from_block elements:
+   from_block preserves inst_id, set(inst_defs), and set(inst_uses).
+   So full_dep(eda)(x, y) ⟺ full_dep(eda)(x', y') when inst_ids match
+   and all instructions are from_block elements of the same block.
+   Proof: eda_dep only uses inst_id (proven as eda_dep_inst_id_only).
+          inst_defs = inst_outputs preserved by flip_operands_inst_outputs.
+          set(inst_uses) = set(operand_vars) preserved by flip_operands_operand_vars_set.
+   This condition is exactly what map_choose_original_topo_sorted_restricted needs. *)
+
+(* Key bridge: DFT output block's body, mapped back to originals via
+   choose_original, is topo_sorted w.r.t. the original block's full_dep.
+
+   Strategy:
+   1. topo_sorted_map: reduce MAP choose_original to showing choose_original
+      preserves full_dep (proven above as full_dep_choose_original)
+   2. For first iteration: schedule_topo_sorted_full_dep applies directly
+      (input = original block, EDA = original EDA)
+   3. For subsequent iterations: the EDA changes but all full_dep edges from
+      the original EDA are preserved because effect-conflicting pairs maintain
+      their relative order (chained transitively through the EDA).
+   4. build_full_eda_pseudo_strip removes pseudo prefix.
+*)
+Triviality dft_fn_output_topo_sorted:
+  !fn bb bb'.
+    wf_ssa fn /\ wf_function fn /\
+    MEM bb fn.fn_blocks /\
+    MEM bb' (dft_fn fn).fn_blocks /\
+    bb.bb_label = bb'.bb_label ==>
+    topo_sorted (full_dep (build_full_eda bb.bb_instructions))
+      (MAP (choose_original (block_body bb)) (block_body bb'))
+Proof
+  cheat
+QED
+
+(* ===== Function-level: run_blocks lift_result ===== *)
+
+(* Specialized rewrite for run_blocks (SUC fuel) — avoids hanging issues
+   with simp/ONCE_REWRITE_TAC on the recursive definition *)
+val run_blocks_SUC = let
+  val rb = run_blocks_def
+  val (vars, _) = strip_forall (concl rb)
+  val [sv,fv,fnv,cv] = vars
+  val inst = SPECL [sv, mk_comb(``SUC``, fv), fnv, cv] rb
+in SIMP_RULE (srw_ss()) [] inst |> GENL [sv, fv, fnv, cv] end;
+
+(* run_blocks with DFT-transformed blocks produces lift_result-equivalent
+   results. Fuel induction on run_blocks. *)
+Triviality dft_fn_run_blocks_lift:
+  !fuel ctx fn s.
+    wf_ssa fn /\ wf_function fn ==>
     lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
       (run_blocks fuel ctx fn s)
       (run_blocks fuel ctx (dft_fn fn) s)
 Proof
-  cheat
+  Induct_on `fuel`
+  >- simp[Ntimes run_blocks_def 2, lift_result_def]
+  >> rpt strip_tac >>
+     CONV_TAC (RATOR_CONV (RAND_CONV (REWR_CONV run_blocks_SUC))) >>
+     CONV_TAC (RAND_CONV (REWR_CONV run_blocks_SUC)) >>
+     Cases_on `lookup_block s.vs_current_bb fn.fn_blocks` >> simp[]
+  (* NONE case: block not found in fn *)
+  >- (`lookup_block s.vs_current_bb (dft_fn fn).fn_blocks = NONE` by
+        (irule dft_fn_lookup_block_none >> simp[]) >>
+      simp[lift_result_def])
+  (* SOME x case: block found in fn *)
+  >> rename1 `SOME bb` >>
+     `?bb'. lookup_block s.vs_current_bb (dft_fn fn).fn_blocks = SOME bb'` by
+       (irule dft_fn_lookup_block >> metis_tac[]) >>
+     simp[] >>
+     (* Get MEM bb, block_perm_of bb', bb_well_formed bb' *)
+     `MEM bb fn.fn_blocks` by
+       (fs[lookup_block_def] >> imp_res_tac venomExecPropsTheory.FIND_MEM) >>
+     `bb.bb_label = bb'.bb_label` by
+       (fs[lookup_block_def] >>
+        imp_res_tac venomExecPropsTheory.FIND_P >> gvs[]) >>
+     `block_perm_of fn bb'` by
+       (irule dft_fn_lookup_perm_of >> metis_tac[]) >>
+     `MEM bb' (dft_fn fn).fn_blocks` by
+       (fs[lookup_block_def] >> imp_res_tac venomExecPropsTheory.FIND_MEM) >>
+     `bb_well_formed bb'` by
+       (irule dft_fn_blocks_well_formed >> metis_tac[]) >>
+     (* DFT output is topo_sorted under full_dep *)
+     `topo_sorted (full_dep (build_full_eda bb.bb_instructions))
+        (MAP (choose_original (block_body bb)) (block_body bb'))` by
+       (qspecl_then [`fn`, `bb`, `bb'`] mp_tac dft_fn_output_topo_sorted >>
+        simp[]) >>
+     (* Use block_perm_of_exec_block_lift *)
+     drule_all block_perm_of_exec_block_lift >>
+     disch_then (qspecl_then [`fuel`, `ctx`, `s`] assume_tac) >>
+     (* Two cases: both Error, or lift_result *)
+     gvs[]
+     (* Both Error case: Error propagates through run_blocks case-split *)
+     >- simp[lift_result_def]
+     (* lift_result case *)
+     >> Cases_on `exec_block fuel ctx bb (s with vs_inst_idx := 0)` >>
+        Cases_on `exec_block fuel ctx bb' (s with vs_inst_idx := 0)` >>
+        gvs[lift_result_def, execution_equiv_def, revert_equiv_def]
+        (* OK-OK case: states equal, use IH *)
+        >- (imp_res_tac state_equiv_empty_eq >> gvs[] >>
+            IF_CASES_TAC >> gvs[lift_result_def, execution_equiv_def] >>
+            qpat_x_assum `!ctx fn' s'. wf_ssa fn' /\ _ ==> _`
+              (qspecl_then [`ctx`, `fn`, `v`] mp_tac) >>
+            simp[])
 QED
 
-(* ===== Pass correctness ===== *)
+(* ===== Function-level: run_function lift_result ===== *)
 
-(* TODO: needs fuel determinism proof.
-   For now, cheated pending fuel determinism infrastructure. *)
+Triviality dft_fn_run_function_lift:
+  !fuel ctx fn s.
+    wf_ssa fn /\ wf_function fn /\
+    s.vs_inst_idx = 0 /\ ~s.vs_halted ==>
+    lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
+      (run_function fuel ctx fn s)
+      (run_function fuel ctx (dft_fn fn) s)
+Proof
+  rpt strip_tac >>
+  simp[run_function_def] >>
+  `fn_entry_label (dft_fn fn) = fn_entry_label fn` by (
+    simp[fn_entry_label_def, entry_block_def] >>
+    `~NULL (dft_fn fn).fn_blocks = ~NULL fn.fn_blocks` by (
+      `MAP (\b. b.bb_label) (dft_fn fn).fn_blocks =
+       MAP (\b. b.bb_label) fn.fn_blocks` by simp[dft_fn_labels_map] >>
+      Cases_on `fn.fn_blocks` >> Cases_on `(dft_fn fn).fn_blocks` >>
+      gvs[]) >>
+    Cases_on `NULL fn.fn_blocks` >> simp[] >>
+    `MAP (\b. b.bb_label) (dft_fn fn).fn_blocks =
+     MAP (\b. b.bb_label) fn.fn_blocks` by simp[dft_fn_labels_map] >>
+    Cases_on `fn.fn_blocks` >> Cases_on `(dft_fn fn).fn_blocks` >>
+    gvs[]) >>
+  simp[] >>
+  Cases_on `fn_entry_label fn` >> simp[lift_result_def] >>
+  irule dft_fn_run_blocks_lift >> simp[]
+QED
+
+(* ===== Fuel determinism helpers ===== *)
+
+Triviality run_function_fuel_determ:
+  !fuel fuel' ctx fn s.
+    terminates (run_function fuel ctx fn s) /\
+    terminates (run_function fuel' ctx fn s) ==>
+    run_function fuel ctx fn s = run_function fuel' ctx fn s
+Proof
+  rpt strip_tac >>
+  simp[run_function_def] >>
+  Cases_on `fn_entry_label fn` >> gvs[run_function_def, terminates_def] >>
+  `!e. run_blocks fuel ctx fn
+       (s with <| vs_current_bb := x; vs_inst_idx := 0 |>) <> Error e` by
+    (gvs[run_function_def] >>
+     Cases_on `run_blocks fuel ctx fn
+       (s with <| vs_current_bb := x; vs_inst_idx := 0 |>)` >>
+     gvs[terminates_def]) >>
+  `!e. run_blocks fuel' ctx fn
+       (s with <| vs_current_bb := x; vs_inst_idx := 0 |>) <> Error e` by
+    (gvs[run_function_def] >>
+     Cases_on `run_blocks fuel' ctx fn
+       (s with <| vs_current_bb := x; vs_inst_idx := 0 |>)` >>
+     gvs[terminates_def]) >>
+  Cases_on `fuel <= fuel'`
+  >- metis_tac[fuel_mono |> CONJUNCTS |> last]
+  >> (`fuel' <= fuel` by simp[] >> metis_tac[fuel_mono |> CONJUNCTS |> last])
+QED
+
+(* ===== COUNTEREXAMPLE: dft_pass_correct is FALSE as stated ===== *)
+(*
+ * The theorem is false because bb_well_formed only constrains PHI
+ * instructions to form a prefix, but PARAM (also a pseudo) can appear
+ * after non-pseudos. dft_block moves ALL pseudos to the front, which
+ * can move a failing PARAM before an aborting non-pseudo instruction.
+ *
+ * Counterexample: Block [ASSERT(Lit 0w), PARAM(0)->x, STOP]
+ *   with s.vs_params = [].
+ *
+ * Original execution: ASSERT(0w) -> Abort (terminates)
+ * DFT reorders to:    [PARAM(0)->x, ASSERT(Lit 0w), STOP]
+ * DFT execution:      PARAM(0) -> Error (does not terminate)
+ *
+ * Fix: strengthen bb_well_formed to require ALL pseudos (not just PHI)
+ * form a prefix of the block.
+ *)
+
+Definition cex_fn_def:
+  cex_fn = <| fn_name := "entry"; fn_blocks := [
+    <| bb_label := "entry"; bb_instructions := [
+      <| inst_id := 1; inst_opcode := ASSERT;
+         inst_operands := [Lit 0w]; inst_outputs := [] |>;
+      <| inst_id := 2; inst_opcode := PARAM;
+         inst_operands := [Lit 0w]; inst_outputs := ["x"] |>;
+      <| inst_id := 3; inst_opcode := STOP;
+         inst_operands := []; inst_outputs := [] |>
+    ] |>] |>
+End
+
+Definition cex_ctx_def:
+  cex_ctx = <| ctx_functions := []; ctx_entry := NONE |>
+End
+
+Definition cex_s_def:
+  cex_s = init_venom_state "entry"
+End
+
+(* DFT reorders [ASSERT, PARAM, STOP] to [PARAM, ASSERT, STOP] *)
+Triviality cex_dft_reorders:
+  (dft_fn cex_fn).fn_blocks = [
+    <| bb_label := "entry"; bb_instructions := [
+      <| inst_id := 2; inst_opcode := PARAM;
+         inst_operands := [Lit 0w]; inst_outputs := ["x"] |>;
+      <| inst_id := 1; inst_opcode := ASSERT;
+         inst_operands := [Lit 0w]; inst_outputs := [] |>;
+      <| inst_id := 3; inst_opcode := STOP;
+         inst_operands := []; inst_outputs := [] |>
+    ] |>]
+Proof
+  EVAL_TAC
+QED
+
+(* Preconditions hold *)
+Triviality cex_wf_ssa:
+  wf_ssa cex_fn
+Proof
+  simp[wf_ssa_def, ssa_form_def, def_dominates_uses_def, cex_fn_def,
+       fn_insts_def, fn_insts_blocks_def] >>
+  rpt strip_tac >> gvs[]
+QED
+
+Triviality cex_wf_function:
+  wf_function cex_fn
+Proof
+  rw[wf_function_def, cex_fn_def, fn_has_entry_def, fn_inst_ids_distinct_def,
+     bb_well_formed_def, fn_succs_closed_def, bb_succs_def,
+     fn_labels_def, is_terminator_def]
+  (* terminator only at end *)
+  >- (`i = 0 \/ i = 1 \/ i = 2` by decide_tac >> gvs[is_terminator_def])
+  (* PHI prefix — vacuous (no PHI) *)
+  >- (`j = 0 \/ j = 1 \/ j = 2` by decide_tac >> gvs[])
+  (* succs_closed — STOP has no successors *)
+  >> gvs[get_successors_def]
+QED
+
+Triviality cex_init_state:
+  cex_s.vs_inst_idx = 0 /\ ~cex_s.vs_halted
+Proof
+  EVAL_TAC
+QED
+
+(* Original execution terminates (Abort) *)
+Triviality cex_orig_terminates:
+  terminates (run_function 10 cex_ctx cex_fn cex_s)
+Proof
+  EVAL_TAC
+QED
+
+(* DFT execution does not terminate (Error) for any fuel *)
+Triviality cex_dft_not_terminates:
+  !fuel. ~terminates (run_function fuel cex_ctx (dft_fn cex_fn) cex_s)
+Proof
+  Cases >- EVAL_TAC >>
+  simp[cex_fn_def, cex_ctx_def, cex_s_def, run_function_def,
+       fn_entry_label_def, dft_fn_def, dft_block_def] >>
+  ONCE_REWRITE_TAC[run_blocks_def] >>
+  simp[lookup_block_def] >>
+  ONCE_REWRITE_TAC[exec_block_def] >>
+  simp[get_instruction_def] >>
+  ONCE_REWRITE_TAC[step_inst_def] >>
+  EVAL_TAC
+QED
+
+(* The theorem is FALSE *)
+Theorem dft_pass_correct_is_false:
+  ?fn ctx s.
+    wf_ssa fn /\ wf_function fn /\
+    s.vs_inst_idx = 0 /\ ~s.vs_halted /\
+    ~pass_correct (state_equiv {}) (execution_equiv {}) revert_equiv
+      (\fuel. run_function fuel ctx fn s)
+      (\fuel. run_function fuel ctx (dft_fn fn) s)
+Proof
+  qexistsl [`cex_fn`, `cex_ctx`, `cex_s`] >>
+  simp[cex_wf_ssa, cex_wf_function, cex_init_state] >>
+  rewrite_tac[pass_correct_def] >>
+  strip_tac >>
+  `?fuel. terminates (run_function fuel cex_ctx cex_fn cex_s)` by
+    (qexists `10` >> EVAL_TAC) >>
+  `!fuel. ~terminates (run_function fuel cex_ctx (dft_fn cex_fn) cex_s)` by
+    simp[cex_dft_not_terminates] >>
+  metis_tac[]
+QED
+
+(* ===== Pass-level correctness (FALSE — see above) ===== *)
+
+(* dft_pass_correct requires fn_pseudos_prefix — see dft_pass_correct_is_false
+ * above for a counterexample without it. pseudos_prefix is a separate
+ * predicate (not added to bb_well_formed) to avoid 30+ min rebuild. *)
 Theorem dft_pass_correct:
   !fn ctx s.
-    (!bb order. MEM bb fn.fn_blocks ==>
-      !fuel ctx s.
-        s.vs_inst_idx = 0 ==>
-        lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
-          (exec_block fuel ctx bb s)
-          (exec_block fuel ctx (dft_block order bb) s)) ==>
+    wf_ssa fn /\ wf_function fn /\ fn_pseudos_prefix fn /\
+    s.vs_inst_idx = 0 /\ ~s.vs_halted ==>
     pass_correct (state_equiv {}) (execution_equiv {}) revert_equiv
-      (\fuel. run_blocks fuel ctx fn s)
-      (\fuel. run_blocks fuel ctx (dft_fn fn) s)
+      (\fuel. run_function fuel ctx fn s)
+      (\fuel. run_function fuel ctx (dft_fn fn) s)
 Proof
   cheat
 QED
 
-(* ===== Obligations ===== *)
-
-(* DFT only reorders instructions within blocks — no new outputs. *)
-Theorem dft_preserves_ssa_form:
-  ∀fn. ssa_form fn ⇒ ssa_form (dft_fn fn)
-Proof
-  cheat
-QED
-
-Theorem dft_preserves_wf_function:
-  ∀fn. wf_function fn ⇒ wf_function (dft_fn fn)
-Proof
-  cheat
-QED
-
-(* DFT is the only pass that runs after SUE — must preserve sue form. *)
-Theorem dft_preserves_single_use_form:
-  ∀fn. single_use_form fn ⇒ single_use_form (dft_fn fn)
-Proof
-  cheat
-QED

--- a/venom/passes/dft/proofs/dftCorrectnessScript.sml
+++ b/venom/passes/dft/proofs/dftCorrectnessScript.sml
@@ -6827,11 +6827,20 @@ val run_blocks_SUC = let
   val inst = SPECL [sv, mk_comb(``SUC``, fv), fnv, cv] rb
 in SIMP_RULE (srw_ss()) [] inst |> GENL [sv, fv, fnv, cv] end;
 
+(* DFT preserves fn_pseudos_prefix: dft_block outputs phis ++ scheduled,
+   so pseudos remain at the front. Cheated pending proof of
+   schedule_from_entries producing only non-pseudo instructions. *)
+Triviality dft_fn_pseudos_prefix:
+  !fn. fn_pseudos_prefix fn ==> fn_pseudos_prefix (dft_fn fn)
+Proof
+  cheat
+QED
+
 (* run_blocks with DFT-transformed blocks produces lift_result-equivalent
    results. Fuel induction on run_blocks. *)
-Triviality dft_fn_run_blocks_lift:
+Theorem dft_fn_run_blocks_lift:
   !fuel ctx fn s.
-    wf_ssa fn /\ wf_function fn ==>
+    wf_ssa fn /\ wf_function fn /\ fn_pseudos_prefix fn ==>
     lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
       (run_blocks fuel ctx fn s)
       (run_blocks fuel ctx (dft_fn fn) s)
@@ -6863,6 +6872,12 @@ Proof
        (fs[lookup_block_def] >> imp_res_tac venomExecPropsTheory.FIND_MEM) >>
      `bb_well_formed bb'` by
        (irule dft_fn_blocks_well_formed >> metis_tac[]) >>
+     `pseudos_prefix bb` by
+       (gvs[fn_pseudos_prefix_def]) >>
+     `pseudos_prefix bb'` by
+       (`fn_pseudos_prefix (dft_fn fn)` by
+          (irule dft_fn_pseudos_prefix >> simp[]) >>
+        gvs[fn_pseudos_prefix_def]) >>
      (* DFT output is topo_sorted under full_dep *)
      `topo_sorted (full_dep (build_full_eda bb.bb_instructions))
         (MAP (choose_original (block_body bb)) (block_body bb'))` by
@@ -6891,7 +6906,7 @@ QED
 
 Triviality dft_fn_run_function_lift:
   !fuel ctx fn s.
-    wf_ssa fn /\ wf_function fn /\
+    wf_ssa fn /\ wf_function fn /\ fn_pseudos_prefix fn /\
     s.vs_inst_idx = 0 /\ ~s.vs_halted ==>
     lift_result (state_equiv {}) (execution_equiv {}) revert_equiv
       (run_function fuel ctx fn s)

--- a/venom/passes/dft/proofs/dftCorrectnessScript.sml
+++ b/venom/passes/dft/proofs/dftCorrectnessScript.sml
@@ -6944,135 +6944,14 @@ Proof
   >> (`fuel' <= fuel` by simp[] >> metis_tac[fuel_mono |> CONJUNCTS |> last])
 QED
 
-(* ===== COUNTEREXAMPLE: dft_pass_correct is FALSE as stated ===== *)
-(*
- * The theorem is false because bb_well_formed only constrains PHI
- * instructions to form a prefix, but PARAM (also a pseudo) can appear
- * after non-pseudos. dft_block moves ALL pseudos to the front, which
- * can move a failing PARAM before an aborting non-pseudo instruction.
- *
- * Counterexample: Block [ASSERT(Lit 0w), PARAM(0)->x, STOP]
- *   with s.vs_params = [].
- *
- * Original execution: ASSERT(0w) -> Abort (terminates)
- * DFT reorders to:    [PARAM(0)->x, ASSERT(Lit 0w), STOP]
- * DFT execution:      PARAM(0) -> Error (does not terminate)
- *
- * Fix: strengthen bb_well_formed to require ALL pseudos (not just PHI)
- * form a prefix of the block.
- *)
+(* ===== Pass-level correctness ===== *)
 
-Definition cex_fn_def:
-  cex_fn = <| fn_name := "entry"; fn_blocks := [
-    <| bb_label := "entry"; bb_instructions := [
-      <| inst_id := 1; inst_opcode := ASSERT;
-         inst_operands := [Lit 0w]; inst_outputs := [] |>;
-      <| inst_id := 2; inst_opcode := PARAM;
-         inst_operands := [Lit 0w]; inst_outputs := ["x"] |>;
-      <| inst_id := 3; inst_opcode := STOP;
-         inst_operands := []; inst_outputs := [] |>
-    ] |>] |>
-End
-
-Definition cex_ctx_def:
-  cex_ctx = <| ctx_functions := []; ctx_entry := NONE |>
-End
-
-Definition cex_s_def:
-  cex_s = init_venom_state "entry"
-End
-
-(* DFT reorders [ASSERT, PARAM, STOP] to [PARAM, ASSERT, STOP] *)
-Triviality cex_dft_reorders:
-  (dft_fn cex_fn).fn_blocks = [
-    <| bb_label := "entry"; bb_instructions := [
-      <| inst_id := 2; inst_opcode := PARAM;
-         inst_operands := [Lit 0w]; inst_outputs := ["x"] |>;
-      <| inst_id := 1; inst_opcode := ASSERT;
-         inst_operands := [Lit 0w]; inst_outputs := [] |>;
-      <| inst_id := 3; inst_opcode := STOP;
-         inst_operands := []; inst_outputs := [] |>
-    ] |>]
-Proof
-  EVAL_TAC
-QED
-
-(* Preconditions hold *)
-Triviality cex_wf_ssa:
-  wf_ssa cex_fn
-Proof
-  simp[wf_ssa_def, ssa_form_def, def_dominates_uses_def, cex_fn_def,
-       fn_insts_def, fn_insts_blocks_def] >>
-  rpt strip_tac >> gvs[]
-QED
-
-Triviality cex_wf_function:
-  wf_function cex_fn
-Proof
-  rw[wf_function_def, cex_fn_def, fn_has_entry_def, fn_inst_ids_distinct_def,
-     bb_well_formed_def, fn_succs_closed_def, bb_succs_def,
-     fn_labels_def, is_terminator_def]
-  (* terminator only at end *)
-  >- (`i = 0 \/ i = 1 \/ i = 2` by decide_tac >> gvs[is_terminator_def])
-  (* PHI prefix — vacuous (no PHI) *)
-  >- (`j = 0 \/ j = 1 \/ j = 2` by decide_tac >> gvs[])
-  (* succs_closed — STOP has no successors *)
-  >> gvs[get_successors_def]
-QED
-
-Triviality cex_init_state:
-  cex_s.vs_inst_idx = 0 /\ ~cex_s.vs_halted
-Proof
-  EVAL_TAC
-QED
-
-(* Original execution terminates (Abort) *)
-Triviality cex_orig_terminates:
-  terminates (run_function 10 cex_ctx cex_fn cex_s)
-Proof
-  EVAL_TAC
-QED
-
-(* DFT execution does not terminate (Error) for any fuel *)
-Triviality cex_dft_not_terminates:
-  !fuel. ~terminates (run_function fuel cex_ctx (dft_fn cex_fn) cex_s)
-Proof
-  Cases >- EVAL_TAC >>
-  simp[cex_fn_def, cex_ctx_def, cex_s_def, run_function_def,
-       fn_entry_label_def, dft_fn_def, dft_block_def] >>
-  ONCE_REWRITE_TAC[run_blocks_def] >>
-  simp[lookup_block_def] >>
-  ONCE_REWRITE_TAC[exec_block_def] >>
-  simp[get_instruction_def] >>
-  ONCE_REWRITE_TAC[step_inst_def] >>
-  EVAL_TAC
-QED
-
-(* The theorem is FALSE *)
-Theorem dft_pass_correct_is_false:
-  ?fn ctx s.
-    wf_ssa fn /\ wf_function fn /\
-    s.vs_inst_idx = 0 /\ ~s.vs_halted /\
-    ~pass_correct (state_equiv {}) (execution_equiv {}) revert_equiv
-      (\fuel. run_function fuel ctx fn s)
-      (\fuel. run_function fuel ctx (dft_fn fn) s)
-Proof
-  qexistsl [`cex_fn`, `cex_ctx`, `cex_s`] >>
-  simp[cex_wf_ssa, cex_wf_function, cex_init_state] >>
-  rewrite_tac[pass_correct_def] >>
-  strip_tac >>
-  `?fuel. terminates (run_function fuel cex_ctx cex_fn cex_s)` by
-    (qexists `10` >> EVAL_TAC) >>
-  `!fuel. ~terminates (run_function fuel cex_ctx (dft_fn cex_fn) cex_s)` by
-    simp[cex_dft_not_terminates] >>
-  metis_tac[]
-QED
-
-(* ===== Pass-level correctness (FALSE — see above) ===== *)
-
-(* dft_pass_correct requires fn_pseudos_prefix — see dft_pass_correct_is_false
- * above for a counterexample without it. pseudos_prefix is a separate
- * predicate (not added to bb_well_formed) to avoid 30+ min rebuild. *)
+(* dft_pass_correct requires fn_pseudos_prefix: without it, the theorem is
+ * false. Counterexample: Block [ASSERT(Lit 0w), PARAM(0)->x, STOP] with
+ * s.vs_params = []. Original aborts at ASSERT; DFT moves PARAM before
+ * ASSERT, hitting Error instead (PARAM with empty params list).
+ * pseudos_prefix is a separate predicate (not added to bb_well_formed)
+ * to avoid 30+ min rebuild of execEquivProofs. *)
 Theorem dft_pass_correct:
   !fn ctx s.
     wf_ssa fn /\ wf_function fn /\ fn_pseudos_prefix fn /\

--- a/venom/passes/dft/proofs/dftIdempotentScript.sml
+++ b/venom/passes/dft/proofs/dftIdempotentScript.sml
@@ -1,0 +1,539 @@
+(*
+ * DFT Idempotent — Input-Order-Independence of dft_block
+ *
+ * Key result: dft_block order (dft_block order' bb) = dft_block order bb
+ *
+ * This means applying dft_block to an already-dft'd block gives the same
+ * result as applying it to the original. The second dft_block "sees through"
+ * the first transformation.
+ *
+ * Proof strategy: Show that the schedule pipeline only depends on:
+ *   (1) The set of non-pseudo inst_ids (with their opcodes and outputs)
+ *   (2) The phi instructions (same in both cases)
+ *   (3) The order parameter (same in both cases)
+ * NOT on the order of non-pseudo instructions in bb.bb_instructions.
+ *
+ * Key sub-lemmas:
+ *   - producing_inst is order-independent under unique defs
+ *   - build_eda is order-independent when same-effect-type pairs
+ *     maintain relative order (which dft_block guarantees)
+ *   - DFS is deterministic given same deps and order
+ *)
+
+Theory dftIdempotent
+Ancestors
+  dftStructural dftDefs venomExecSemantics venomEffects passSharedDefs
+  venomInst list rich_list sorting finite_map
+
+(* ===== producing_inst order-independence ===== *)
+
+(* producing_inst returns the FIRST instruction with var in outputs.
+   Under unique defs (at most one inst defines each var), the result
+   is the same regardless of list order. *)
+
+Definition unique_defs_def:
+  unique_defs insts <=>
+    !i j. i < j /\ j < LENGTH insts ==>
+      DISJOINT (set (EL i insts).inst_outputs) (set (EL j insts).inst_outputs)
+End
+
+(* producing_inst returns an instruction that is in the list
+   and has var in its outputs. *)
+Theorem producing_inst_unique:
+  !insts var inst.
+    producing_inst insts var = SOME inst ==>
+    MEM inst insts /\ MEM var inst.inst_outputs
+Proof
+  Induct >> rw[producing_inst_def] >>
+  BasicProvers.every_case_tac >> gvs[] >> metis_tac[]
+QED
+
+Theorem producing_inst_mem_outputs:
+  !insts var inst.
+    producing_inst insts var = SOME inst ==>
+    MEM var inst.inst_outputs
+Proof
+  Induct >> rw[producing_inst_def] >>
+  BasicProvers.every_case_tac >> gvs[] >> metis_tac[]
+QED
+
+(* For an instruction at the head that does NOT define var,
+   producing_inst skips it *)
+Triviality producing_inst_skip:
+  !h rest var.
+    ~MEM var h.inst_outputs ==>
+    producing_inst (h :: rest) var = producing_inst rest var
+Proof
+  rw[producing_inst_def]
+QED
+
+(* For an instruction at the head that DOES define var,
+   producing_inst returns it *)
+Triviality producing_inst_hit:
+  !h rest var.
+    MEM var h.inst_outputs ==>
+    producing_inst (h :: rest) var = SOME h
+Proof
+  rw[producing_inst_def]
+QED
+
+(* Key: if there is a unique definer in the list, producing_inst finds it
+   regardless of position *)
+Theorem producing_inst_unique_definer:
+  !insts var inst.
+    MEM inst insts /\ MEM var inst.inst_outputs /\
+    (!j. MEM j insts /\ j <> inst ==> ~MEM var j.inst_outputs) ==>
+    producing_inst insts var = SOME inst
+Proof
+  Induct >> rw[producing_inst_def] >>
+  Cases_on `MEM var h.inst_outputs`
+  >- (gvs[] >> metis_tac[])
+  >> gvs[] >> metis_tac[]
+QED
+
+(* ===== flip_operands preserves key properties ===== *)
+
+(* flip_operands preserves inst_opcode for non-comparators *)
+Triviality flip_operands_opcode_non_comp:
+  !i. ~is_comparator i.inst_opcode ==>
+      (flip_operands i).inst_opcode = i.inst_opcode
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM]
+QED
+
+(* flip_operands preserves write_effects and read_effects *)
+Triviality flip_operands_write_effects:
+  !i. write_effects (flip_operands i).inst_opcode = write_effects i.inst_opcode
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  Cases_on `is_comparator i.inst_opcode` >> simp[] >>
+  Cases_on `i.inst_opcode` >>
+  gvs[is_comparator_def, flip_comparison_opcode_def, write_effects_def]
+QED
+
+Triviality flip_operands_read_effects:
+  !i. read_effects (flip_operands i).inst_opcode = read_effects i.inst_opcode
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  Cases_on `is_comparator i.inst_opcode` >> simp[] >>
+  Cases_on `i.inst_opcode` >>
+  gvs[is_comparator_def, flip_comparison_opcode_def, read_effects_def]
+QED
+
+Triviality flip_operands_is_terminator:
+  !i. is_terminator (flip_operands i).inst_opcode = is_terminator i.inst_opcode
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  Cases_on `is_comparator i.inst_opcode` >> simp[] >>
+  Cases_on `i.inst_opcode` >>
+  gvs[is_comparator_def, flip_comparison_opcode_def, is_terminator_def]
+QED
+
+(* flip_operands_involution is now in dftStructuralTheory *)
+
+(* ===== dft_block structural decomposition ===== *)
+
+(* The non-pseudos of dft_block output are exactly the scheduled part *)
+Triviality dft_block_instructions:
+  !order bb.
+    (dft_block order bb).bb_instructions =
+    FILTER (\i. is_pseudo i.inst_opcode) bb.bb_instructions ++
+    schedule_from_entries bb.bb_instructions order
+      (build_full_eda bb.bb_instructions)
+      (build_offspring_map bb.bb_instructions order)
+      (entry_instructions bb.bb_instructions order
+        (build_full_eda bb.bb_instructions))
+Proof
+  rw[dft_block_def, LET_THM]
+QED
+
+(* Non-pseudos of dft_block output = the scheduled part *)
+Triviality dft_block_non_pseudos:
+  !order bb.
+    FILTER (\i. ~is_pseudo i.inst_opcode)
+      (dft_block order bb).bb_instructions =
+    schedule_from_entries bb.bb_instructions order
+      (build_full_eda bb.bb_instructions)
+      (build_offspring_map bb.bb_instructions order)
+      (entry_instructions bb.bb_instructions order
+        (build_full_eda bb.bb_instructions))
+Proof
+  rw[dft_block_instructions, rich_listTheory.FILTER_APPEND] >>
+  simp[rich_listTheory.FILTER_FILTER] >>
+  `FILTER (\i. ~is_pseudo i.inst_opcode)
+    (FILTER (\i. is_pseudo i.inst_opcode) bb.bb_instructions) = []` by
+    (simp[FILTER_EQ_NIL, EVERY_MEM, MEM_FILTER]) >>
+  simp[] >>
+  `FILTER (\i. ~is_pseudo i.inst_opcode)
+    (schedule_from_entries bb.bb_instructions order
+      (build_full_eda bb.bb_instructions)
+      (build_offspring_map bb.bb_instructions order)
+      (entry_instructions bb.bb_instructions order
+        (build_full_eda bb.bb_instructions))) =
+   schedule_from_entries bb.bb_instructions order
+      (build_full_eda bb.bb_instructions)
+      (build_offspring_map bb.bb_instructions order)
+      (entry_instructions bb.bb_instructions order
+        (build_full_eda bb.bb_instructions))` suffices_by simp[] >>
+  simp[FILTER_EQ_ID, EVERY_MEM] >>
+  rpt strip_tac >>
+  metis_tac[schedule_output_from_block, build_full_eda_wf, entry_instructions_mem]
+QED
+
+(* ===== Effect-equivalent instructions ===== *)
+
+(* Two instructions are "effect-equivalent" if they have the same inst_id,
+   and the same write/read effects. This is the relevant equivalence for
+   build_eda — it processes instructions only through these fields. *)
+Definition eff_equiv_def:
+  eff_equiv i1 i2 <=>
+    i1.inst_id = i2.inst_id /\
+    write_effects i1.inst_opcode = write_effects i2.inst_opcode /\
+    read_effects i1.inst_opcode = read_effects i2.inst_opcode
+End
+
+(* flip_operands produces effect-equivalent instructions *)
+Theorem flip_operands_eff_equiv:
+  !i. eff_equiv i (flip_operands i) /\ eff_equiv (flip_operands i) i
+Proof
+  rw[eff_equiv_def, flip_operands_write_effects, flip_operands_read_effects] >>
+  metis_tac[flip_operands_inst_id]
+QED
+
+(* from_block instructions are effect-equivalent to originals *)
+Theorem from_block_eff_equiv:
+  !block_insts i.
+    from_block block_insts i ==>
+    ?j. MEM j block_insts /\ ~is_pseudo j.inst_opcode /\ eff_equiv i j
+Proof
+  rw[from_block_def, eff_equiv_def] >> rpt strip_tac >> gvs[]
+  >- metis_tac[]
+  >> qexists_tac `j` >> simp[flip_operands_write_effects, flip_operands_read_effects] >>
+  metis_tac[flip_operands_inst_id]
+QED
+
+(* ===== Effect tracking equivalence via injection ===== *)
+
+(* et_equiv_via f: tracking state et2 is the image of et1 under injection f.
+   This captures structural consistency: same instruction stored in et1 maps
+   to same instruction in et2 via f, so nub behaves identically. *)
+Definition et_equiv_via_def:
+  et_equiv_via f et1 et2 <=>
+    (!eff. case (FLOOKUP et1.et_last_write eff, FLOOKUP et2.et_last_write eff) of
+      (NONE, NONE) => T
+    | (SOME w1, SOME w2) => w2 = f w1
+    | (NONE, SOME _) => F  (* et2 has writer but et1 doesn't *)
+    | (SOME _, NONE) => F  (* et1 has writer but et2 doesn't *)
+    ) /\
+    (!eff. case (FLOOKUP et1.et_all_reads eff, FLOOKUP et2.et_all_reads eff) of
+      (NONE, NONE) => T
+    | (SOME rs1, SOME rs2) => rs2 = MAP f rs1
+    | (NONE, SOME _) => F  (* et2 has readers but et1 doesn't *)
+    | (SOME _, NONE) => F  (* et1 has readers but et2 doesn't *)
+    )
+End
+
+(* Identity gives reflexivity *)
+Triviality et_equiv_via_id:
+  !et. et_equiv_via I et et
+Proof
+  rw[et_equiv_via_def] >> rpt strip_tac >>
+  Cases_on `FLOOKUP et.et_last_write eff` >> simp[] >>
+  Cases_on `FLOOKUP et.et_all_reads eff` >> simp[MAP_ID]
+QED
+
+(* Empty tracking states are equivalent via any f *)
+Triviality et_equiv_via_empty:
+  !f. et_equiv_via f empty_effect_track empty_effect_track
+Proof
+  rw[et_equiv_via_def, empty_effect_track_def, FLOOKUP_DEF, FDOM_FEMPTY]
+QED
+
+(* Helper: et_get_reads under et_equiv_via *)
+Triviality et_get_reads_via:
+  !f et1 et2 eff.
+    et_equiv_via f et1 et2 ==>
+    et_get_reads et2 eff = MAP f (et_get_reads et1 eff)
+Proof
+  rw[et_equiv_via_def, et_get_reads_def] >>
+  first_x_assum (qspec_then `eff` mp_tac) >>
+  Cases_on `FLOOKUP et1.et_all_reads eff` >>
+  Cases_on `FLOOKUP et2.et_all_reads eff` >> simp[]
+QED
+
+(* Helper: FLOOKUP et_last_write under et_equiv_via *)
+Triviality et_last_write_via:
+  !f et1 et2 eff.
+    et_equiv_via f et1 et2 ==>
+    case FLOOKUP et1.et_last_write eff of
+      NONE => FLOOKUP et2.et_last_write eff = NONE
+    | SOME w => FLOOKUP et2.et_last_write eff = SOME (f w)
+Proof
+  rw[et_equiv_via_def] >>
+  pop_assum kall_tac >>
+  first_x_assum (qspec_then `eff` mp_tac) >>
+  Cases_on `FLOOKUP et1.et_last_write eff` >>
+  Cases_on `FLOOKUP et2.et_last_write eff` >> simp[]
+QED
+
+(* Helper: write FOLDL preserves et_equiv_via *)
+Triviality write_step_via:
+  !f et1 et2 i1 weff.
+    et_equiv_via f et1 et2 ==>
+    et_equiv_via f
+      (et1 with <| et_last_write := et1.et_last_write |+ (weff, i1);
+                    et_all_reads := et1.et_all_reads |+ (weff, []) |>)
+      (et2 with <| et_last_write := et2.et_last_write |+ (weff, f i1);
+                    et_all_reads := et2.et_all_reads |+ (weff, []) |>)
+Proof
+  rw[et_equiv_via_def] >> rpt strip_tac >>
+  first_x_assum (qspec_then `eff` mp_tac) >>
+  Cases_on `eff = weff` >> simp[FLOOKUP_UPDATE]
+QED
+
+Triviality write_foldl_via:
+  !f effs et1 et2 i1.
+    et_equiv_via f et1 et2 ==>
+    et_equiv_via f
+      (FOLDL (\acc weff.
+        acc with <| et_last_write := acc.et_last_write |+ (weff, i1);
+                    et_all_reads := acc.et_all_reads |+ (weff, []) |>) et1 effs)
+      (FOLDL (\acc weff.
+        acc with <| et_last_write := acc.et_last_write |+ (weff, f i1);
+                    et_all_reads := acc.et_all_reads |+ (weff, []) |>) et2 effs)
+Proof
+  Induct_on `effs`
+  >- simp[]
+  >> rpt strip_tac >>
+  ONCE_REWRITE_TAC[FOLDL] >>
+  CONV_TAC (DEPTH_CONV BETA_CONV) >>
+  first_x_assum irule >> irule write_step_via >> simp[]
+QED
+
+(* Helper: single read step preserves et_equiv_via *)
+Triviality read_step_via:
+  !f et1 et2 i1 reff.
+    et_equiv_via f et1 et2 ==>
+    et_equiv_via f
+      (et1 with et_all_reads :=
+        et1.et_all_reads |+ (reff, et_get_reads et1 reff ++ [i1]))
+      (et2 with et_all_reads :=
+        et2.et_all_reads |+ (reff, et_get_reads et2 reff ++ [f i1]))
+Proof
+  rpt strip_tac >>
+  `et_get_reads et2 reff = MAP f (et_get_reads et1 reff)` by
+    metis_tac[et_get_reads_via] >>
+  fs[et_equiv_via_def] >> rpt strip_tac >>
+  first_x_assum (qspec_then `eff` mp_tac) >>
+  Cases_on `eff = reff` >> simp[FLOOKUP_UPDATE, MAP_APPEND]
+QED
+
+(* Helper: read FOLDL preserves et_equiv_via *)
+Triviality read_foldl_via:
+  !f effs et1 et2 i1.
+    et_equiv_via f et1 et2 ==>
+    et_equiv_via f
+      (FOLDL (\acc reff.
+        acc with et_all_reads :=
+          acc.et_all_reads |+ (reff, et_get_reads acc reff ++ [i1])) et1 effs)
+      (FOLDL (\acc reff.
+        acc with et_all_reads :=
+          acc.et_all_reads |+ (reff, et_get_reads acc reff ++ [f i1])) et2 effs)
+Proof
+  Induct_on `effs`
+  >- simp[]
+  >> rpt strip_tac >>
+  ONCE_REWRITE_TAC[FOLDL] >>
+  CONV_TAC (DEPTH_CONV BETA_CONV) >>
+  first_x_assum irule >> irule read_step_via >> simp[]
+QED
+
+(* Helper: MAP THE o FILTER IS_SOME o MAP distributes through OPTION_MAP *)
+Triviality filter_some_map_option:
+  !f g1 g2 ls.
+    (!x. MEM x ls ==> g2 x = OPTION_MAP f (g1 x)) ==>
+    MAP THE (FILTER IS_SOME (MAP g2 ls)) =
+    MAP f (MAP THE (FILTER IS_SOME (MAP g1 ls)))
+Proof
+  ntac 3 gen_tac >> Induct >> simp[] >> rpt strip_tac >>
+  `g2 h = OPTION_MAP f (g1 h)` by simp[] >>
+  Cases_on `g1 h` >> gvs[]
+QED
+
+(* Helper: FLAT distributes through pointwise MAP f *)
+Triviality flat_map_map_f:
+  !f g1 g2 ls.
+    (!x. MEM x ls ==> g2 x = MAP f (g1 x)) ==>
+    FLAT (MAP g2 ls) = MAP f (FLAT (MAP g1 ls))
+Proof
+  ntac 3 gen_tac >> Induct >> simp[MAP_APPEND]
+QED
+
+(* Helper: the raw dep list (before nub) maps through f *)
+Triviality raw_deps_map_f:
+  !f et1 et2 i1.
+    (!eff. et_get_reads et2 eff = MAP f (et_get_reads et1 eff)) /\
+    (!eff. case FLOOKUP et1.et_last_write eff of
+        NONE => FLOOKUP et2.et_last_write eff = NONE
+      | SOME w => FLOOKUP et2.et_last_write eff = SOME (f w)) /\
+    (!i. (f i).inst_id = i.inst_id) ==>
+    FLAT (MAP (\weff. et_get_reads et2 weff ++
+        (if weff = Eff_MSIZE then []
+         else case FLOOKUP et2.et_last_write weff of
+                NONE => [] | SOME w => [w]))
+        (effects_to_list (write_effects i1.inst_opcode))) ++
+    MAP THE (FILTER IS_SOME (MAP (\reff.
+        case FLOOKUP et2.et_last_write reff of
+          NONE => NONE
+        | SOME writer =>
+            if writer.inst_id <> i1.inst_id then SOME writer else NONE)
+        (effects_to_list (read_effects i1.inst_opcode))))
+    =
+    MAP f (
+      FLAT (MAP (\weff. et_get_reads et1 weff ++
+          (if weff = Eff_MSIZE then []
+           else case FLOOKUP et1.et_last_write weff of
+                  NONE => [] | SOME w => [w]))
+          (effects_to_list (write_effects i1.inst_opcode))) ++
+      MAP THE (FILTER IS_SOME (MAP (\reff.
+          case FLOOKUP et1.et_last_write reff of
+            NONE => NONE
+          | SOME writer =>
+              if writer.inst_id <> i1.inst_id then SOME writer else NONE)
+          (effects_to_list (read_effects i1.inst_opcode)))))
+Proof
+  rpt strip_tac >>
+  REWRITE_TAC[MAP_APPEND] >>
+  (* Write part: use flat_map_map_f *)
+  sg `FLAT (MAP (\weff. et_get_reads et2 weff ++
+      (if weff = Eff_MSIZE then []
+       else case FLOOKUP et2.et_last_write weff of
+              NONE => [] | SOME w => [w]))
+      (effects_to_list (write_effects i1.inst_opcode))) =
+    MAP f (FLAT (MAP (\weff. et_get_reads et1 weff ++
+      (if weff = Eff_MSIZE then []
+       else case FLOOKUP et1.et_last_write weff of
+              NONE => [] | SOME w => [w]))
+      (effects_to_list (write_effects i1.inst_opcode))))`
+  >- (
+    irule flat_map_map_f >> rpt strip_tac >> rename1 `MEM weff _` >>
+    simp[MAP_APPEND] >>
+    first_x_assum (qspec_then `weff` mp_tac) >>
+    Cases_on `FLOOKUP et1.et_last_write weff` >> simp[] >>
+    strip_tac >> gvs[] >>
+    Cases_on `weff = Eff_MSIZE` >> simp[]
+  ) >>
+  (* Read part: use filter_some_map_option *)
+  sg `MAP THE (FILTER IS_SOME (MAP (\reff.
+      case FLOOKUP et2.et_last_write reff of
+        NONE => NONE
+      | SOME writer =>
+          if writer.inst_id <> i1.inst_id then SOME writer else NONE)
+      (effects_to_list (read_effects i1.inst_opcode)))) =
+    MAP f (MAP THE (FILTER IS_SOME (MAP (\reff.
+      case FLOOKUP et1.et_last_write reff of
+        NONE => NONE
+      | SOME writer =>
+          if writer.inst_id <> i1.inst_id then SOME writer else NONE)
+      (effects_to_list (read_effects i1.inst_opcode)))))`
+  >- (
+    irule filter_some_map_option >> rpt strip_tac >> rename1 `MEM reff _` >>
+    first_x_assum (qspec_then `reff` mp_tac) >>
+    Cases_on `FLOOKUP et1.et_last_write reff` >> simp[] >>
+    strip_tac >> gvs[] >>
+    Cases_on `x.inst_id <> i1.inst_id` >> simp[]
+  ) >>
+  simp[]
+QED
+
+(* Main lemma: compute_effect_deps maps deps through f.
+   When f is globally injective and preserves inst_id/effects,
+   deps2 = MAP f deps1 and et_equiv_via is preserved. *)
+Theorem compute_effect_deps_via:
+  !f et1 et2 i1 deps1 et1' deps2 et2'.
+    et_equiv_via f et1 et2 /\
+    INJ f UNIV UNIV /\
+    (!i. (f i).inst_id = i.inst_id) /\
+    (!i. write_effects (f i).inst_opcode = write_effects i.inst_opcode) /\
+    (!i. read_effects (f i).inst_opcode = read_effects i.inst_opcode) /\
+    compute_effect_deps et1 i1 = (deps1, et1') /\
+    compute_effect_deps et2 (f i1) = (deps2, et2') ==>
+    et_equiv_via f et1' et2' /\
+    deps2 = MAP f deps1
+Proof
+  rpt strip_tac >>
+  fs[compute_effect_deps_def, LET_THM] >>
+  ntac 4 (pop_assum (SUBST_ALL_TAC o SYM)) >> fs[]
+  >- (
+    irule read_foldl_via >>
+    irule (SIMP_RULE (srw_ss()) [] write_foldl_via) >> simp[]
+  )
+  >>
+  (* Establish key hypotheses *)
+  `!eff. et_get_reads et2 eff = MAP f (et_get_reads et1 eff)` by
+    metis_tac[et_get_reads_via]
+  >>
+  `!eff. case FLOOKUP et1.et_last_write eff of
+      NONE => FLOOKUP et2.et_last_write eff = NONE
+    | SOME w => FLOOKUP et2.et_last_write eff = SOME (f w)` by
+    metis_tac[et_last_write_via]
+  >>
+  (* Use raw_deps_map_f to rewrite inner_et2 = MAP f inner_et1 *)
+  imp_res_tac raw_deps_map_f >>
+  pop_assum (qspec_then `i1` (fn th => REWRITE_TAC[th])) >>
+  (* Now: nub(MAP f inner) = MAP f (nub inner) via nub_MAP_INJ *)
+  irule nub_MAP_INJ >>
+  first_assum (irule o MATCH_MP (DB.fetch "pred_set" "INJ_SUBSET_UNIV"))
+QED
+
+(* ===== Main Idempotency Result ===== *)
+
+(* Key structural lemma: dft_block expands into phis ++ schedule,
+   and the schedule only depends on bb.bb_instructions.
+   Two blocks with the same bb_instructions and bb_label produce
+   the same dft_block output. *)
+Triviality dft_block_only_depends_on_insts:
+  !order bb1 bb2.
+    bb1.bb_instructions = bb2.bb_instructions /\
+    bb1.bb_label = bb2.bb_label ==>
+    dft_block order bb1 = dft_block order bb2
+Proof
+  rw[dft_block_def, LET_THM] >>
+  simp[basic_block_component_equality]
+QED
+
+(* Counterexample: dft_block_idempotent is FALSE without unique_defs.
+   Two instructions with duplicate outputs get reordered by dft_block,
+   and reordering changes producing_inst, breaking the fixed-point property. *)
+Theorem dft_block_idempotent_needs_unique_defs:
+  ?order bb.
+    dft_block order (dft_block order bb) <> dft_block order bb
+Proof
+  qexistsl_tac [`[]`,
+    `<| bb_label := "t";
+        bb_instructions :=
+          [<| inst_id := 1; inst_opcode := ADD;
+              inst_operands := [Lit 0w; Lit 0w]; inst_outputs := ["x"] |>;
+           <| inst_id := 2; inst_opcode := ADD;
+              inst_operands := [Lit 0w; Lit 0w]; inst_outputs := ["x"] |>;
+           <| inst_id := 3; inst_opcode := STOP;
+              inst_operands := [Var "x"]; inst_outputs := [] |>] |>`] >>
+  EVAL_TAC
+QED
+
+(* dft_block_idempotent: proved FALSE by counterexample above.
+   build_eda is order-dependent due to "last writer clears readers" mechanism. *)
+
+

--- a/venom/passes/dft/proofs/dftPermSimScript.sml
+++ b/venom/passes/dft/proofs/dftPermSimScript.sml
@@ -1,0 +1,1227 @@
+(*
+ * DFT Permutation Simulation
+ *
+ * Key lemma: if all instructions are pairwise bilaterally independent
+ * and all succeed (OK), then any permutation produces the same final state.
+ *
+ * Uses independent_commute_eq (from dftBlockSimTheory) for adjacent swaps,
+ * then extends to arbitrary permutations via PERM induction.
+ *)
+
+Theory dftPermSim
+Ancestors
+  dftBlockSim dftCommutation dftDefs
+  analysisSimDefs analysisSimProofsBase
+  passSharedDefs passSharedProps passSharedTransfer passSharedField
+  passSimulationDefs stateEquiv
+  venomExecSemantics venomExecProps venomEffects
+  venomState venomInst venomInstProps
+  sorting pred_set list rich_list
+
+(* ===== Symmetry helpers ===== *)
+
+Triviality effects_independent_sym:
+  !op1 op2. effects_independent op1 op2 ==> effects_independent op2 op1
+Proof
+  rw[effects_independent_def] >> metis_tac[DISJOINT_SYM]
+QED
+
+
+(* ===== run_insts append decomposition ===== *)
+
+Theorem run_insts_append:
+  !fuel ctx l1 l2 s.
+    run_insts fuel ctx (l1 ++ l2) s =
+    case run_insts fuel ctx l1 s of
+      OK s' => run_insts fuel ctx l2 s'
+    | other => other
+Proof
+  Induct_on `l1` >> rpt strip_tac >>
+  simp[run_insts_def] >>
+  Cases_on `step_inst fuel ctx h s` >> simp[run_insts_def]
+QED
+
+(* ===== Bilateral independence ===== *)
+
+Definition bi_independent_def:
+  bi_independent i1 i2 <=>
+    DISJOINT (set (inst_defs i1)) (set (inst_uses i2)) /\
+    DISJOINT (set (inst_defs i2)) (set (inst_uses i1)) /\
+    DISJOINT (set (inst_defs i1)) (set (inst_defs i2)) /\
+    effects_independent i1.inst_opcode i2.inst_opcode /\
+    abort_compatible i1.inst_opcode i2.inst_opcode /\
+    ~is_terminator i1.inst_opcode /\ ~is_terminator i2.inst_opcode /\
+    ~is_alloca_op i1.inst_opcode /\ ~is_alloca_op i2.inst_opcode /\
+    ~is_ext_call_op i1.inst_opcode /\ ~is_ext_call_op i2.inst_opcode /\
+    i1.inst_opcode <> INVOKE /\ i2.inst_opcode <> INVOKE
+End
+
+Triviality bi_independent_sym:
+  !i1 i2. bi_independent i1 i2 <=> bi_independent i2 i1
+Proof
+  rw[bi_independent_def, effects_independent_def, abort_compatible_def] >>
+  metis_tac[DISJOINT_SYM]
+QED
+
+(* bi_independent implies the preconditions of effects_independent_commute *)
+Triviality bi_independent_commute_pre:
+  !i1 i2.
+    bi_independent i1 i2 ==>
+    DISJOINT (set (inst_defs i1)) (set (inst_uses i2)) /\
+    DISJOINT (set (inst_defs i2)) (set (inst_uses i1)) /\
+    DISJOINT (set (inst_defs i1)) (set (inst_defs i2)) /\
+    effects_independent i1.inst_opcode i2.inst_opcode /\
+    ~is_terminator i1.inst_opcode /\ ~is_terminator i2.inst_opcode /\
+    ~is_alloca_op i1.inst_opcode /\ ~is_alloca_op i2.inst_opcode
+Proof
+  simp[bi_independent_def]
+QED
+
+(* ===== Extended bilateral independence (allows INVOKE) ===== *)
+
+(* Like bi_independent but without abort_compatible and ~INVOKE.
+   INVOKE can be reordered past pure ops because effects_independent INVOKE ADD = T.
+   The swap proof for ext uses step_inst_ok_frame (all opcodes) instead of
+   step_inst_base. *)
+Definition ext_bi_independent_def:
+  ext_bi_independent i1 i2 <=>
+    DISJOINT (set (inst_defs i1)) (set (inst_uses i2)) /\
+    DISJOINT (set (inst_defs i2)) (set (inst_uses i1)) /\
+    DISJOINT (set (inst_defs i1)) (set (inst_defs i2)) /\
+    effects_independent i1.inst_opcode i2.inst_opcode /\
+    ~is_terminator i1.inst_opcode /\ ~is_terminator i2.inst_opcode /\
+    ~is_alloca_op i1.inst_opcode /\ ~is_alloca_op i2.inst_opcode /\
+    ~is_ext_call_op i1.inst_opcode /\ ~is_ext_call_op i2.inst_opcode
+End
+
+Theorem ext_bi_independent_sym:
+  !i1 i2. ext_bi_independent i1 i2 <=> ext_bi_independent i2 i1
+Proof
+  rw[ext_bi_independent_def, effects_independent_def] >>
+  metis_tac[DISJOINT_SYM]
+QED
+
+Theorem bi_independent_imp_ext:
+  !i1 i2. bi_independent i1 i2 ==> ext_bi_independent i1 i2
+Proof
+  simp[bi_independent_def, ext_bi_independent_def]
+QED
+
+(* ===== Helpers for adjacent swap ===== *)
+
+(* Var membership implies operand_vars membership *)
+Triviality var_mem_operand_vars:
+  !y ops. MEM (Var y) ops ==> MEM y (operand_vars ops)
+Proof
+  Induct_on `ops` >> simp[operand_vars_def] >>
+  rpt strip_tac >> gvs[operand_var_def] >>
+  Cases_on `operand_var h` >> simp[]
+QED
+
+(* ===== Adjacent swap: OK case ===== *)
+
+(* The 5 conditions for step_inst_base_ok_transfer follow from
+   step_inst a s = OK sa + disjointness + effects_independence.
+   Extract as a reusable tactic for both directions. *)
+(* Shared tactic for the 5 conditions of step_inst_base_ok_transfer.
+   Expects: step_inst fuel ctx a s = OK sa, DISJOINT outputs/operands,
+   effects_independent in assumptions. Variable names must match. *)
+val ok_transfer_field_tac =
+  let val pres_tac =
+    qspecl_then [`fuel`, `ctx`, `a`, `s`, `sa`] mp_tac
+      step_inst_preserves_all >> simp[]
+  in
+  rpt conj_tac
+  >- (rpt strip_tac >>
+      Cases_on `op` >> simp[eval_operand_def] >>
+      FIRST [
+        (rename1 `Var n` >>
+         qspecl_then [`fuel`, `ctx`, `a`, `s`, `sa`] mp_tac
+           step_preserves_non_output_vars >> simp[] >>
+         disch_then (qspec_then `n` mp_tac) >>
+         impl_tac >- (gvs[DISJOINT_DEF, EXTENSION] >>
+           metis_tac[var_mem_operand_vars, MEM]) >>
+         simp[]),
+        metis_tac[step_preserves_labels]
+      ])
+  >- pres_tac >- pres_tac
+  >> (pres_tac >> strip_tac >>
+      spose_not_then strip_assume_tac >>
+      gvs[effects_independent_def] >>
+      `Eff_RETURNDATA IN read_effects RETURNDATACOPY` by EVAL_TAC >>
+      metis_tac[IN_DISJOINT])
+  end;
+
+(* Backward: b succeeds on sa ==> b succeeds on s *)
+Triviality step_ok_transfer_backward:
+  !fuel ctx a b s sa sab.
+    step_inst fuel ctx a s = OK sa /\
+    step_inst_base b sa = OK sab /\
+    ~is_terminator a.inst_opcode /\ ~is_terminator b.inst_opcode /\
+    ~is_alloca_op a.inst_opcode /\ ~is_ext_call_op a.inst_opcode /\
+    ~is_alloca_op b.inst_opcode /\ ~is_ext_call_op b.inst_opcode /\
+    a.inst_opcode <> INVOKE /\
+    DISJOINT (set a.inst_outputs) (set (operand_vars b.inst_operands)) /\
+    effects_independent a.inst_opcode b.inst_opcode ==>
+    ?sb. step_inst_base b s = OK sb
+Proof
+  rpt strip_tac >>
+  irule step_inst_base_ok_transfer >>
+  simp[] >> qexistsl_tac [`sa`, `sab`] >> simp[] >>
+  ok_transfer_field_tac
+QED
+
+(* Forward: b succeeds on s ==> b succeeds on sa *)
+Triviality step_ok_transfer_forward:
+  !fuel ctx a b s sa sb.
+    step_inst fuel ctx a s = OK sa /\
+    step_inst_base b s = OK sb /\
+    ~is_terminator a.inst_opcode /\ ~is_terminator b.inst_opcode /\
+    ~is_alloca_op a.inst_opcode /\ ~is_ext_call_op a.inst_opcode /\
+    ~is_alloca_op b.inst_opcode /\ ~is_ext_call_op b.inst_opcode /\
+    a.inst_opcode <> INVOKE /\
+    DISJOINT (set a.inst_outputs) (set (operand_vars b.inst_operands)) /\
+    effects_independent a.inst_opcode b.inst_opcode ==>
+    ?sab. step_inst_base b sa = OK sab
+Proof
+  rpt strip_tac >>
+  irule step_inst_base_ok_transfer >>
+  simp[] >> qexistsl_tac [`s`, `sb`] >> simp[] >>
+  ok_transfer_field_tac
+QED
+
+Triviality step_swap_ok:
+  !fuel ctx a b s sa sab.
+    bi_independent a b /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  gvs[bi_independent_def, inst_defs_def, inst_uses_def] >>
+  (* step_inst_base versions *)
+  (sg `step_inst_base a s = OK sa` >- gvs[step_inst_non_invoke]) >>
+  (sg `step_inst_base b sa = OK sab` >- gvs[step_inst_non_invoke]) >>
+  (* b succeeds on s (backward transfer: sa -> s) *)
+  (sg `?sb. step_inst_base b s = OK sb`
+   >- (irule step_ok_transfer_backward >>
+       simp[] >> qexistsl_tac [`a`, `ctx`, `fuel`, `sa`, `sab`] >>
+       gvs[])) >>
+  (* a succeeds on sb (forward transfer: s -> sb, with b as modifier) *)
+  (sg `?sa'. step_inst_base a sb = OK sa'`
+   >- (qspecl_then [`fuel`, `ctx`, `b`, `a`, `s`, `sb`, `sa`] mp_tac
+         step_ok_transfer_forward >>
+       simp[step_inst_non_invoke] >>
+       impl_tac >- metis_tac[effects_independent_sym] >>
+       simp[])) >>
+  qexists_tac `sb` >>
+  (conj_tac >- gvs[step_inst_non_invoke]) >>
+  (* convert to step_inst *)
+  (sg `step_inst fuel ctx b s = OK sb`
+   >- gvs[step_inst_non_invoke]) >>
+  (sg `step_inst fuel ctx a sb = OK sa'`
+   >- gvs[step_inst_non_invoke]) >>
+  (* sa' = sab by independent_commute_eq *)
+  `sab = sa'` suffices_by simp[] >>
+  irule independent_commute_eq >>
+  qexistsl_tac [`ctx`, `fuel`, `a`, `b`, `s`, `sa`, `sb`] >>
+  gvs[inst_defs_def, inst_uses_def]
+QED
+
+(* Adjacent swap in run_insts context *)
+Triviality run_insts_swap_adjacent_ok:
+  !fuel ctx prefix a b suffix s s_result.
+    bi_independent a b /\
+    run_insts fuel ctx (prefix ++ [a; b] ++ suffix) s = OK s_result ==>
+    run_insts fuel ctx (prefix ++ [b; a] ++ suffix) s = OK s_result
+Proof
+  rpt strip_tac >>
+  gvs[run_insts_append] >>
+  Cases_on `run_insts fuel ctx prefix s` >>
+  gvs[run_insts_def, AllCaseEqs()] >>
+  Cases_on `step_inst fuel ctx a v` >>
+  gvs[run_insts_def, AllCaseEqs()] >>
+  Cases_on `step_inst fuel ctx b v'` >>
+  gvs[run_insts_def, AllCaseEqs()] >>
+  drule_all step_swap_ok >> strip_tac >>
+  simp[]
+QED
+
+(* Bubble independent element to front of a prefix *)
+Theorem run_insts_bubble_to_front:
+  !prefix fuel ctx x suffix s r.
+    EVERY (bi_independent x) prefix /\
+    run_insts fuel ctx (prefix ++ [x] ++ suffix) s = OK r ==>
+    run_insts fuel ctx ([x] ++ prefix ++ suffix) s = OK r
+Proof
+  Induct_on `prefix` >> simp[] >>
+  rpt strip_tac >> gvs[EVERY_DEF] >>
+  (* h :: prefix ++ [x] ++ suffix executed OK.
+     Decompose: step h then run (prefix ++ [x] ++ suffix). *)
+  gvs[run_insts_def, AllCaseEqs()] >>
+  (* IH: bubble x past prefix after stepping h *)
+  first_x_assum drule >> disch_then drule >> strip_tac >>
+  (* Now: run_insts (x :: prefix ++ suffix) after step h = OK r *)
+  gvs[run_insts_def, AllCaseEqs()] >>
+  (* Swap x and h: bi_independent x h, step h s = OK, step x (step h s) = OK
+     ==> step x s = OK sx, step h sx = same final state *)
+  `bi_independent h x` by metis_tac[bi_independent_sym] >>
+  drule_all step_swap_ok >> strip_tac >>
+  simp[run_insts_def]
+QED
+
+(* ===== Pure step characterization ===== *)
+
+(* effects_independent with INVOKE implies the other op has empty effects *)
+Triviality effects_independent_invoke_empty:
+  !op. effects_independent INVOKE op ==>
+       write_effects op = {} /\ read_effects op = {} /\ op <> INVOKE
+Proof
+  Cases >> simp[effects_independent_def, write_effects_def,
+                read_effects_def, all_effects_def] >> EVAL_TAC
+QED
+
+(* Given effects_independent between INVOKE and op, derive all useful facts:
+   op is not INVOKE, has empty effects, and is not an ext_call_op.
+   Eliminates ~30 lines of boilerplate per use site. *)
+Triviality invoke_implies_pure:
+  !op. effects_independent INVOKE op ==>
+    op <> INVOKE /\
+    write_effects op = {} /\
+    read_effects op = {} /\
+    ~is_ext_call_op op
+Proof
+  Cases >>
+  simp[effects_independent_def, write_effects_def, read_effects_def,
+       is_ext_call_op_def, all_effects_def] >> EVAL_TAC
+QED
+
+(* A non-INVOKE, non-terminator, non-alloca, non-ext_call instruction with
+   empty write+read_effects, inst_wf, and one output: OK result is update_var.
+   Thin wrapper around pure_step_structure (from dftBlockSim). *)
+Triviality pure_step_is_update_var:
+  !fuel ctx b s sb.
+    step_inst fuel ctx b s = OK sb /\
+    b.inst_opcode <> INVOKE /\
+    ~is_terminator b.inst_opcode /\
+    ~is_alloca_op b.inst_opcode /\
+    ~is_ext_call_op b.inst_opcode /\
+    write_effects b.inst_opcode = {} /\
+    read_effects b.inst_opcode = {} /\
+    inst_wf b /\
+    LENGTH b.inst_outputs = 1 ==>
+    ?v. sb = update_var (HD b.inst_outputs) v s
+Proof
+  rpt strip_tac >>
+  `step_inst_base b s = OK sb` by gvs[step_inst_non_invoke] >>
+  drule pure_step_structure >> simp[] >>
+  strip_tac >> gvs[] >> metis_tac[]
+QED
+
+(* Transfer a non-INVOKE, empty-effects instruction across any non-terminator
+   OK step. If step_inst_base a s = OK sa and step_inst b s = OK sb
+   with a's operands disjoint from b's outputs, then step_inst_base a sb = OK.
+   Handles PHI/PARAM/RETURNDATACOPY by using step_preserves_* on b. *)
+Triviality pure_inst_transfer_across:
+  !fuel ctx a b s sa sb.
+    step_inst_base a s = OK sa /\
+    step_inst fuel ctx b s = OK sb /\
+    a.inst_opcode <> INVOKE /\
+    ~is_terminator a.inst_opcode /\ ~is_terminator b.inst_opcode /\
+    ~is_alloca_op a.inst_opcode /\
+    write_effects a.inst_opcode = {} /\
+    read_effects a.inst_opcode = {} /\
+    DISJOINT (set b.inst_outputs) (set (operand_vars a.inst_operands)) ==>
+    ?sba. step_inst_base a sb = OK sba
+Proof
+  rpt strip_tac >>
+  qspecl_then [`a`, `s`, `sa`, `sb`] mp_tac step_inst_base_ok_transfer >>
+  (* Discharge side conditions *)
+  `~is_ext_call_op a.inst_opcode` by (
+    spose_not_then strip_assume_tac >>
+    Cases_on `a.inst_opcode` >>
+    gvs[is_ext_call_op_def, write_effects_def, all_effects_def]) >>
+  `!op. MEM op a.inst_operands ==>
+        eval_operand op s = eval_operand op sb` by (
+    rpt strip_tac >> Cases_on `op` >> simp[eval_operand_def]
+    >- (rename1 `Var n` >>
+        qspecl_then [`fuel`, `ctx`, `b`, `s`, `sb`] mp_tac
+          step_preserves_non_output_vars >> simp[] >>
+        disch_then (qspec_then `n` mp_tac) >>
+        impl_tac
+        >- (gvs[DISJOINT_DEF, EXTENSION] >>
+            metis_tac[var_mem_operand_vars, MEM])
+        >> simp[])
+    >> (qspecl_then [`fuel`, `ctx`, `b`, `s`, `sb`] mp_tac
+          step_preserves_labels >> simp[])) >>
+  `a.inst_opcode = PHI ==> s.vs_prev_bb = sb.vs_prev_bb` by (
+    strip_tac >>
+    qspecl_then [`fuel`, `ctx`, `b`, `s`, `sb`] mp_tac
+      step_preserves_control_flow >> simp[]) >>
+  `a.inst_opcode = PARAM ==> s.vs_params = sb.vs_params` by (
+    strip_tac >>
+    qspecl_then [`fuel`, `ctx`, `b`, `s`, `sb`] mp_tac
+      step_preserves_params >> simp[]) >>
+  `a.inst_opcode = RETURNDATACOPY ==> s.vs_returndata = sb.vs_returndata` by (
+    strip_tac >> gvs[read_effects_def]) >>
+  simp[]
+QED
+
+(* ===== Extended swap: allows INVOKE ===== *)
+
+(* Backward transfer for ext: b (non-INVOKE) succeeds on s given b succeeded
+   on sa, where a modified s to sa but a's outputs are disjoint from b's
+   operands. Works even when a is INVOKE. *)
+Triviality step_ok_transfer_backward_ext:
+  !fuel ctx a b s sa sab.
+    step_inst fuel ctx a s = OK sa /\
+    step_inst_base b sa = OK sab /\
+    ~is_terminator a.inst_opcode /\ ~is_terminator b.inst_opcode /\
+    ~is_alloca_op b.inst_opcode /\ ~is_ext_call_op b.inst_opcode /\
+    DISJOINT (set a.inst_outputs) (set (operand_vars b.inst_operands)) /\
+    effects_independent a.inst_opcode b.inst_opcode ==>
+    ?sb. step_inst_base b s = OK sb
+Proof
+  rpt strip_tac >>
+  qspecl_then [`b`, `sa`, `sab`, `s`] mp_tac step_inst_base_ok_transfer >>
+  simp[] >> disch_then irule >>
+  (* operand values preserved: sa -> s *)
+  conj_tac
+  >- (rpt strip_tac >>
+      Cases_on `op` >> simp[eval_operand_def]
+      >- (rename1 `Var n` >>
+          qspecl_then [`fuel`, `ctx`, `a`, `s`, `sa`] mp_tac
+            step_preserves_non_output_vars >> simp[] >>
+          disch_then (qspec_then `n` mp_tac) >>
+          impl_tac >- (gvs[DISJOINT_DEF, EXTENSION] >>
+            metis_tac[var_mem_operand_vars, MEM]) >>
+          simp[])
+      >> (qspecl_then [`fuel`, `ctx`, `a`, `s`, `sa`] mp_tac
+            step_preserves_labels >> simp[])) >>
+  (* PARAM: vs_params preserved by non-term step *)
+  conj_tac
+  >- (strip_tac >>
+      qspecl_then [`fuel`, `ctx`, `a`, `s`, `sa`] mp_tac
+        step_preserves_params >> simp[]) >>
+  (* PHI: vs_prev_bb preserved by non-term step *)
+  conj_tac
+  >- (strip_tac >>
+      qspecl_then [`fuel`, `ctx`, `a`, `s`, `sa`] mp_tac
+        step_preserves_control_flow >> simp[]) >>
+  (* RETURNDATACOPY: vs_returndata preserved *)
+  strip_tac >>
+  Cases_on `is_alloca_op a.inst_opcode`
+  >- (drule_all step_alloca_preserves >> simp[])
+  >> (qspecl_then [`fuel`, `ctx`, `a`, `s`, `sa`] mp_tac
+        write_effects_sound_returndata >> simp[] >>
+      disch_then irule >>
+      gvs[effects_independent_def] >>
+      `Eff_RETURNDATA IN read_effects RETURNDATACOPY` by EVAL_TAC >>
+      metis_tac[IN_DISJOINT])
+QED
+
+(* Forward transfer for ext: a succeeds on sb given a succeeded on s,
+   where b modified s to sb but b's outputs are disjoint from a's operands.
+   Works even when a is INVOKE (uses step_inst_ok_frame).
+
+   Case 1 (a=INVOKE): b is pure (empty effects), so sb = s or sb = update_var.
+     Use step_inst_ok_frame to transfer INVOKE across the update.
+   Case 2 (a≠INVOKE, b=INVOKE): a is pure, use pure_inst_transfer_across.
+   Case 3 (a≠INVOKE, b≠INVOKE): delegate to non-ext step_ok_transfer_forward. *)
+
+(* Helper: a_invoke case *)
+Triviality step_ok_transfer_forward_ext_invoke:
+  !fuel ctx a b s sa sb.
+    a.inst_opcode = INVOKE /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b s = OK sb /\
+    ~is_terminator b.inst_opcode /\
+    ~is_alloca_op b.inst_opcode /\
+    ~is_ext_call_op b.inst_opcode /\
+    DISJOINT (set b.inst_outputs) (set (operand_vars a.inst_operands)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    effects_independent a.inst_opcode b.inst_opcode /\
+    inst_wf b ==>
+    ?sba. step_inst fuel ctx a sb = OK sba
+Proof
+  rpt strip_tac >>
+  `b.inst_opcode <> INVOKE` by (
+    spose_not_then strip_assume_tac >>
+    gvs[EVAL ``effects_independent INVOKE INVOKE``]) >>
+  `write_effects b.inst_opcode = {} /\ read_effects b.inst_opcode = {}` by
+    metis_tac[effects_independent_invoke_empty] >>
+  fs[step_inst_non_invoke] >>
+  qspecl_then [`b`, `s`, `sb`] mp_tac pure_step_structure >> simp[] >>
+  strip_tac >> gvs[] >>
+  (* Only update_var case remains; b.inst_outputs=[] case solved by gvs *)
+  qspecl_then [`fuel`, `ctx`, `a`, `s`, `sa`, `out`, `val`] mp_tac
+    step_inst_ok_frame >>
+  impl_tac
+  >- (simp[] >>
+      conj_tac
+      >- (rpt strip_tac >> spose_not_then strip_assume_tac >> gvs[] >>
+          drule var_mem_operand_vars >> gvs[])
+      >> (gvs[inst_defs_def, DISJOINT_DEF, EXTENSION] >> EVAL_TAC))
+  >> (strip_tac >> metis_tac[])
+QED
+
+(* Helper: a_not_invoke case *)
+Triviality step_ok_transfer_forward_ext_non_invoke:
+  !fuel ctx a b s sa sb.
+    a.inst_opcode <> INVOKE /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b s = OK sb /\
+    ~is_terminator a.inst_opcode /\ ~is_terminator b.inst_opcode /\
+    ~is_alloca_op a.inst_opcode /\ ~is_alloca_op b.inst_opcode /\
+    ~is_ext_call_op a.inst_opcode /\
+    ~is_ext_call_op b.inst_opcode /\
+    DISJOINT (set b.inst_outputs) (set (operand_vars a.inst_operands)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    effects_independent a.inst_opcode b.inst_opcode /\
+    inst_wf b ==>
+    ?sba. step_inst fuel ctx a sb = OK sba
+Proof
+  rpt strip_tac >>
+  Cases_on `b.inst_opcode = INVOKE`
+  >- (
+    `effects_independent INVOKE a.inst_opcode` by
+      metis_tac[effects_independent_sym] >>
+    `write_effects a.inst_opcode = {} /\ read_effects a.inst_opcode = {}` by
+      metis_tac[effects_independent_invoke_empty] >>
+    `step_inst_base a s = OK sa` by gvs[step_inst_non_invoke] >>
+    qspecl_then [`fuel`, `ctx`, `a`, `b`, `s`, `sa`, `sb`] mp_tac
+      pure_inst_transfer_across >> simp[] >>
+    strip_tac >> qexists `sba` >> gvs[step_inst_non_invoke])
+  >> (
+    `step_inst_base a s = OK sa` by gvs[step_inst_non_invoke] >>
+    `step_inst_base b s = OK sb` by gvs[step_inst_non_invoke] >>
+    qspecl_then [`fuel`, `ctx`, `b`, `a`, `s`, `sb`, `sa`] mp_tac
+      step_ok_transfer_forward >>
+    simp[] >>
+    (impl_tac >- metis_tac[effects_independent_sym]) >>
+    strip_tac >>
+    qexists `sab` >> gvs[step_inst_non_invoke])
+QED
+
+(* Main theorem: combines both cases *)
+Triviality step_ok_transfer_forward_ext:
+  !fuel ctx a b s sa sb.
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b s = OK sb /\
+    ~is_terminator a.inst_opcode /\ ~is_terminator b.inst_opcode /\
+    ~is_alloca_op a.inst_opcode /\ ~is_alloca_op b.inst_opcode /\
+    ~is_ext_call_op a.inst_opcode /\
+    ~is_ext_call_op b.inst_opcode /\
+    DISJOINT (set b.inst_outputs) (set (operand_vars a.inst_operands)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    effects_independent a.inst_opcode b.inst_opcode /\
+    inst_wf b ==>
+    ?sba. step_inst fuel ctx a sb = OK sba
+Proof
+  rpt strip_tac >>
+  Cases_on `a.inst_opcode = INVOKE`
+  >- (irule step_ok_transfer_forward_ext_invoke >> metis_tac[])
+  >> (irule step_ok_transfer_forward_ext_non_invoke >> metis_tac[])
+QED
+
+(* The ext swap: given ext_bi_independent, inst_wf, and a;b succeeds OK,
+   then b;a also succeeds OK with the same final state.
+   Split into non-INVOKE and INVOKE helpers to keep each proof manageable. *)
+
+(* Helper: non-INVOKE b case *)
+Triviality step_swap_ok_ext_non_invoke:
+  !fuel ctx a b s sa sab.
+    ext_bi_independent a b /\ inst_wf a /\ inst_wf b /\
+    b.inst_opcode <> INVOKE /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  gvs[ext_bi_independent_def] >>
+  `step_inst_base b sa = OK sab` by gvs[step_inst_non_invoke] >>
+  (* Backward: b succeeds on s *)
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`sa`,`sab`] mp_tac
+    step_ok_transfer_backward_ext >>
+  (impl_tac >- gvs[inst_defs_def, inst_uses_def]) >> strip_tac >>
+  `step_inst fuel ctx b s = OK sb` by gvs[step_inst_non_invoke] >>
+  (* Forward: a succeeds on sb *)
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`sa`,`sb`] mp_tac
+    step_ok_transfer_forward_ext >>
+  (impl_tac >- gvs[inst_defs_def, inst_uses_def]) >> strip_tac >>
+  qexists_tac `sb` >> simp[] >>
+  (* Equality: sab = sba *)
+  `sab = sba` suffices_by simp[] >>
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`sa`,`sb`,`sab`,`sba`] mp_tac
+    independent_commute_eq_ext >>
+  (impl_tac >- gvs[inst_defs_def, inst_uses_def]) >> simp[]
+QED
+
+(* Helper: INVOKE b case. a must be pure (invoke_implies_pure).
+   Split further into inst_outputs=[] and inst_outputs=[out] sub-cases. *)
+
+(* Sub-case: a has no outputs (identity step) *)
+Triviality step_swap_ok_ext_invoke_no_out:
+  !fuel ctx a b s sab.
+    step_inst_base a s = OK s /\
+    a.inst_outputs = [] /\
+    a.inst_opcode <> INVOKE /\
+    write_effects a.inst_opcode = {} /\
+    read_effects a.inst_opcode = {} /\
+    inst_wf a /\ inst_wf b /\
+    b.inst_opcode = INVOKE /\
+    ~is_terminator a.inst_opcode /\ ~is_alloca_op a.inst_opcode /\
+    ~is_ext_call_op a.inst_opcode /\
+    DISJOINT (set (inst_defs a)) (set (inst_uses b)) /\
+    DISJOINT (set (inst_defs b)) (set (inst_uses a)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    step_inst fuel ctx b s = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  qexists_tac `sab` >> simp[] >>
+  (* Transfer a's success from s to sab *)
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`s`,`sab`] mp_tac
+    pure_inst_transfer_across >>
+  (impl_tac >- gvs[inst_defs_def, inst_uses_def,
+                    is_terminator_def, is_alloca_op_def]) >> strip_tac >>
+  (* By pure_step_structure on sba, inst_outputs=[] ⟹ sba = sab *)
+  qspecl_then [`a`, `sab`, `sba`] mp_tac pure_step_structure >>
+  simp[] >> strip_tac >> gvs[step_inst_non_invoke]
+QED
+
+(* Helper: INVOKE b case, one_out sub-case *)
+Triviality step_swap_ok_ext_invoke_one_out:
+  !fuel ctx a b s out val_ sab.
+    step_inst_base a s = OK (update_var out val_ s) /\
+    a.inst_outputs = [out] /\
+    a.inst_opcode <> INVOKE /\
+    write_effects a.inst_opcode = {} /\
+    read_effects a.inst_opcode = {} /\
+    inst_wf a /\ inst_wf b /\
+    b.inst_opcode = INVOKE /\
+    ~is_terminator a.inst_opcode /\ ~is_alloca_op a.inst_opcode /\
+    ~is_ext_call_op a.inst_opcode /\
+    DISJOINT (set (inst_defs a)) (set (inst_uses b)) /\
+    DISJOINT (set (inst_defs b)) (set (inst_uses a)) /\
+    DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    step_inst fuel ctx a s = OK (update_var out val_ s) /\
+    step_inst fuel ctx b (update_var out val_ s) = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  (* Use invoke_frame to derive step_inst b s = OK sb *)
+  qspecl_then [`fuel`,`ctx`,`b`,`s`,`out`,`val_`] mp_tac
+    step_inst_invoke_frame >>
+  impl_tac
+  >- (simp[] >> conj_tac
+      >- (rpt strip_tac >> spose_not_then strip_assume_tac >>
+          gvs[inst_defs_def, inst_uses_def, DISJOINT_DEF, EXTENSION] >>
+          drule var_mem_operand_vars >> strip_tac >> metis_tac[])
+      >> gvs[inst_defs_def, DISJOINT_DEF, EXTENSION])
+  >> strip_tac >>
+  (* step_inst b (update_var out val_ s) = OK sab, so
+     case step_inst b s = OK sb and sab = update_var out val_ sb *)
+  Cases_on `step_inst fuel ctx b s` >> gvs[] >>
+  rename1 `step_inst fuel ctx b s = OK sb` >>
+  (* Goal is now: step_inst a sb = OK (update_var out val_ sb) *)
+  (* Transfer a's success from s to sb *)
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`update_var out val_ s`,`sb`] mp_tac
+    pure_inst_transfer_across >>
+  (impl_tac >- gvs[inst_defs_def, inst_uses_def, is_terminator_def]) >>
+  strip_tac >>
+  `step_inst fuel ctx a sb = OK sba` by gvs[step_inst_non_invoke] >>
+  (* Use independent_commute_eq_ext: sba = update_var out val_ sb *)
+  `update_var out val_ sb = sba` suffices_by gvs[] >>
+  qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`update_var out val_ s`,`sb`,
+               `update_var out val_ sb`,`sba`] mp_tac
+    independent_commute_eq_ext >>
+  simp[] >>
+  (impl_tac >- gvs[effects_independent_def, is_terminator_def,
+                    is_alloca_op_def, is_ext_call_op_def]) >>
+  simp[]
+QED
+
+(* Helper: INVOKE b case. a must be pure (invoke_implies_pure). *)
+Triviality step_swap_ok_ext_invoke:
+  !fuel ctx a b s sa sab.
+    ext_bi_independent a b /\ inst_wf a /\ inst_wf b /\
+    b.inst_opcode = INVOKE /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  gvs[ext_bi_independent_def] >>
+  `effects_independent INVOKE a.inst_opcode` by
+    metis_tac[effects_independent_sym] >>
+  drule invoke_implies_pure >> strip_tac >>
+  `step_inst_base a s = OK sa` by gvs[step_inst_non_invoke] >>
+  qspecl_then [`a`, `s`, `sa`] mp_tac pure_step_structure >>
+  simp[] >> strip_tac
+  >- (
+    (* no_out case: a.inst_outputs = [], sa = s *)
+    gvs[] >>
+    qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`sab`] mp_tac
+      step_swap_ok_ext_invoke_no_out >>
+    gvs[inst_defs_def, inst_uses_def])
+  >> (
+    (* one_out case: a.inst_outputs = [out], sa = update_var out val s *)
+    gvs[] >> rename1 `step_inst_base a s = OK (update_var out vv s)` >>
+    qspecl_then [`fuel`,`ctx`,`a`,`b`,`s`,`out`,`vv`,`sab`] mp_tac
+      step_swap_ok_ext_invoke_one_out >>
+    gvs[inst_defs_def, inst_uses_def])
+QED
+
+(* Combining both cases *)
+Theorem step_swap_ok_ext:
+  !fuel ctx a b s sa sab.
+    ext_bi_independent a b /\
+    inst_wf a /\ inst_wf b /\
+    step_inst fuel ctx a s = OK sa /\
+    step_inst fuel ctx b sa = OK sab ==>
+    ?sb. step_inst fuel ctx b s = OK sb /\
+         step_inst fuel ctx a sb = OK sab
+Proof
+  rpt strip_tac >>
+  Cases_on `b.inst_opcode = INVOKE`
+  >- (drule_all step_swap_ok_ext_invoke >> simp[])
+  >> (drule_all step_swap_ok_ext_non_invoke >> simp[])
+QED
+
+(* Adjacent swap in run_insts context, ext version *)
+Triviality run_insts_swap_adjacent_ok_ext:
+  !fuel ctx prefix a b suffix s s_result.
+    ext_bi_independent a b /\ inst_wf a /\ inst_wf b /\
+    run_insts fuel ctx (prefix ++ [a; b] ++ suffix) s = OK s_result ==>
+    run_insts fuel ctx (prefix ++ [b; a] ++ suffix) s = OK s_result
+Proof
+  rpt strip_tac >>
+  gvs[run_insts_append] >>
+  Cases_on `run_insts fuel ctx prefix s` >>
+  gvs[run_insts_def, AllCaseEqs()] >>
+  Cases_on `step_inst fuel ctx a v` >>
+  gvs[run_insts_def, AllCaseEqs()] >>
+  Cases_on `step_inst fuel ctx b v'` >>
+  gvs[run_insts_def, AllCaseEqs()] >>
+  drule_all step_swap_ok_ext >> strip_tac >>
+  simp[]
+QED
+
+(* Bubble independent element to front, ext version *)
+Theorem run_insts_bubble_to_front_ext:
+  !prefix fuel ctx x suffix s r.
+    EVERY (ext_bi_independent x) prefix /\
+    EVERY inst_wf (x :: prefix) /\
+    run_insts fuel ctx (prefix ++ [x] ++ suffix) s = OK r ==>
+    run_insts fuel ctx ([x] ++ prefix ++ suffix) s = OK r
+Proof
+  Induct_on `prefix` >> simp[] >>
+  rpt strip_tac >> gvs[EVERY_DEF] >>
+  gvs[run_insts_def, AllCaseEqs()] >>
+  rename1 `step_inst fuel ctx h s = OK sh` >>
+  (* Apply IH to sh *)
+  first_x_assum (qspecl_then [`fuel`, `ctx`, `x`, `suffix`, `sh`, `r`] mp_tac) >>
+  simp[] >> strip_tac >>
+  rename1 `step_inst fuel ctx x sh = OK sx` >>
+  (* Swap h and x: step_inst h s = OK sh, step_inst x sh = OK sx *)
+  `ext_bi_independent h x` by metis_tac[ext_bi_independent_sym] >>
+  qspecl_then [`fuel`, `ctx`, `h`, `x`, `s`, `sh`, `sx`] mp_tac
+    step_swap_ok_ext >> simp[] >> strip_tac >>
+  qexists `sb` >> simp[]
+QED
+
+(* ===== Pairwise ext independence ===== *)
+
+Definition pairwise_ext_bi_independent_def:
+  pairwise_ext_bi_independent [] = T /\
+  pairwise_ext_bi_independent (x :: rest) =
+    (EVERY (ext_bi_independent x) rest /\ pairwise_ext_bi_independent rest)
+End
+
+Triviality pairwise_ext_bi_independent_perm:
+  !l1 l2. PERM l1 l2 ==>
+    (pairwise_ext_bi_independent l1 ==> pairwise_ext_bi_independent l2) /\
+    (!x. EVERY (ext_bi_independent x) l1 ==> EVERY (ext_bi_independent x) l2)
+Proof
+  ho_match_mp_tac PERM_IND >>
+  rw[pairwise_ext_bi_independent_def, EVERY_DEF] >>
+  gvs[pairwise_ext_bi_independent_def, EVERY_DEF] >>
+  metis_tac[ext_bi_independent_sym]
+QED
+
+Triviality run_insts_perm_ok_ext_strong:
+  !l1 l2.
+    PERM l1 l2 ==>
+    (pairwise_ext_bi_independent l1 ==> pairwise_ext_bi_independent l2) /\
+    (!x. EVERY (ext_bi_independent x) l1 ==> EVERY (ext_bi_independent x) l2) /\
+    (EVERY inst_wf l1 ==> EVERY inst_wf l2) /\
+    (!fuel ctx s s_result.
+       pairwise_ext_bi_independent l1 /\
+       EVERY inst_wf l1 /\
+       run_insts fuel ctx l1 s = OK s_result ==>
+       run_insts fuel ctx l2 s = OK s_result)
+Proof
+  ho_match_mp_tac PERM_IND >>
+  rw[pairwise_ext_bi_independent_def, EVERY_DEF] >>
+  gvs[pairwise_ext_bi_independent_def, EVERY_DEF]
+  >- (gvs[run_insts_def] >>
+      Cases_on `step_inst fuel ctx x s` >> gvs[] >>
+      res_tac >> gvs[])
+  >- metis_tac[ext_bi_independent_sym]
+  >- (gvs[run_insts_def, AllCaseEqs()] >>
+      rename1 `step_inst _ _ x s = OK sx` >>
+      rename1 `step_inst _ _ y sx = OK sy` >>
+      qspecl_then [`fuel`, `ctx`, `x`, `y`, `s`, `sx`, `sy`] mp_tac
+        step_swap_ok_ext >> simp[] >> strip_tac >>
+      qexists `sb` >> simp[] >> res_tac)
+QED
+
+Theorem run_insts_perm_ok_ext:
+  !l1 l2.
+    PERM l1 l2 ==>
+    !fuel ctx s s_result.
+      pairwise_ext_bi_independent l1 /\
+      EVERY inst_wf l1 /\
+      run_insts fuel ctx l1 s = OK s_result ==>
+      run_insts fuel ctx l2 s = OK s_result
+Proof
+  metis_tac[run_insts_perm_ok_ext_strong]
+QED
+
+(* ===== Pairwise independence ===== *)
+
+(* All pairs in a list are bi-independent *)
+Definition pairwise_bi_independent_def:
+  pairwise_bi_independent [] = T /\
+  pairwise_bi_independent (x :: rest) =
+    (EVERY (bi_independent x) rest /\ pairwise_bi_independent rest)
+End
+
+Triviality pairwise_bi_independent_cons:
+  !x rest.
+    pairwise_bi_independent (x :: rest) <=>
+    EVERY (bi_independent x) rest /\ pairwise_bi_independent rest
+Proof
+  simp[pairwise_bi_independent_def]
+QED
+
+Triviality pairwise_bi_independent_swap:
+  !x y rest.
+    pairwise_bi_independent (x :: y :: rest) ==>
+    pairwise_bi_independent (y :: x :: rest)
+Proof
+  rw[pairwise_bi_independent_def, EVERY_MEM] >>
+  metis_tac[bi_independent_sym]
+QED
+
+(* Key: pairwise bi-independence is preserved by PERM.
+   Proved by PERM induction on the strengthened property
+   that also preserves EVERY (bi_independent x) for all x. *)
+Triviality pairwise_bi_independent_perm:
+  !l1 l2. PERM l1 l2 ==>
+    pairwise_bi_independent l1 ==> pairwise_bi_independent l2
+Proof
+  `!l1 l2. PERM l1 l2 ==>
+     (pairwise_bi_independent l1 ==> pairwise_bi_independent l2) /\
+     (!x. EVERY (bi_independent x) l1 ==> EVERY (bi_independent x) l2)`
+    suffices_by metis_tac[] >>
+  ho_match_mp_tac PERM_IND >> rpt conj_tac >>
+  simp[pairwise_bi_independent_def, EVERY_DEF] >>
+  rpt strip_tac >> gvs[] >>
+  metis_tac[bi_independent_sym]
+QED
+
+(* ===== Main OK-case permutation theorem ===== *)
+
+(* Strengthened version carrying pairwise preservation for the trans case *)
+Triviality run_insts_perm_ok_strong:
+  !l1 l2.
+    PERM l1 l2 ==>
+    (pairwise_bi_independent l1 ==> pairwise_bi_independent l2) /\
+    (!x. EVERY (bi_independent x) l1 ==> EVERY (bi_independent x) l2) /\
+    (!fuel ctx s s_result.
+       pairwise_bi_independent l1 /\
+       run_insts fuel ctx l1 s = OK s_result ==>
+       run_insts fuel ctx l2 s = OK s_result)
+Proof
+  ho_match_mp_tac PERM_IND >>
+  rw[pairwise_bi_independent_def, EVERY_DEF] >>
+  gvs[pairwise_bi_independent_def, EVERY_DEF]
+  >- (gvs[run_insts_def] >>
+      Cases_on `step_inst fuel ctx x s` >> gvs[] >>
+      res_tac >> gvs[])
+  >- metis_tac[bi_independent_sym]
+  >> gvs[run_insts_def, AllCaseEqs()] >>
+  drule_all step_swap_ok >> strip_tac >> simp[]
+QED
+
+Theorem run_insts_perm_ok:
+  !l1 l2.
+    PERM l1 l2 ==>
+    !fuel ctx s s_result.
+      pairwise_bi_independent l1 /\
+      run_insts fuel ctx l1 s = OK s_result ==>
+      run_insts fuel ctx l2 s = OK s_result
+Proof
+  metis_tac[run_insts_perm_ok_strong]
+QED
+
+(* ===== Topological ordering equivalence ===== *)
+
+(* Two permutations that are both topologically sorted w.r.t. a relation
+   dep (where incomparable elements are bi_independent) produce the same
+   run_insts OK result.
+
+   Proof by strong induction on LENGTH l2. The first element x of l2
+   has no deps (topo_sorted), and nothing in l1's prefix before x
+   depends on x (topo_sorted l1) or is depended on by x (topo_sorted l2
+   with x first). So x is bi_independent with the entire prefix.
+   bubble_to_front moves x to the front. Then IH on the tails. *)
+
+Definition topo_sorted_def:
+  topo_sorted dep l <=>
+    !i j. i < j /\ j < LENGTH l ==> ~dep (EL i l) (EL j l)
+End
+
+(* Main theorem *)
+(* Helper: EL in (prefix ++ suffix) relates to (prefix ++ [x] ++ suffix) *)
+Theorem el_delete_map:
+  !n prefix x suffix.
+    n < LENGTH prefix + LENGTH suffix ==>
+    EL n (prefix ++ suffix) =
+    EL (if n < LENGTH prefix then n else SUC n)
+       (prefix ++ [x] ++ suffix)
+Proof
+  rpt strip_tac >> Cases_on `n < LENGTH prefix`
+  >- simp[EL_APPEND1]
+  >> `LENGTH prefix <= n` by simp[] >>
+     simp[EL_APPEND2] >>
+     `LENGTH prefix <= SUC n` by simp[] >>
+     simp[EL_APPEND2] >>
+     `SUC n - LENGTH prefix = SUC (n - LENGTH prefix)` by simp[] >>
+     `SUC n - (LENGTH prefix + 1) = n - LENGTH prefix` by simp[] >>
+     simp[]
+QED
+
+(* Helper: topo_sorted is preserved when removing an element *)
+Theorem topo_sorted_delete:
+  !dep prefix x suffix.
+    topo_sorted dep (prefix ++ [x] ++ suffix) ==>
+    topo_sorted dep (prefix ++ suffix)
+Proof
+  rw[topo_sorted_def] >> rpt strip_tac >>
+  `i < LENGTH prefix + LENGTH suffix` by simp[] >>
+  `j < LENGTH prefix + LENGTH suffix` by simp[] >>
+  `EL i (prefix ++ suffix) =
+     EL (if i < LENGTH prefix then i else SUC i)
+        (prefix ++ [x] ++ suffix)` by
+    (irule el_delete_map >> simp[]) >>
+  `EL j (prefix ++ suffix) =
+     EL (if j < LENGTH prefix then j else SUC j)
+        (prefix ++ [x] ++ suffix)` by
+    (irule el_delete_map >> simp[]) >>
+  first_x_assum (qspecl_then
+    [`if i < LENGTH prefix then i else SUC i`,
+     `if j < LENGTH prefix then j else SUC j`] mp_tac) >>
+  rpt (COND_CASES_TAC >> gvs[])
+QED
+
+(* Helper: topo_sorted tail *)
+Theorem topo_sorted_tail:
+  !dep x rest. topo_sorted dep (x :: rest) ==> topo_sorted dep rest
+Proof
+  rw[topo_sorted_def] >> rpt strip_tac >>
+  first_x_assum (qspecl_then [`SUC i`, `SUC j`] mp_tac) >> simp[]
+QED
+
+(* Helper: PERM delete from cons *)
+Theorem perm_cons_delete:
+  !x rest prefix suffix.
+    PERM (prefix ++ [x] ++ suffix) (x :: rest) ==>
+    PERM (prefix ++ suffix) rest
+Proof
+  rpt strip_tac >>
+  `prefix ++ [x] ++ suffix = prefix ++ x :: suffix` by simp[] >>
+  gvs[] >>
+  full_simp_tac std_ss [PERM_FUN_APPEND_CONS] >>
+  gvs[PERM_CONS_IFF]
+QED
+
+Triviality prefix_bi_independent:
+  !prefix x suffix rest dep.
+    PERM (prefix ++ [x] ++ suffix) (x :: rest) /\
+    ALL_DISTINCT (prefix ++ [x] ++ suffix) /\
+    topo_sorted dep (prefix ++ [x] ++ suffix) /\
+    topo_sorted dep (x :: rest) /\
+    (!x' y. MEM x' (prefix ++ [x] ++ suffix) /\
+            MEM y (prefix ++ [x] ++ suffix) /\
+            x' <> y /\ ~dep x' y /\ ~dep y x' ==>
+            bi_independent x' y) ==>
+    EVERY (bi_independent x) prefix
+Proof
+  rw[EVERY_MEM] >>
+  `?k. k < LENGTH prefix /\ e = EL k prefix` by metis_tac[MEM_EL] >> gvs[] >>
+  `ALL_DISTINCT (x :: rest)` by metis_tac[ALL_DISTINCT_PERM] >>
+  `~dep (EL k prefix) x` by
+    (qpat_x_assum `topo_sorted _ (prefix ++ _ ++ _)` mp_tac >>
+     rw[topo_sorted_def] >>
+     first_x_assum (qspecl_then [`k`, `LENGTH prefix`] mp_tac) >>
+     simp[EL_APPEND1, EL_APPEND2]) >>
+  `MEM (EL k prefix) (x :: rest)` by
+    (irule (iffLR PERM_MEM_EQ) >>
+     qexists_tac `prefix ++ [x] ++ suffix` >>
+     simp[MEM_APPEND, MEM_EL]) >>
+  `EL k prefix <> x` by
+    (gvs[ALL_DISTINCT_APPEND] >> metis_tac[MEM_EL]) >>
+  `MEM (EL k prefix) rest` by gvs[MEM] >>
+  `~dep x (EL k prefix)` by
+    (qpat_x_assum `topo_sorted _ (x :: rest)` mp_tac >>
+     rw[topo_sorted_def] >>
+     `?m. m < LENGTH rest /\ EL k prefix = EL m rest` by metis_tac[MEM_EL] >>
+     first_x_assum (qspecl_then [`0`, `SUC m`] mp_tac) >> simp[]) >>
+  first_x_assum irule >>
+  simp[MEM_APPEND]
+QED
+
+Triviality run_insts_topo_equiv_aux:
+  !n l1 l2 dep fuel ctx s r.
+    LENGTH l2 = n /\
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> bi_independent x y) /\
+    run_insts fuel ctx l1 s = OK r ==>
+    run_insts fuel ctx l2 s = OK r
+Proof
+  Induct_on `n` >> rpt strip_tac
+  >- gvs[PERM_NIL, run_insts_def]
+  >> Cases_on `l2` >- gvs[]
+  >> rename1 `PERM l1 (x :: rest)` >>
+  `LENGTH rest = n` by gvs[] >>
+  (* Find x in l1 *)
+  `MEM x l1` by metis_tac[PERM_MEM_EQ, MEM] >>
+  `?prefix suffix. l1 = prefix ++ [x] ++ suffix /\ ~MEM x prefix`
+    by metis_tac[MEM_SPLIT_APPEND_first] >>
+  qpat_x_assum `_ = _ ++ [_] ++ _` SUBST_ALL_TAC >>
+  (* Now l1 is substituted but universal hypothesis keeps MEM _ (prefix ++ [x] ++ suffix) form *)
+  `ALL_DISTINCT (x :: rest)` by metis_tac[ALL_DISTINCT_PERM] >>
+  (* x is bi_independent with all prefix elements *)
+  `EVERY (bi_independent x) prefix` by
+    metis_tac[prefix_bi_independent] >>
+  (* Bubble x to front *)
+  drule run_insts_bubble_to_front >>
+  disch_then (qspecl_then [`fuel`, `ctx`, `suffix`, `s`, `r`] mp_tac) >>
+  simp[] >> strip_tac >>
+  (* Now: run_insts (x :: prefix ++ suffix) = OK r *)
+  qpat_x_assum `!x' y. MEM x' _ /\ _ ==> _`
+    (fn th => gvs[run_insts_def, AllCaseEqs()] >> assume_tac th) >>
+  rename1 `step_inst fuel ctx x s = OK s'` >>
+  (* Apply IH to tails *)
+  first_x_assum irule >>
+  simp[] >>
+  qexistsl_tac [`dep`, `prefix ++ suffix`] >>
+  rpt conj_tac
+  >- (rpt strip_tac >> first_x_assum irule >>
+      gvs[MEM_APPEND])
+  >- gvs[ALL_DISTINCT_APPEND]
+  >- simp[]
+  >- metis_tac[perm_cons_delete]
+  >- metis_tac[topo_sorted_delete]
+  >- metis_tac[topo_sorted_tail]
+QED
+
+Theorem run_insts_topo_equiv:
+  !l1 l2 dep fuel ctx s r.
+    PERM l1 l2 /\ ALL_DISTINCT l1 /\
+    topo_sorted dep l1 /\ topo_sorted dep l2 /\
+    (!x y. MEM x l1 /\ MEM y l1 /\ x <> y /\
+           ~dep x y /\ ~dep y x ==> bi_independent x y) /\
+    run_insts fuel ctx l1 s = OK r ==>
+    run_insts fuel ctx l2 s = OK r
+Proof
+  rpt strip_tac >> irule run_insts_topo_equiv_aux >>
+  simp[] >> qexistsl_tac [`dep`, `l1`] >> simp[]
+QED
+
+(* ===== flip_operands preserves step_inst semantics ===== *)
+
+(*
+ * For commutative ops (ADD,MUL,EQ,AND,OR,XOR): swapping operands
+ * applies the commutative binary function to swapped args — same result.
+ * For comparators (GT<->LT, SGT<->SLT): swapping operands AND
+ * flipping opcode: f(a,b) = g(b,a) where g is the flipped comparison.
+ *)
+
+(* exec_pure2 with swapped operands: f(op2,op1) = g(op1,op2) *)
+Triviality exec_pure2_swap:
+  !f g (i:instruction) st op1 op2.
+    (!x y. f y x = g x y) /\ i.inst_operands = [op1; op2] ==>
+    exec_pure2 f (i with inst_operands := [op2; op1]) st =
+    exec_pure2 g i st
+Proof
+  rw[exec_pure2_def] >>
+  Cases_on `eval_operand op1 st` >> Cases_on `eval_operand op2 st` >> gvs[]
+QED
+
+(* exec_pure2 ignores inst_opcode and inst_id *)
+Triviality exec_pure2_opcode_irrel[simp]:
+  exec_pure2 f (i with inst_opcode := op) st = exec_pure2 f i st
+Proof rw[exec_pure2_def]
+QED
+
+(* Helpers to avoid 92-way case splits *)
+Triviality commutative_not_comparator:
+  !op. is_commutative op ==> ~is_comparator op
+Proof Cases >> EVAL_TAC
+QED
+
+Triviality commutative_cases:
+  !op. is_commutative op ==>
+    op = ADD \/ op = MUL \/ op = EQ \/ op = AND \/ op = OR \/ op = XOR
+Proof Cases >> EVAL_TAC
+QED
+
+Triviality comparator_cases:
+  !op. is_comparator op ==> op = GT \/ op = LT \/ op = SGT \/ op = SLT
+Proof Cases >> EVAL_TAC
+QED
+
+val comm_lemmas =
+  [wordsTheory.WORD_ADD_COMM, wordsTheory.WORD_MULT_COMM,
+   wordsTheory.WORD_AND_COMM, wordsTheory.WORD_OR_COMM,
+   wordsTheory.WORD_XOR_COMM,
+   arithmeticTheory.GREATER_DEF, wordsTheory.WORD_GREATER];
+
+(*
+ * flip_operands preserves step_inst_base.
+ * For commutative ops: operands swapped, opcode same -> exec_pure2_swap.
+ * For comparators: operands swapped AND opcode flipped -> case-by-case.
+ *)
+Triviality flip_commutative:
+  !i st op1 op2.
+    is_commutative i.inst_opcode /\ i.inst_operands = [op1; op2] ==>
+    step_inst_base (flip_operands i) st = step_inst_base i st
+Proof
+  rpt strip_tac >>
+  drule commutative_cases >> drule commutative_not_comparator >>
+  strip_tac >> strip_tac >>
+  fs[flip_operands_def, step_inst_base_def] >>
+  irule exec_pure2_swap >> rw comm_lemmas >> rw[EQ_SYM_EQ]
+QED
+
+Triviality flip_comparator:
+  !i st op1 op2.
+    is_comparator i.inst_opcode /\ i.inst_operands = [op1; op2] ==>
+    step_inst_base (flip_operands i) st = step_inst_base i st
+Proof
+  rpt strip_tac >>
+  drule comparator_cases >> strip_tac >>
+  fs[flip_operands_def, is_comparator_def, flip_comparison_opcode_def,
+     step_inst_base_def] >>
+  (* exec_pure2_opcode_irrel strips the opcode update *)
+  simp[] >>
+  irule exec_pure2_swap >> rw comm_lemmas
+QED
+
+Theorem flip_operands_step_inst_base:
+  !i st. is_flippable i.inst_opcode ==>
+    step_inst_base (flip_operands i) st = step_inst_base i st
+Proof
+  rpt strip_tac >>
+  Cases_on `i.inst_operands` >- simp[flip_operands_def] >>
+  Cases_on `t` >- simp[flip_operands_def] >>
+  Cases_on `t'`
+  >- (rename1 `i.inst_operands = [op1; op2]` >>
+      gvs[is_flippable_def] >>
+      metis_tac[flip_commutative, flip_comparator])
+  >> simp[flip_operands_def]
+QED
+
+Triviality flippable_not_invoke:
+  !op. is_flippable op ==> op <> INVOKE
+Proof Cases >> EVAL_TAC
+QED
+
+Triviality flip_opcode_not_invoke:
+  !i. is_flippable i.inst_opcode ==>
+    (flip_operands i).inst_opcode <> INVOKE
+Proof
+  rpt strip_tac >>
+  imp_res_tac flippable_not_invoke >>
+  `?ops. i.inst_operands = ops` by simp[] >>
+  Cases_on `ops` >> fs[flip_operands_def] >>
+  Cases_on `t` >> fs[flip_operands_def] >>
+  Cases_on `t'` >> fs[flip_operands_def] >>
+  gvs[is_flippable_def] >>
+  imp_res_tac commutative_not_comparator >> gvs[] >>
+  gvs[is_comparator_def, flip_comparison_opcode_def]
+QED
+
+Theorem flip_operands_step_inst:
+  !fuel ctx i st. is_flippable i.inst_opcode ==>
+    step_inst fuel ctx (flip_operands i) st = step_inst fuel ctx i st
+Proof
+  rpt strip_tac >>
+  imp_res_tac flippable_not_invoke >>
+  imp_res_tac flip_opcode_not_invoke >>
+  simp[step_inst_non_invoke] >>
+  irule flip_operands_step_inst_base >> simp[]
+QED
+
+(* ===== NoFail + non-terminator: step_inst_base never Halt/Abort ===== *)
+
+(* Pre-compute per-opcode step_inst_base clauses and no-halt-abort theorems.
+   Each exec helper (pure1/2/3, read0/1, write2, alloca, ext_call, create,
+   delegatecall) only returns OK or Error — never Halt or Abort. *)
+
+val nf_nt_ops = List.filter (fn op_tm =>
+  let val nf = EVAL ``opcode_fail_class ^op_tm = NoFail``
+      val nt = EVAL ``~is_terminator ^op_tm``
+  in aconv (rhs (concl nf)) T andalso aconv (rhs (concl nt)) T end
+) (TypeBase.constructors_of ``:opcode``);
+
+val nfnt_clauses = map (fn op_tm =>
+  SIMP_CONV (srw_ss()) [step_inst_base_def]
+    (mk_comb(mk_comb(``step_inst_base``,
+      ``inst with inst_opcode := ^op_tm``), ``st:venom_state``))
+) nf_nt_ops;
+
+val exec_helper_defs = [
+  exec_pure1_def, exec_pure2_def, exec_pure3_def,
+  exec_read0_def, exec_read1_def, exec_write2_def,
+  exec_alloca_def, exec_ext_call_def, exec_create_def,
+  exec_delegatecall_def, LET_THM, AllCaseEqs()];
+
+val per_op_no_halt_abort = map (fn (op_tm, clause) =>
+  prove(
+    ``inst.inst_opcode = ^op_tm ==>
+      (!h. step_inst_base inst st <> Halt h) /\
+      (!a es. step_inst_base inst st <> Abort a es)``,
+    strip_tac >>
+    `inst with inst_opcode := ^op_tm = inst`
+      by simp[instruction_component_equality] >>
+    pop_assum (fn eq => ONCE_REWRITE_TAC [GSYM eq]) >>
+    ONCE_REWRITE_TAC [clause] >> simp exec_helper_defs)
+) (ListPair.zip(nf_nt_ops, nfnt_clauses));
+
+val per_op_combined = LIST_CONJ per_op_no_halt_abort;
+
+Theorem step_inst_nofail_not_halt_abort:
+  !inst s.
+    opcode_fail_class inst.inst_opcode = NoFail /\
+    ~is_terminator inst.inst_opcode ==>
+    (!h. step_inst_base inst s <> Halt h) /\
+    (!a es. step_inst_base inst s <> Abort a es)
+Proof
+  rpt gen_tac >> Cases_on `inst.inst_opcode` >>
+  simp[opcode_fail_class_def, is_terminator_def] >>
+  metis_tac[per_op_combined]
+QED
+
+

--- a/venom/passes/dft/proofs/dftPermSimScript.sml
+++ b/venom/passes/dft/proofs/dftPermSimScript.sml
@@ -89,6 +89,7 @@ Definition ext_bi_independent_def:
     DISJOINT (set (inst_defs i2)) (set (inst_uses i1)) /\
     DISJOINT (set (inst_defs i1)) (set (inst_defs i2)) /\
     effects_independent i1.inst_opcode i2.inst_opcode /\
+    abort_compatible i1.inst_opcode i2.inst_opcode /\
     ~is_terminator i1.inst_opcode /\ ~is_terminator i2.inst_opcode /\
     ~is_alloca_op i1.inst_opcode /\ ~is_alloca_op i2.inst_opcode /\
     ~is_ext_call_op i1.inst_opcode /\ ~is_ext_call_op i2.inst_opcode
@@ -97,7 +98,8 @@ End
 Theorem ext_bi_independent_sym:
   !i1 i2. ext_bi_independent i1 i2 <=> ext_bi_independent i2 i1
 Proof
-  rw[ext_bi_independent_def, effects_independent_def] >>
+  rw[ext_bi_independent_def, effects_independent_def,
+     abort_compatible_def] >>
   metis_tac[DISJOINT_SYM]
 QED
 
@@ -608,6 +610,8 @@ Triviality step_swap_ok_ext_invoke_one_out:
     DISJOINT (set (inst_defs a)) (set (inst_uses b)) /\
     DISJOINT (set (inst_defs b)) (set (inst_uses a)) /\
     DISJOINT (set (inst_defs a)) (set (inst_defs b)) /\
+    effects_independent a.inst_opcode b.inst_opcode /\
+    abort_compatible a.inst_opcode b.inst_opcode /\
     step_inst fuel ctx a s = OK (update_var out val_ s) /\
     step_inst fuel ctx b (update_var out val_ s) = OK sab ==>
     ?sb. step_inst fuel ctx b s = OK sb /\
@@ -641,7 +645,7 @@ Proof
                `update_var out val_ sb`,`sba`] mp_tac
     independent_commute_eq_ext >>
   simp[] >>
-  (impl_tac >- gvs[effects_independent_def, is_terminator_def,
+  (impl_tac >- gvs[is_terminator_def,
                     is_alloca_op_def, is_ext_call_op_def]) >>
   simp[]
 QED

--- a/venom/passes/dft/proofs/dftPipelineInvarScript.sml
+++ b/venom/passes/dft/proofs/dftPipelineInvarScript.sml
@@ -1,0 +1,985 @@
+(*
+ * DFT Pipeline Invariance — supporting lemmas
+ *
+ * Key results:
+ *   inst_data_deps_id_agree — under unique_defs + id-structure agreement,
+ *     inst_data_deps returns same inst_ids for permuted block_insts
+ *   build_eda_agree — same effect-ful subsequence and id set => same eda map
+ *   build_full_eda_pseudo_strip — build_full_eda ignores pseudo instructions
+ *
+ * Definitions:
+ *   has_effects — predicate for instructions with non-empty effect sets
+ *   eda_fold_step — single-step fold function used in build_eda
+ *)
+
+Theory dftPipelineInvar
+Ancestors
+  dftStructural dftIdempotent dftDefs venomExecSemantics venomEffects
+  passSharedDefs venomInst list rich_list sorting finite_map pred_set
+
+(* ================================================================
+   Helpers
+   ================================================================ *)
+
+Theorem unique_defs_no_shared_output:
+  !insts i j var.
+    unique_defs insts /\
+    MEM i insts /\ MEM j insts /\ i <> j /\
+    MEM var i.inst_outputs /\ MEM var j.inst_outputs ==>
+    F
+Proof
+  rpt gen_tac >> strip_tac >> fs[unique_defs_def] >>
+  `?ni. ni < LENGTH insts /\ EL ni insts = i` by metis_tac[MEM_EL] >>
+  `?nj. nj < LENGTH insts /\ EL nj insts = j` by metis_tac[MEM_EL] >>
+  `ni <> nj` by (strip_tac >> gvs[]) >>
+  `ni < nj \/ nj < ni` by DECIDE_TAC >| [
+    first_x_assum (qspecl_then [`ni`, `nj`] mp_tac) >>
+    simp[IN_DISJOINT] >> metis_tac[],
+    first_x_assum (qspecl_then [`nj`, `ni`] mp_tac) >>
+    simp[IN_DISJOINT] >> metis_tac[]
+  ]
+QED
+
+Theorem producing_inst_perm_id:
+  !insts1 insts2 var i1 i2.
+    unique_defs insts1 /\
+    producing_inst insts1 var = SOME i1 /\
+    producing_inst insts2 var = SOME i2 /\
+    (!j. MEM j insts2 ==>
+         ?k. MEM k insts1 /\ k.inst_id = j.inst_id /\
+             k.inst_outputs = j.inst_outputs) ==>
+    i2.inst_id = i1.inst_id
+Proof
+  rpt strip_tac >>
+  `MEM i2 insts2 /\ MEM var i2.inst_outputs` by metis_tac[producing_inst_unique] >>
+  `?k. MEM k insts1 /\ k.inst_id = i2.inst_id /\ k.inst_outputs = i2.inst_outputs`
+    by metis_tac[] >>
+  `MEM var k.inst_outputs` by metis_tac[] >>
+  `MEM i1 insts1 /\ MEM var i1.inst_outputs` by metis_tac[producing_inst_unique] >>
+  Cases_on `k = i1` >> gvs[] >>
+  metis_tac[unique_defs_no_shared_output]
+QED
+
+Triviality producing_inst_none_no_mem:
+  !insts var.
+    producing_inst insts var = NONE ==>
+    !i. MEM i insts ==> ~MEM var i.inst_outputs
+Proof
+  Induct >> rw[producing_inst_def] >>
+  BasicProvers.every_case_tac >> gvs[] >> metis_tac[]
+QED
+
+Theorem producing_inst_none_agree:
+  !insts1 insts2 var.
+    producing_inst insts1 var = NONE /\
+    (!j. MEM j insts2 ==>
+         ?k. MEM k insts1 /\ k.inst_outputs = j.inst_outputs) ==>
+    producing_inst insts2 var = NONE
+Proof
+  rpt strip_tac >>
+  Cases_on `producing_inst insts2 var` >> simp[] >>
+  rename1 `SOME i2` >>
+  imp_res_tac producing_inst_unique >>
+  `?k. MEM k insts1 /\ k.inst_outputs = i2.inst_outputs` by metis_tac[] >>
+  `~MEM var k.inst_outputs` by metis_tac[producing_inst_none_no_mem] >>
+  metis_tac[]
+QED
+
+(* ================================================================
+   operand_producer inst_id agreement
+   ================================================================ *)
+
+(* Under unique_defs, operand_producer on two lists with same
+   inst_id+outputs elements returns OPTION_MAP with same inst_id *)
+Triviality operand_producer_id_agree:
+  !insts1 insts2 op.
+    unique_defs insts1 /\
+    (!j. MEM j insts2 ==>
+         ?k. MEM k insts1 /\ k.inst_id = j.inst_id /\
+             k.inst_outputs = j.inst_outputs) /\
+    (!k. MEM k insts1 ==>
+         ?j. MEM j insts2 /\ j.inst_id = k.inst_id /\
+             j.inst_outputs = k.inst_outputs) ==>
+    case (operand_producer insts1 op, operand_producer insts2 op) of
+      (NONE, NONE) => T
+    | (SOME i1, SOME i2) => i1.inst_id = i2.inst_id
+    | (NONE, SOME _) => F
+    | (SOME _, NONE) => F
+Proof
+  rpt strip_tac >>
+  Cases_on `op` >> simp[operand_producer_def] >>
+  Cases_on `producing_inst insts1 s` >>
+  Cases_on `producing_inst insts2 s` >> simp[]
+  (* NONE/SOME: use producing_inst_none_agree to derive contradiction *)
+  >- (rename1 `_ = SOME i2` >>
+      `!j. MEM j insts2 ==> ?k. MEM k insts1 /\ k.inst_outputs = j.inst_outputs`
+        by (rpt strip_tac >> res_tac >> metis_tac[]) >>
+      drule_all producing_inst_none_agree >> gvs[])
+  (* SOME/NONE: symmetric case *)
+  >- (rename1 `_ = SOME i1` >>
+      `!j. MEM j insts1 ==> ?k. MEM k insts2 /\ k.inst_outputs = j.inst_outputs`
+        by (rpt strip_tac >> res_tac >> metis_tac[]) >>
+      drule_all producing_inst_none_agree >> gvs[])
+  (* SOME/SOME: use producing_inst_perm_id *)
+  >> drule_all producing_inst_perm_id >> simp[]
+QED
+
+(* ================================================================
+   inst_data_deps inst_id agreement
+   ================================================================ *)
+
+(* MAP THE o FILTER IS_SOME o MAP preserves inst_id when individual
+   elements agree on inst_id *)
+Triviality map_the_filter_id_agree:
+  !f1 f2 ls.
+    (!x. MEM x ls ==>
+      case (f1 x, f2 x) of
+        (NONE, NONE) => T
+      | (SOME a, SOME b) => a.inst_id = b.inst_id
+      | (NONE, SOME _) => F
+      | (SOME _, NONE) => F) ==>
+    MAP (\i. i.inst_id) (MAP THE (FILTER IS_SOME (MAP f1 ls))) =
+    MAP (\i. i.inst_id) (MAP THE (FILTER IS_SOME (MAP f2 ls)))
+Proof
+  ntac 2 gen_tac >> Induct >- simp[] >>
+  rpt strip_tac >>
+  (* Discharge IH: restrict MEM hypothesis to tail *)
+  `MAP (\i. i.inst_id) (MAP THE (FILTER IS_SOME (MAP f1 ls))) =
+   MAP (\i. i.inst_id) (MAP THE (FILTER IS_SOME (MAP f2 ls)))` by
+    (first_x_assum irule >> rpt strip_tac >>
+     first_x_assum (qspec_then `x` mp_tac) >> simp[MEM]) >>
+  (* Handle the head *)
+  first_x_assum (qspec_then `h` mp_tac) >> simp[MEM] >>
+  Cases_on `f1 h` >> Cases_on `f2 h` >> simp[MAP, FILTER]
+QED
+
+(* Key nub lemma: if MAP f agrees and f is injective on each list's elements,
+   then MAP f after nub also agrees. Proof via nub_MAP_INJ. *)
+Triviality nub_map_agree:
+  !f xs ys.
+    MAP f xs = MAP f ys /\
+    INJ f (set xs) UNIV /\
+    INJ f (set ys) UNIV ==>
+    MAP f (nub xs) = MAP f (nub ys)
+Proof
+  rpt strip_tac >>
+  `nub (MAP f xs) = MAP f (nub xs)` by metis_tac[nub_MAP_INJ] >>
+  `nub (MAP f ys) = MAP f (nub ys)` by metis_tac[nub_MAP_INJ] >>
+  metis_tac[]
+QED
+
+(* producing_inst returns unique objects: same inst_id implies same object,
+   because producing_inst scans the list and returns the first match,
+   and under unique_defs + ALL_DISTINCT inst_ids, the match is unique. *)
+Triviality producing_inst_inj:
+  !insts v1 v2 i1 i2.
+    ALL_DISTINCT (MAP (\i. i.inst_id) insts) /\
+    producing_inst insts v1 = SOME i1 /\
+    producing_inst insts v2 = SOME i2 /\
+    i1.inst_id = i2.inst_id ==>
+    i1 = i2
+Proof
+  Induct >> rw[producing_inst_def] >>
+  BasicProvers.every_case_tac >> gvs[MEM_MAP] >>
+  imp_res_tac producing_inst_unique >> metis_tac[]
+QED
+
+(* operand_producer SOME results come from producing_inst *)
+Triviality operand_producer_is_producing:
+  !insts op i.
+    operand_producer insts op = SOME i ==>
+    ?v. producing_inst insts v = SOME i
+Proof
+  Cases_on `op` >> rw[operand_producer_def] >> metis_tac[]
+QED
+
+(* Any element of MAP THE (FILTER IS_SOME (MAP f ls)) is f(x) for some x in ls *)
+Triviality mem_map_the_filter:
+  !f ls x.
+    MEM x (MAP THE (FILTER IS_SOME (MAP f ls))) ==>
+    ?y. MEM y ls /\ f y = SOME x
+Proof
+  ntac 1 gen_tac >> Induct >> simp[MAP, FILTER] >> rpt strip_tac >>
+  Cases_on `f h` >> gvs[FILTER, MEM] >> metis_tac[]
+QED
+
+(* Helper: any member of a deps list (var_deps or order_deps) comes from
+   producing_inst, giving us a SOME equation we can feed to producing_inst_inj *)
+Triviality mem_var_deps_producing:
+  !insts ops x.
+    MEM x (MAP THE (FILTER IS_SOME (MAP (operand_producer insts) ops))) ==>
+    ?v. producing_inst insts v = SOME x
+Proof
+  rpt strip_tac >>
+  drule mem_map_the_filter >> strip_tac >>
+  drule operand_producer_is_producing >> metis_tac[]
+QED
+
+Triviality mem_order_deps_producing:
+  !insts order x.
+    MEM x (MAP THE (FILTER IS_SOME (MAP (producing_inst insts) order))) ==>
+    ?v. producing_inst insts v = SOME x
+Proof
+  rpt strip_tac >> drule mem_map_the_filter >> metis_tac[]
+QED
+
+(* var_deps and order_deps elements satisfy INJ inst_id.
+   Matches inst_data_deps_def (order_deps include self-dep filter). *)
+Triviality deps_list_inj:
+  !insts order inst.
+    ALL_DISTINCT (MAP (\i. i.inst_id) insts) ==>
+    let var_deps = MAP THE (FILTER IS_SOME
+      (MAP (operand_producer insts) inst.inst_operands)) in
+    let order_deps =
+      if is_terminator inst.inst_opcode
+      then FILTER (\d. d.inst_id <> inst.inst_id)
+             (MAP THE (FILTER IS_SOME (MAP (producing_inst insts) order)))
+      else [] in
+    INJ (\i. i.inst_id) (set (var_deps ++ order_deps)) UNIV
+Proof
+  rpt strip_tac >> simp[INJ_DEF] >> rpt strip_tac >>
+  Cases_on `is_terminator inst.inst_opcode` >> gvs[MEM_APPEND, MEM, MEM_FILTER] >>
+  rpt (first_x_assum
+    (strip_assume_tac o MATCH_MP mem_var_deps_producing)) >>
+  rpt (first_x_assum
+    (strip_assume_tac o MATCH_MP mem_order_deps_producing)) >>
+  irule producing_inst_inj >> metis_tac[]
+QED
+
+(* Helper: var_deps MAP inst_id agrees *)
+Triviality var_deps_id_agree:
+  !insts1 insts2 ops.
+    unique_defs insts1 /\
+    (!j. MEM j insts2 ==>
+         ?k. MEM k insts1 /\ k.inst_id = j.inst_id /\
+             k.inst_outputs = j.inst_outputs) /\
+    (!k. MEM k insts1 ==>
+         ?j. MEM j insts2 /\ j.inst_id = k.inst_id /\
+             j.inst_outputs = k.inst_outputs) ==>
+    MAP (\i. i.inst_id)
+      (MAP THE (FILTER IS_SOME (MAP (operand_producer insts1) ops))) =
+    MAP (\i. i.inst_id)
+      (MAP THE (FILTER IS_SOME (MAP (operand_producer insts2) ops)))
+Proof
+  rpt strip_tac >> irule map_the_filter_id_agree >> rpt strip_tac >>
+  mp_tac (Q.SPECL [`insts1`, `insts2`, `x`] operand_producer_id_agree) >>
+  impl_tac >- metis_tac[] >>
+  Cases_on `operand_producer insts1 x` >>
+  Cases_on `operand_producer insts2 x` >> simp[]
+QED
+
+(* Helper: order_deps MAP inst_id agrees *)
+Triviality order_deps_id_agree:
+  !insts1 insts2 order.
+    unique_defs insts1 /\
+    (!j. MEM j insts2 ==>
+         ?k. MEM k insts1 /\ k.inst_id = j.inst_id /\
+             k.inst_outputs = j.inst_outputs) /\
+    (!k. MEM k insts1 ==>
+         ?j. MEM j insts2 /\ j.inst_id = k.inst_id /\
+             j.inst_outputs = k.inst_outputs) ==>
+    MAP (\i. i.inst_id)
+      (MAP THE (FILTER IS_SOME (MAP (producing_inst insts1) order))) =
+    MAP (\i. i.inst_id)
+      (MAP THE (FILTER IS_SOME (MAP (producing_inst insts2) order)))
+Proof
+  rpt strip_tac >> irule map_the_filter_id_agree >> rpt strip_tac >>
+  Cases_on `producing_inst insts1 x` >>
+  Cases_on `producing_inst insts2 x` >> simp[]
+  (* NONE/SOME on insts2: use none_agree insts1→insts2 *)
+  >- (`!j. MEM j insts2 ==> ?k. MEM k insts1 /\ k.inst_outputs = j.inst_outputs`
+       by (rpt strip_tac >> res_tac >> metis_tac[]) >>
+      drule_all producing_inst_none_agree >> gvs[])
+  (* SOME/NONE on insts2: use none_agree insts2→insts1 *)
+  >- (`!j. MEM j insts1 ==> ?k. MEM k insts2 /\ k.inst_outputs = j.inst_outputs`
+       by (rpt strip_tac >> res_tac >> metis_tac[]) >>
+      drule_all producing_inst_none_agree >> gvs[])
+  >> drule_all producing_inst_perm_id >> simp[]
+QED
+
+(* If MAP f l1 = MAP f l2, filtering by a predicate on f preserves the
+   MAP f agreement. Used for the FILTER in inst_data_deps order_deps. *)
+Triviality filter_map_agree:
+  !f P l1 l2.
+    MAP f l1 = MAP f l2 ==>
+    MAP f (FILTER (\x. P (f x)) l1) = MAP f (FILTER (\x. P (f x)) l2)
+Proof
+  Induct_on `l1` >> Cases_on `l2` >> simp[] >>
+  rpt strip_tac >> Cases_on `P (f h)` >> gvs[] >>
+  first_x_assum irule >> simp[]
+QED
+
+(* inst_data_deps returns same inst_ids for two agreeing block_insts lists *)
+Theorem inst_data_deps_id_agree:
+  !insts1 insts2 order inst.
+    unique_defs insts1 /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) insts1) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) insts2) /\
+    (!j. MEM j insts2 ==>
+         ?k. MEM k insts1 /\ k.inst_id = j.inst_id /\
+             k.inst_outputs = j.inst_outputs) /\
+    (!k. MEM k insts1 ==>
+         ?j. MEM j insts2 /\ j.inst_id = k.inst_id /\
+             j.inst_outputs = k.inst_outputs) ==>
+    MAP (\i. i.inst_id)
+      (inst_data_deps insts2 order inst) =
+    MAP (\i. i.inst_id)
+      (inst_data_deps insts1 order inst)
+Proof
+  rpt strip_tac >>
+  simp[inst_data_deps_def, LET_THM] >>
+  imp_res_tac var_deps_id_agree >>
+  imp_res_tac order_deps_id_agree >>
+  `MAP (\i. i.inst_id)
+     (FILTER (\d. d.inst_id <> inst.inst_id)
+       (MAP THE (FILTER IS_SOME (MAP (producing_inst insts2) order)))) =
+   MAP (\i. i.inst_id)
+     (FILTER (\d. d.inst_id <> inst.inst_id)
+       (MAP THE (FILTER IS_SOME (MAP (producing_inst insts1) order))))` by
+    (qspecl_then [`\d. d.inst_id`, `\x. x <> inst.inst_id`]
+       mp_tac filter_map_agree >> simp[]) >>
+  irule nub_map_agree >> rpt conj_tac
+  >- (Cases_on `is_terminator inst.inst_opcode` >> gvs[MAP_APPEND])
+  >- (mp_tac (Q.SPECL [`insts2`, `order`, `inst`] deps_list_inj) >>
+      simp[LET_THM, LIST_TO_SET_APPEND])
+  >> mp_tac (Q.SPECL [`insts1`, `order`, `inst`] deps_list_inj) >>
+  simp[LET_THM, LIST_TO_SET_APPEND]
+QED
+
+(* ================================================================
+   Effect-free instruction lemmas
+   ================================================================ *)
+
+(* Flippable opcodes are effect-free: no writes, no reads *)
+Triviality is_flippable_effect_free:
+  !op. is_flippable op ==>
+    write_effects op = {} /\ read_effects op = {}
+Proof
+  Cases >> simp[is_flippable_def, is_commutative_def, is_comparator_def,
+                write_effects_def, read_effects_def, empty_effects_def]
+QED
+
+(* Effect-free instructions are identity in compute_effect_deps *)
+Triviality compute_effect_deps_eff_free:
+  !et inst.
+    write_effects inst.inst_opcode = {} /\
+    read_effects inst.inst_opcode = {} ==>
+    compute_effect_deps et inst = ([], et)
+Proof
+  rpt strip_tac >>
+  simp[compute_effect_deps_def, LET_THM, effects_to_list_def,
+       FILTER_EQ_NIL, EVERY_MEM, MEM]
+QED
+
+(* ================================================================
+   compute_effect_deps key locality
+   ================================================================ *)
+
+(* All effect values appear in the master list *)
+Triviality effect_mem_all:
+  !e. MEM e [Eff_STORAGE; Eff_TRANSIENT; Eff_MEMORY; Eff_MSIZE;
+             Eff_IMMUTABLES; Eff_RETURNDATA; Eff_LOG; Eff_BALANCE;
+             Eff_EXTCODE]
+Proof
+  Cases >> simp[]
+QED
+
+(* MEM in effects_to_list ⟺ membership in the set *)
+Triviality mem_effects_to_list:
+  !e S. MEM e (effects_to_list S) <=> e IN S
+Proof
+  rpt gen_tac >>
+  ONCE_REWRITE_TAC[effects_to_list_def] >>
+  simp[MEM_FILTER, effect_mem_all]
+QED
+
+(* FOLDL over write effects preserves FLOOKUP at keys outside the update set *)
+Triviality foldl_write_preserves_lw:
+  !weffs et inst e. ~MEM e weffs ==>
+    FLOOKUP (FOLDL (\acc weff.
+       <| et_last_write := acc.et_last_write |+ (weff, inst);
+          et_all_reads := acc.et_all_reads |+ (weff, []) |>)
+      et weffs).et_last_write e = FLOOKUP et.et_last_write e
+Proof
+  Induct >> simp[FOLDL] >> rpt strip_tac >> fs[] >>
+  first_x_assum (qspecl_then
+    [`<| et_last_write := et.et_last_write |+ (h, inst);
+         et_all_reads := et.et_all_reads |+ (h, []) |>`,
+     `inst`, `e`] mp_tac) >> simp[FLOOKUP_UPDATE]
+QED
+
+Triviality foldl_write_preserves_ar:
+  !weffs et inst e. ~MEM e weffs ==>
+    FLOOKUP (FOLDL (\acc weff.
+       <| et_last_write := acc.et_last_write |+ (weff, inst);
+          et_all_reads := acc.et_all_reads |+ (weff, []) |>)
+      et weffs).et_all_reads e = FLOOKUP et.et_all_reads e
+Proof
+  Induct >> simp[FOLDL] >> rpt strip_tac >> fs[] >>
+  first_x_assum (qspecl_then
+    [`<| et_last_write := et.et_last_write |+ (h, inst);
+         et_all_reads := et.et_all_reads |+ (h, []) |>`,
+     `inst`, `e`] mp_tac) >> simp[FLOOKUP_UPDATE]
+QED
+
+(* FOLDL over read effects: preserves et_last_write entirely *)
+Triviality foldl_read_preserves_lw:
+  !reffs et inst.
+    (FOLDL (\acc reff.
+       acc with et_all_reads :=
+         acc.et_all_reads |+ (reff, et_get_reads acc reff ++ [inst]))
+      et reffs).et_last_write = et.et_last_write
+Proof
+  Induct >> simp[FOLDL] >> rpt gen_tac >>
+  first_x_assum (qspecl_then
+    [`et with et_all_reads :=
+        et.et_all_reads |+ (h, et_get_reads et h ++ [inst])`, `inst`] mp_tac) >>
+  simp[]
+QED
+
+(* FOLDL over read effects: preserves FLOOKUP et_all_reads at keys outside *)
+Triviality foldl_read_preserves_ar:
+  !reffs et inst e. ~MEM e reffs ==>
+    FLOOKUP (FOLDL (\acc reff.
+       acc with et_all_reads :=
+         acc.et_all_reads |+ (reff, et_get_reads acc reff ++ [inst]))
+      et reffs).et_all_reads e = FLOOKUP et.et_all_reads e
+Proof
+  Induct >> simp[FOLDL] >> rpt strip_tac >> fs[] >>
+  first_x_assum (qspecl_then
+    [`et with et_all_reads :=
+        et.et_all_reads |+ (h, et_get_reads et h ++ [inst])`,
+     `inst`, `e`] mp_tac) >> simp[FLOOKUP_UPDATE]
+QED
+
+(* Main locality lemma: compute_effect_deps preserves et keys outside
+   the instruction's write_effects ∪ read_effects *)
+Triviality compute_effect_deps_preserves_key:
+  !et inst e.
+    e NOTIN write_effects inst.inst_opcode /\
+    e NOTIN read_effects inst.inst_opcode ==>
+    FLOOKUP (SND (compute_effect_deps et inst)).et_last_write e =
+      FLOOKUP et.et_last_write e /\
+    FLOOKUP (SND (compute_effect_deps et inst)).et_all_reads e =
+      FLOOKUP et.et_all_reads e
+Proof
+  rpt strip_tac >>
+  simp[compute_effect_deps_def, LET_THM] >>
+  `~MEM e (effects_to_list (write_effects inst.inst_opcode))`
+    by simp[mem_effects_to_list] >>
+  `~MEM e (effects_to_list (read_effects inst.inst_opcode))`
+    by simp[mem_effects_to_list] >>
+  simp[foldl_read_preserves_lw, foldl_read_preserves_ar,
+       foldl_write_preserves_lw, foldl_write_preserves_ar]
+QED
+
+(* Converse of preserves_key: compute_effect_deps depends only on
+   effect keys of the instruction *)
+(* Helper: write FOLDL preserves FLOOKUP agreement at all keys *)
+Triviality foldl_write_agree:
+  !wl et1 et2 inst.
+    (!e. FLOOKUP et1.et_last_write e = FLOOKUP et2.et_last_write e /\
+         FLOOKUP et1.et_all_reads e = FLOOKUP et2.et_all_reads e) ==>
+    (!e.
+      FLOOKUP (FOLDL (\acc weff.
+         <| et_last_write := acc.et_last_write |+ (weff, inst);
+            et_all_reads := acc.et_all_reads |+ (weff, []) |>) et1 wl).et_last_write e =
+      FLOOKUP (FOLDL (\acc weff.
+         <| et_last_write := acc.et_last_write |+ (weff, inst);
+            et_all_reads := acc.et_all_reads |+ (weff, []) |>) et2 wl).et_last_write e) /\
+    (!e.
+      FLOOKUP (FOLDL (\acc weff.
+         <| et_last_write := acc.et_last_write |+ (weff, inst);
+            et_all_reads := acc.et_all_reads |+ (weff, []) |>) et1 wl).et_all_reads e =
+      FLOOKUP (FOLDL (\acc weff.
+         <| et_last_write := acc.et_last_write |+ (weff, inst);
+            et_all_reads := acc.et_all_reads |+ (weff, []) |>) et2 wl).et_all_reads e)
+Proof
+  Induct >> simp[FOLDL] >> rpt strip_tac >> (
+    first_x_assum (qspecl_then [
+      `<| et_last_write := et1.et_last_write |+ (h, inst);
+          et_all_reads := et1.et_all_reads |+ (h, []) |>`,
+      `<| et_last_write := et2.et_last_write |+ (h, inst);
+          et_all_reads := et2.et_all_reads |+ (h, []) |>`,
+      `inst`] mp_tac) >>
+    simp[] >> (impl_tac >- (gen_tac >> simp[FLOOKUP_UPDATE] >> rw[] >> simp[])) >>
+    simp[])
+QED
+
+(* Helper: read FOLDL agrees when bases agree *)
+Triviality foldl_read_agree:
+  !rl et1 et2 inst.
+    (!e. FLOOKUP et1.et_last_write e = FLOOKUP et2.et_last_write e) /\
+    (!e. FLOOKUP et1.et_all_reads e = FLOOKUP et2.et_all_reads e) ==>
+    FOLDL (\acc reff. acc with et_all_reads :=
+      acc.et_all_reads |+ (reff, (case FLOOKUP acc.et_all_reads reff of
+        NONE => [] | SOME rs => rs) ++ [inst])) et1 rl =
+    FOLDL (\acc reff. acc with et_all_reads :=
+      acc.et_all_reads |+ (reff, (case FLOOKUP acc.et_all_reads reff of
+        NONE => [] | SOME rs => rs) ++ [inst])) et2 rl
+Proof
+  Induct >> rpt strip_tac
+  >- (simp[FOLDL, effect_track_component_equality, FLOOKUP_EXT, FUN_EQ_THM])
+  >- (
+    simp[FOLDL] >> first_x_assum irule >> conj_tac
+    >- (gen_tac >> simp[foldl_read_preserves_lw])
+    >- (gen_tac >> simp[FLOOKUP_UPDATE] >> rw[] >> simp[]))
+QED
+
+Triviality compute_effect_deps_locality:
+  !et1 et2 inst.
+    (!e. FLOOKUP et1.et_last_write e = FLOOKUP et2.et_last_write e /\
+         FLOOKUP et1.et_all_reads e = FLOOKUP et2.et_all_reads e) ==>
+    compute_effect_deps et1 inst = compute_effect_deps et2 inst
+Proof
+  rpt strip_tac >>
+  simp[compute_effect_deps_def, LET_THM, et_get_reads_def] >>
+  irule foldl_read_agree >>
+  mp_tac (Q.SPECL [`effects_to_list (write_effects inst.inst_opcode)`,
+                    `et1`, `et2`, `inst`] foldl_write_agree) >>
+  simp[]
+QED
+
+(* ================================================================
+   build_eda: tracking state depends only on effect-ful subsequence
+   ================================================================ *)
+
+(* Predicate: instruction has non-empty effects *)
+Definition has_effects_def:
+  has_effects i <=> write_effects i.inst_opcode <> {} \/
+                    read_effects i.inst_opcode <> {}
+End
+
+(* Define the FOLDL step function used in build_eda *)
+Definition eda_fold_step_def:
+  eda_fold_step (acc_map, et) inst =
+    let (deps, et') = compute_effect_deps et inst in
+    (acc_map |+ (inst.inst_id, deps), et')
+End
+
+(* The SND of eda_fold_step doesn't depend on the map accumulator *)
+Triviality eda_fold_step_snd:
+  !acc et inst. SND (eda_fold_step (acc, et) inst) = SND (compute_effect_deps et inst)
+Proof
+  rpt gen_tac >> simp[eda_fold_step_def, LET_THM] >>
+  Cases_on `compute_effect_deps et inst` >> simp[]
+QED
+
+(* Corollary: SND of FOLDL doesn't depend on the map accumulator *)
+Triviality eda_foldl_snd_acc_irrel:
+  !insts acc1 acc2 et.
+    SND (FOLDL eda_fold_step (acc1, et) insts) =
+    SND (FOLDL eda_fold_step (acc2, et) insts)
+Proof
+  Induct >> simp[FOLDL] >>
+  rpt gen_tac >>
+  `SND (eda_fold_step (acc1,et) h) = SND (eda_fold_step (acc2,et) h)` by
+    simp[eda_fold_step_snd] >>
+  Cases_on `eda_fold_step (acc1,et) h` >>
+  Cases_on `eda_fold_step (acc2,et) h` >>
+  fs[]
+QED
+
+(* The tracking state (SND of fold) is unchanged by effect-free instructions,
+   and the map entry for that instruction is []. *)
+Triviality eda_fold_eff_free_snd:
+  !insts acc et.
+    EVERY (\i. write_effects i.inst_opcode = {} /\
+               read_effects i.inst_opcode = {}) insts ==>
+    SND (FOLDL eda_fold_step (acc, et) insts) = et
+Proof
+  Induct >> simp[FOLDL, eda_fold_step_def, LET_THM] >>
+  rpt strip_tac >> imp_res_tac compute_effect_deps_eff_free >> simp[]
+QED
+
+(* Interleaving effect-free instructions preserves the tracking state
+   and produces the same deps for effect-ful instructions.
+
+   Key property: if we partition the instruction list into effect-ful
+   and effect-free, the fold's tracking state trajectory depends only
+   on the effect-ful subsequence.
+
+   We prove: for any instruction list, the SND of the fold equals
+   the SND of the fold over just the effect-ful instructions. *)
+Triviality eda_fold_snd_filter:
+  !insts acc et.
+    SND (FOLDL eda_fold_step (acc, et) insts) =
+    SND (FOLDL eda_fold_step (acc, et)
+      (FILTER (\i. write_effects i.inst_opcode <> {} \/
+                    read_effects i.inst_opcode <> {}) insts))
+Proof
+  Induct >- simp[] >>
+  rpt gen_tac >>
+  ONCE_REWRITE_TAC[rich_listTheory.FOLDL] >>
+  ONCE_REWRITE_TAC[FILTER] >>
+  BETA_TAC >>
+  Cases_on `write_effects h.inst_opcode <> {} \/ read_effects h.inst_opcode <> {}` >>
+  fs[] >| [
+    (* h has effects — IH applies directly after splitting the pair *)
+    Cases_on `eda_fold_step (acc,et) h` >> simp[],
+    (* h is effect-free — eda_fold_step changes only acc, not et *)
+    imp_res_tac compute_effect_deps_eff_free >>
+    simp[eda_fold_step_def, LET_THM] >>
+    metis_tac[eda_foldl_snd_acc_irrel]
+  ]
+QED
+
+(* ================================================================
+   Per-key tracking state factorization
+   ================================================================ *)
+
+(* Deps-only locality: FST depends only on effect keys *)
+Triviality compute_effect_deps_fst_locality:
+  !et1 et2 inst.
+    (!e. e IN write_effects inst.inst_opcode \/
+         e IN read_effects inst.inst_opcode ==>
+      FLOOKUP et1.et_last_write e = FLOOKUP et2.et_last_write e /\
+      FLOOKUP et1.et_all_reads e = FLOOKUP et2.et_all_reads e) ==>
+    FST (compute_effect_deps et1 inst) = FST (compute_effect_deps et2 inst)
+Proof
+  rpt strip_tac >>
+  `(!e. MEM e (effects_to_list (write_effects inst.inst_opcode)) ==>
+    FLOOKUP et1.et_last_write e = FLOOKUP et2.et_last_write e /\
+    FLOOKUP et1.et_all_reads e = FLOOKUP et2.et_all_reads e) /\
+   (!e. MEM e (effects_to_list (read_effects inst.inst_opcode)) ==>
+    FLOOKUP et1.et_last_write e = FLOOKUP et2.et_last_write e /\
+    FLOOKUP et1.et_all_reads e = FLOOKUP et2.et_all_reads e)` by (
+    conj_tac >> gen_tac >> strip_tac >> first_x_assum match_mp_tac >>
+    pop_assum mp_tac >> ONCE_REWRITE_TAC[effects_to_list_def] >>
+    simp[MEM_FILTER]) >>
+  simp[compute_effect_deps_def, LET_THM, et_get_reads_def] >>
+  AP_TERM_TAC >>
+  `MAP (\weff.
+      (case FLOOKUP et1.et_all_reads weff of NONE => [] | SOME rs => rs) ++
+      (if weff = Eff_MSIZE then []
+       else case FLOOKUP et1.et_last_write weff of NONE => [] | SOME w => [w]))
+    (effects_to_list (write_effects inst.inst_opcode)) =
+   MAP (\weff.
+      (case FLOOKUP et2.et_all_reads weff of NONE => [] | SOME rs => rs) ++
+      (if weff = Eff_MSIZE then []
+       else case FLOOKUP et2.et_last_write weff of NONE => [] | SOME w => [w]))
+    (effects_to_list (write_effects inst.inst_opcode))` by (
+    irule MAP_CONG >> simp[] >> rpt strip_tac >> res_tac >> simp[]) >>
+  `MAP (\reff. case FLOOKUP et1.et_last_write reff of
+      NONE => NONE | SOME writer =>
+        if writer.inst_id <> inst.inst_id then SOME writer else NONE)
+    (effects_to_list (read_effects inst.inst_opcode)) =
+   MAP (\reff. case FLOOKUP et2.et_last_write reff of
+      NONE => NONE | SOME writer =>
+        if writer.inst_id <> inst.inst_id then SOME writer else NONE)
+    (effects_to_list (read_effects inst.inst_opcode))` by (
+    irule MAP_CONG >> simp[] >> rpt strip_tac >> res_tac >> simp[]) >>
+  simp[]
+QED
+
+(* Per-key write FOLDL: at MEM key, result is SOME inst / SOME [] *)
+Triviality foldl_write_at_mem_lw:
+  !wl et inst e. MEM e wl ==>
+    FLOOKUP (FOLDL (\acc weff.
+       <| et_last_write := acc.et_last_write |+ (weff, inst);
+          et_all_reads := acc.et_all_reads |+ (weff, []) |>) et wl).et_last_write e =
+    SOME inst
+Proof
+  Induct >> simp[FOLDL] >> rpt strip_tac >> gvs[] >>
+  Cases_on `MEM e wl`
+  >- (first_x_assum irule >> simp[])
+  >- simp[foldl_write_preserves_lw, FLOOKUP_UPDATE]
+QED
+
+Triviality foldl_write_at_mem_ar:
+  !wl et inst e. MEM e wl ==>
+    FLOOKUP (FOLDL (\acc weff.
+       <| et_last_write := acc.et_last_write |+ (weff, inst);
+          et_all_reads := acc.et_all_reads |+ (weff, []) |>) et wl).et_all_reads e =
+    SOME []
+Proof
+  Induct >> simp[FOLDL] >> rpt strip_tac >> gvs[] >>
+  Cases_on `MEM e wl`
+  >- (first_x_assum irule >> simp[])
+  >- simp[foldl_write_preserves_ar, FLOOKUP_UPDATE]
+QED
+
+
+(* ================================================================
+   build_eda agreement: same effect-ful subsequence => same result
+   ================================================================ *)
+
+
+
+(* Effect-free instructions add (id, []) and don't change tracking state *)
+Triviality eda_fold_step_eff_free:
+  !acc et inst.
+    ~has_effects inst ==>
+    eda_fold_step (acc, et) inst = (acc |+ (inst.inst_id, []), et)
+Proof
+  rpt strip_tac >>
+  fs[has_effects_def, eda_fold_step_def, LET_THM] >>
+  imp_res_tac compute_effect_deps_eff_free >> simp[]
+QED
+
+(* FOLDL over effect-free instructions: each adds (id, []) to the map,
+   tracking state unchanged *)
+Triviality eda_foldl_eff_free:
+  !insts acc et.
+    EVERY (\i. ~has_effects i) insts ==>
+    FOLDL eda_fold_step (acc, et) insts =
+    (FOLDL (\m i. m |+ (i.inst_id, [])) acc insts, et)
+Proof
+  Induct >> simp[FOLDL] >>
+  rpt strip_tac >>
+  `eda_fold_step (acc, et) h = (acc |+ (h.inst_id, []), et)` by
+    metis_tac[eda_fold_step_eff_free] >>
+  simp[]
+QED
+
+(* Key lemma: if effect-free inst_id doesn't appear in the effect-ful
+   subsequence, adding (id,[]) before the fold = adding after *)
+Triviality eda_foldl_fst_acc_update:
+  !insts acc et k.
+    ALL_DISTINCT (MAP (\i. i.inst_id) insts) /\
+    ~MEM k (MAP (\i. i.inst_id) insts) ==>
+    FST (FOLDL eda_fold_step (acc |+ (k, ([] : instruction list)), et) insts) =
+    FST (FOLDL eda_fold_step (acc, et) insts) |+ (k, [])
+Proof
+  Induct >- simp[FOLDL] >>
+  rpt strip_tac >>
+  ONCE_REWRITE_TAC[FOLDL] >>
+  simp[eda_fold_step_def, LET_THM] >>
+  Cases_on `compute_effect_deps et h` >>
+  rename1 `_ = (d, et2)` >> simp[] >>
+  `k <> h.inst_id` by (fs[MAP, MEM]) >>
+  `~MEM k (MAP (\i. i.inst_id) insts)` by (fs[MAP, MEM]) >>
+  `ALL_DISTINCT (MAP (\i. i.inst_id) insts)` by (fs[MAP, ALL_DISTINCT]) >>
+  `(acc |+ (k, ([] : instruction list)) |+ (h.inst_id, d)) =
+   (acc |+ (h.inst_id, d) |+ (k, []))` by
+    simp[FUPDATE_COMMUTES] >>
+  pop_assum (fn th => REWRITE_TAC[th]) >>
+  first_x_assum (qspecl_then [`acc |+ (h.inst_id, d)`, `et2`, `k`] mp_tac) >>
+  simp[]
+QED
+
+Theorem all_distinct_map_filter:
+  !f P l. ALL_DISTINCT (MAP f l) ==> ALL_DISTINCT (MAP f (FILTER P l))
+Proof
+  Induct_on `l` >> simp[FILTER] >>
+  rpt strip_tac >> Cases_on `P h` >> simp[MAP] >> fs[MEM_MAP, MEM_FILTER] >>
+  metis_tac[]
+QED
+
+(* Decomposition: FOLDL over full list = FOLDL over effect-ful + empty entries.
+   Requires ALL_DISTINCT so effect-free updates commute past effect-ful ones. *)
+Triviality eda_foldl_fst_decompose:
+  !insts acc et.
+    ALL_DISTINCT (MAP (\i. i.inst_id) insts) ==>
+    FST (FOLDL eda_fold_step (acc, et) insts) =
+    FOLDL (\m id. m |+ (id, ([] : instruction list)))
+      (FST (FOLDL eda_fold_step (acc, et) (FILTER has_effects insts)))
+      (MAP (\i. i.inst_id) (FILTER ($~ o has_effects) insts))
+Proof
+  Induct >- simp[FOLDL] >>
+  rpt strip_tac >>
+  fs[ALL_DISTINCT, MAP] >>
+  Cases_on `has_effects h`
+  >- (
+    (* h has effects: it stays in both FILTERs *)
+    simp[FILTER] >>
+    ONCE_REWRITE_TAC[FOLDL] >>
+    Cases_on `eda_fold_step (acc, et) h` >>
+    rename1 `_ = (acc2, et2)` >> simp[] >>
+    (* IH: the fold over tl decomposes *)
+    first_x_assum (qspecl_then [`acc2`, `et2`] mp_tac) >> simp[]
+  )
+  >- (
+    (* h is effect-free: adds (h.inst_id, []) to map, tracking state unchanged *)
+    simp[FILTER] >>
+    `eda_fold_step (acc, et) h = (acc |+ (h.inst_id, ([] : instruction list)), et)` by
+      metis_tac[eda_fold_step_eff_free] >>
+    ONCE_REWRITE_TAC[FOLDL] >> simp[] >>
+    (* Apply IH to the tail with updated accumulator *)
+    first_x_assum (qspecl_then [`acc |+ (h.inst_id, [])`, `et`] mp_tac) >>
+    simp[] >> strip_tac >>
+    (* Need: FST(FOLDL ... (acc |+ (h.inst_id,[]), et) (FILTER has_effects insts))
+             = FST(FOLDL ... (acc, et) (FILTER has_effects insts)) |+ (h.inst_id, []) *)
+    `~MEM h.inst_id (MAP (\i. i.inst_id) (FILTER has_effects insts))` by (
+      CCONTR_TAC >> fs[] >>
+      `MEM h.inst_id (MAP (\i. i.inst_id) insts)` suffices_by fs[] >>
+      fs[MEM_MAP, MEM_FILTER] >> metis_tac[]
+    ) >>
+    `ALL_DISTINCT (MAP (\i. i.inst_id) (FILTER has_effects insts))` by
+      metis_tac[all_distinct_map_filter] >>
+    drule_all eda_foldl_fst_acc_update >> strip_tac >>
+    simp[] >>
+    (* RHS: FOLDL f base (h.inst_id :: rest) = FOLDL f (base |+ (h.inst_id, [])) rest *)
+    ONCE_REWRITE_TAC[FOLDL] >> simp[]
+  )
+QED
+
+(* ===== FUPDATE_LIST order independence ===== *)
+
+(* FOLDL of constant-value updates = FUPDATE_LIST *)
+Triviality foldl_fupdate_const_to_list:
+  !ids base (v : 'b).
+    FOLDL (\m id. m |+ (id, v)) base ids =
+    base |++ MAP (\id. (id, v)) ids
+Proof
+  Induct >> simp[FOLDL, FUPDATE_LIST_THM]
+QED
+
+(* FUPDATE_LIST with constant value and ALL_DISTINCT keys:
+   lookup is determined by set membership *)
+Triviality fupdate_list_const_lookup:
+  !ids (base : 'a |-> 'b) v k.
+    ALL_DISTINCT ids /\ MEM k ids ==>
+    (base |++ MAP (\id. (id, v)) ids) ' k = v
+Proof
+  Induct >> simp[FUPDATE_LIST_THM] >>
+  rpt strip_tac >> gvs[ALL_DISTINCT] >>
+  `~MEM h (MAP FST (MAP (\id. (id,v)) ids))` by
+    simp[MAP_MAP_o, combinTheory.o_DEF] >>
+  simp[FUPDATE_LIST_APPLY_NOT_MEM, FAPPLY_FUPDATE_THM]
+QED
+
+(* Two ALL_DISTINCT lists with same set give same FUPDATE_LIST result
+   when using constant values *)
+Triviality fupdate_list_const_set_eq:
+  !ids1 ids2 (base : 'a |-> 'b) v.
+    ALL_DISTINCT ids1 /\ ALL_DISTINCT ids2 /\
+    set ids1 = set ids2 ==>
+    base |++ MAP (\id. (id, v)) ids1 =
+    base |++ MAP (\id. (id, v)) ids2
+Proof
+  rpt strip_tac >>
+  `!x. MEM x ids1 <=> MEM x ids2` by fs[EXTENSION] >>
+  rw[fmap_EXT]
+  >- simp[FDOM_FUPDATE_LIST, MAP_MAP_o, combinTheory.o_DEF, EXTENSION]
+  >- (
+    rpt strip_tac >>
+    Cases_on `MEM x ids1`
+    >- (`MEM x ids2` by metis_tac[] >> simp[fupdate_list_const_lookup])
+    >- (
+      `~MEM x ids2` by metis_tac[] >>
+      `~MEM x (MAP FST (MAP (\id. (id,v)) ids1))` by
+        simp[MAP_MAP_o, combinTheory.o_DEF] >>
+      `~MEM x (MAP FST (MAP (\id. (id,v)) ids2))` by
+        simp[MAP_MAP_o, combinTheory.o_DEF] >>
+      simp[FUPDATE_LIST_APPLY_NOT_MEM]
+    )
+  )
+QED
+
+(* FOLDL of constant-value updates with same set = same result *)
+Triviality foldl_fupdate_const_set_eq:
+  !ids1 ids2 (base : 'a |-> 'b) v.
+    ALL_DISTINCT ids1 /\ ALL_DISTINCT ids2 /\
+    set ids1 = set ids2 ==>
+    FOLDL (\m id. m |+ (id, v)) base ids1 =
+    FOLDL (\m id. m |+ (id, v)) base ids2
+Proof
+  metis_tac[foldl_fupdate_const_to_list, fupdate_list_const_set_eq]
+QED
+
+(* ===== build_eda agreement ===== *)
+
+(* Membership in MAP f (FILTER (~P) L): need injectivity for reverse direction *)
+Triviality mem_map_filter_compl:
+  !f (P : 'a -> bool) L x.
+    ALL_DISTINCT (MAP f L) ==>
+    (MEM x (MAP f (FILTER ($~ o P) L)) <=>
+     MEM x (MAP f L) /\ ~MEM x (MAP f (FILTER P L)))
+Proof
+  gen_tac >> gen_tac >> Induct >> simp[FILTER, MAP] >>
+  rpt strip_tac >> fs[ALL_DISTINCT] >>
+  Cases_on `P h` >> simp[FILTER, MAP] >> eq_tac >> rpt strip_tac >> gvs[] >>
+  `MEM (f h) (MAP f L)` suffices_by fs[] >>
+  fs[MEM_MAP, MEM_FILTER] >> metis_tac[]
+QED
+
+(* Main: two lists with same effect-ful subsequence and same id set
+   produce the same eda fold result *)
+Triviality build_eda_agree:
+  !L1 L2.
+    ALL_DISTINCT (MAP (\i. i.inst_id) L1) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) L2) /\
+    FILTER has_effects L1 = FILTER has_effects L2 /\
+    set (MAP (\i. i.inst_id) L1) = set (MAP (\i. i.inst_id) L2) ==>
+    FST (FOLDL eda_fold_step (FEMPTY, empty_effect_track) L1) =
+    FST (FOLDL eda_fold_step (FEMPTY, empty_effect_track) L2)
+Proof
+  rpt strip_tac >>
+  (* Decompose both sides via eda_foldl_fst_decompose *)
+  `FST (FOLDL eda_fold_step (FEMPTY, empty_effect_track) L1) =
+   FOLDL (\m id. m |+ (id, ([] : instruction list)))
+     (FST (FOLDL eda_fold_step (FEMPTY, empty_effect_track)
+       (FILTER has_effects L1)))
+     (MAP (\i. i.inst_id) (FILTER ($~ o has_effects) L1))` by
+    metis_tac[eda_foldl_fst_decompose] >>
+  `FST (FOLDL eda_fold_step (FEMPTY, empty_effect_track) L2) =
+   FOLDL (\m id. m |+ (id, ([] : instruction list)))
+     (FST (FOLDL eda_fold_step (FEMPTY, empty_effect_track)
+       (FILTER has_effects L2)))
+     (MAP (\i. i.inst_id) (FILTER ($~ o has_effects) L2))` by
+    metis_tac[eda_foldl_fst_decompose] >>
+  (* Effect-ful filters are equal, so bases match *)
+  simp[] >>
+  (* Effect-free id sets are equal — via membership characterization *)
+  `set (MAP (\i. i.inst_id) (FILTER ($~ o has_effects) L1)) =
+   set (MAP (\i. i.inst_id) (FILTER ($~ o has_effects) L2))` by (
+    simp[EXTENSION] >> gen_tac >>
+    simp[mem_map_filter_compl] >> fs[EXTENSION]
+  ) >>
+  (* Both id lists are ALL_DISTINCT; apply order-independence *)
+  metis_tac[all_distinct_map_filter, foldl_fupdate_const_set_eq]
+QED
+
+(* ===== build_full_eda pseudo-stripping ===== *)
+
+(* build_full_eda only depends on the non-pseudo sub-list.
+   This lets us strip pseudos and reason about the non-pseudo core. *)
+
+(* Helper: FILTER (¬is_pseudo) distributes over phis ++ nonpseudos *)
+Triviality filter_nonpseudo_append_pseudo:
+  !phis L.
+    EVERY (\i. is_pseudo i.inst_opcode) phis /\
+    EVERY (\i. ~is_pseudo i.inst_opcode) L ==>
+    FILTER (\i. ~is_pseudo i.inst_opcode) (phis ++ L) = L
+Proof
+  Induct >> simp[] >> rpt strip_tac >> gvs[] >>
+  simp[FILTER_EQ_ID]
+QED
+
+(* build_full_eda depends only on the non-pseudo sub-list.
+   Proof approach: build_full_eda is a composition of functions that each
+   begin with FILTER (¬is_pseudo) block_insts. Showing the filter result
+   is the same suffices. Use AP_TERM / CONG reasoning rather than expanding. *)
+Theorem build_full_eda_pseudo_strip:
+  !phis L.
+    EVERY (\i. is_pseudo i.inst_opcode) phis /\
+    EVERY (\i. ~is_pseudo i.inst_opcode) L ==>
+    build_full_eda (phis ++ L) = build_full_eda L
+Proof
+  rpt strip_tac >>
+  drule_all filter_nonpseudo_append_pseudo >> strip_tac >>
+  `FILTER (\i. ~is_pseudo i.inst_opcode) L = L` by
+    simp[FILTER_EQ_ID] >>
+  (* build_full_eda = add_alloca_deps bi (add_barrier_deps bi (add_abort_deps bi (build_eda bi)))
+     Each sub-function uses bi only through FILTER (¬is_pseudo) bi.
+     Since FILTER (¬is_pseudo) (phis ++ L) = L = FILTER (¬is_pseudo) L,
+     every sub-function receives the same filtered list. *)
+  `build_eda (phis ++ L) = build_eda L` by
+    simp[build_eda_def, LET_THM] >>
+  `add_abort_deps (phis ++ L) (build_eda L) =
+   add_abort_deps L (build_eda L)` by
+    simp[add_abort_deps_def, add_chain_deps_def, LET_THM] >>
+  `add_barrier_deps (phis ++ L) (add_abort_deps L (build_eda L)) =
+   add_barrier_deps L (add_abort_deps L (build_eda L))` by
+    simp[add_barrier_deps_def, add_deps_on_barrier_def,
+         add_deps_from_barrier_def, LET_THM] >>
+  `add_alloca_deps (phis ++ L)
+     (add_barrier_deps L (add_abort_deps L (build_eda L))) =
+   add_alloca_deps L
+     (add_barrier_deps L (add_abort_deps L (build_eda L)))` by
+    simp[add_alloca_deps_def, add_chain_deps_def, LET_THM] >>
+  simp[build_full_eda_def, LET_THM]
+QED
+
+val _ = export_theory();

--- a/venom/passes/dft/proofs/dftScheduleFixedScript.sml
+++ b/venom/passes/dft/proofs/dftScheduleFixedScript.sml
@@ -1,0 +1,88 @@
+(*
+ * DFT Schedule Fixed — proved utility lemmas.
+ *
+ * Note: schedule_pipeline_eq was proved FALSE.
+ * The DFS tiebreaking depends on build_eda processing order,
+ * so the pipeline is NOT invariant under instruction permutation.
+ *
+ * Kept: subset_all_distinct_inj, dfs_step_idle, funpow_dfs_step_idle,
+ *       from_block_inst_outputs, from_block_inst_id.
+ *)
+
+Theory dftScheduleFixed
+Ancestors
+  dftPipelineInvar dftStructural dftIdempotent dftDefs venomEffects
+  passSharedDefs venomInst list rich_list sorting
+  finite_map pred_set pair arithmetic
+
+(* ================================================================
+   Subset injectivity
+   ================================================================ *)
+
+Triviality subset_all_distinct_inj:
+  !L (ls : instruction list).
+    ALL_DISTINCT (MAP (\i. i.inst_id) L) /\
+    (!x. MEM x ls ==> MEM x L) ==>
+    INJ (\i:instruction. i.inst_id) (set ls) UNIV
+Proof
+  rpt strip_tac >>
+  `!x y. MEM x ls /\ MEM y ls /\ (x.inst_id = y.inst_id) ==> (x = y)` by (
+    rpt strip_tac >>
+    `MEM x L /\ MEM y L` by metis_tac[] >>
+    `?nx. nx < LENGTH L /\ (EL nx L = x)` by metis_tac[MEM_EL] >>
+    `?ny. ny < LENGTH L /\ (EL ny L = y)` by metis_tac[MEM_EL] >>
+    `EL nx (MAP (\i. i.inst_id) L) = x.inst_id` by simp[EL_MAP] >>
+    `EL ny (MAP (\i. i.inst_id) L) = y.inst_id` by simp[EL_MAP] >>
+    `nx < LENGTH (MAP (\i. i.inst_id) L)` by simp[] >>
+    `ny < LENGTH (MAP (\i. i.inst_id) L)` by simp[] >>
+    `EL nx (MAP (\i. i.inst_id) L) = EL ny (MAP (\i. i.inst_id) L)` by
+      metis_tac[] >>
+    `nx = ny` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+    metis_tac[]) >>
+  simp[INJ_DEF]
+QED
+
+(* ================================================================
+   DFS idle fixpoint
+   ================================================================ *)
+
+Theorem dfs_step_idle:
+  !L order eda om fl s.
+    s.ds_stack = [] ==>
+    dfs_step L order eda om fl s = s
+Proof
+  rw[dfs_step_def]
+QED
+
+Theorem funpow_dfs_step_idle:
+  !n L order eda om fl s.
+    s.ds_stack = [] ==>
+    FUNPOW (dfs_step L order eda om fl) n s = s
+Proof
+  Induct >> simp[FUNPOW] >> rpt strip_tac >>
+  `dfs_step L order eda om fl s = s` by simp[dfs_step_idle] >>
+  simp[]
+QED
+
+(* ================================================================
+   from_block preserves structural properties
+   ================================================================ *)
+
+Triviality from_block_inst_outputs:
+  !L i. from_block L i ==>
+    ?j. MEM j L /\ ~is_pseudo j.inst_opcode /\ i.inst_outputs = j.inst_outputs
+Proof
+  rw[from_block_def] >> gvs[]
+  >- metis_tac[]
+  >> qexists_tac `j` >> simp[flip_operands_inst_outputs]
+QED
+
+Triviality from_block_inst_id:
+  !L i. from_block L i ==>
+    ?j. MEM j L /\ ~is_pseudo j.inst_opcode /\ i.inst_id = j.inst_id
+Proof
+  rw[from_block_def] >> gvs[]
+  >- metis_tac[]
+  >> qexists_tac `j` >> simp[flip_operands_inst_id]
+QED
+

--- a/venom/passes/dft/proofs/dftStructuralScript.sml
+++ b/venom/passes/dft/proofs/dftStructuralScript.sml
@@ -1,0 +1,604 @@
+(*
+ * DFT Structural Properties
+ *
+ * Key result: dft_block output non-pseudos are (modulo flip_operands)
+ * non-pseudo instructions from the input block.
+ *)
+
+Theory dftStructural
+Ancestors
+  dftDefs venomExecSemantics venomEffects passSharedDefs venomInst
+
+(* ===== flip_operands basic properties ===== *)
+
+Theorem flip_operands_inst_id[simp]:
+  !i. (flip_operands i).inst_id = i.inst_id
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  Cases_on `is_comparator i.inst_opcode` >> simp[]
+QED
+
+Theorem flip_operands_inst_outputs[simp]:
+  !i. (flip_operands i).inst_outputs = i.inst_outputs
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  Cases_on `is_comparator i.inst_opcode` >> simp[]
+QED
+
+Theorem flip_operands_is_pseudo:
+  !i. is_pseudo (flip_operands i).inst_opcode = is_pseudo i.inst_opcode
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  Cases_on `is_comparator i.inst_opcode` >> simp[] >>
+  Cases_on `i.inst_opcode` >>
+  fs[is_comparator_def, flip_comparison_opcode_def, is_pseudo_def]
+QED
+
+(* ===== Helper lemmas ===== *)
+
+Triviality producing_inst_mem:
+  !insts var inst.
+    producing_inst insts var = SOME inst ==> MEM inst insts
+Proof
+  Induct >> rw[producing_inst_def] >>
+  BasicProvers.every_case_tac >> gvs[] >> metis_tac[]
+QED
+
+Triviality operand_producer_mem:
+  !block_insts op inst.
+    operand_producer block_insts op = SOME inst ==> MEM inst block_insts
+Proof
+  Cases_on `op` >> rw[operand_producer_def] >>
+  metis_tac[producing_inst_mem]
+QED
+
+Definition eda_wf_def:
+  eda_wf eda block_insts <=>
+    !id deps dep. FLOOKUP eda id = SOME deps /\ MEM dep deps ==>
+                  MEM dep block_insts /\ ~is_pseudo dep.inst_opcode
+End
+
+(* Updating an EDA entry preserves eda_wf if every new dep is valid *)
+Theorem eda_wf_update:
+  !eda block_insts id new_deps.
+    eda_wf eda block_insts /\
+    EVERY (\d. MEM d block_insts /\ ~is_pseudo d.inst_opcode) new_deps ==>
+    eda_wf (eda |+ (id, new_deps)) block_insts
+Proof
+  rw[eda_wf_def] >>
+  gvs[finite_mapTheory.FLOOKUP_UPDATE] >>
+  Cases_on `id = id'` >> gvs[listTheory.EVERY_MEM] >>
+  metis_tac[]
+QED
+
+Theorem inst_all_deps_mem:
+  !block_insts order eda inst dep.
+    eda_wf eda block_insts ==>
+    MEM dep (inst_all_deps block_insts order eda inst) ==>
+    MEM dep block_insts
+Proof
+  rw[inst_all_deps_def, inst_data_deps_def, eda_wf_def, LET_THM] >>
+  fs[listTheory.MEM_nub, listTheory.MEM_APPEND,
+     listTheory.MEM_MAP, listTheory.MEM_FILTER,
+     optionTheory.IS_SOME_EXISTS] >> gvs[]
+  >- metis_tac[operand_producer_mem, optionTheory.THE_DEF]
+  >- metis_tac[producing_inst_mem, optionTheory.THE_DEF]
+  >- (Cases_on `FLOOKUP eda inst.inst_id` >> gvs[] >> metis_tac[])
+  >- metis_tac[operand_producer_mem, optionTheory.THE_DEF]
+  >> Cases_on `FLOOKUP eda inst.inst_id` >> gvs[] >> metis_tac[]
+QED
+
+Triviality qsort_mem_eq:
+  !R l x. MEM x (QSORT R l) <=> MEM x l
+Proof
+  rpt gen_tac >>
+  `PERM l (QSORT R l)` by simp[sortingTheory.QSORT_PERM] >>
+  metis_tac[sortingTheory.PERM_MEM_EQ]
+QED
+
+Theorem sort_children_mem:
+  !block_insts order eda offspring_map parent children x.
+    MEM x (sort_children block_insts order eda offspring_map parent children)
+    <=> MEM x children
+Proof
+  rw[sort_children_def, LET_THM, listTheory.MEM_MAP,
+     qsort_mem_eq, indexedListsTheory.MEM_MAPi] >>
+  eq_tac >> strip_tac
+  >- (Cases_on `y` >> gvs[] >> metis_tac[listTheory.MEM_EL])
+  >> fs[listTheory.MEM_EL] >>
+  qexists_tac `(n, x)` >> simp[]
+QED
+
+(* ===== "from_block": instruction is from block_insts modulo flip ===== *)
+
+Definition from_block_def:
+  from_block block_insts i <=>
+    ?j. MEM j block_insts /\ ~is_pseudo j.inst_opcode /\
+        (i = j \/ (i = flip_operands j /\ is_flippable j.inst_opcode))
+End
+
+(* flip_operands is an involution *)
+Theorem flip_operands_involution:
+  !i. flip_operands (flip_operands i) = i
+Proof
+  rw[flip_operands_def] >>
+  Cases_on `i.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[LET_THM] >>
+  Cases_on `is_comparator i.inst_opcode` >> simp[LET_THM] >>
+  TRY (simp[instruction_component_equality] >> NO_TAC) >>
+  Cases_on `is_comparator (flip_comparison_opcode i.inst_opcode)` >>
+  simp[LET_THM, instruction_component_equality] >>
+  Cases_on `i.inst_opcode` >>
+  gvs[is_comparator_def, flip_comparison_opcode_def]
+QED
+
+(* from_block is transitive: if every non-pseudo in L1 satisfies from_block L0,
+   and from_block L1 i, then from_block L0 i *)
+Theorem from_block_trans:
+  !L0 L1 i.
+    from_block L1 i /\
+    (!j. MEM j L1 /\ ~is_pseudo j.inst_opcode ==> from_block L0 j) ==>
+    from_block L0 i
+Proof
+  rw[from_block_def] >> gvs[] >>
+  first_x_assum drule >> simp[] >> strip_tac >>
+  qexists_tac `j'` >> simp[] >>
+  metis_tac[flip_operands_involution]
+QED
+
+(* ===== DFS output subset property ===== *)
+
+(* Key insight: every DfsEmit on the stack comes from a non-pseudo instruction
+   in block_insts (possibly flipped). The DFS only emits instructions that
+   are non-pseudo members of block_insts. *)
+
+(* We prove this via a FUNPOW invariant on the DFS state.
+   Rather than decomposing into separate stack/output predicates,
+   we prove the output property directly: every element of ds_output
+   satisfies from_block and ~is_pseudo. *)
+
+(* Invariant for DFS FUNPOW proof *)
+Definition dfs_good_state_def:
+  dfs_good_state block_insts st <=>
+    EVERY (\item. case item of
+      | DfsEmit i => from_block block_insts i /\ ~is_pseudo i.inst_opcode
+      | DfsProcess i => MEM i block_insts) st.ds_stack /\
+    EVERY (\i. from_block block_insts i /\ ~is_pseudo i.inst_opcode) st.ds_output
+End
+
+(* dfs_step preserves good_state *)
+Theorem dfs_step_preserves_good:
+  !block_insts order eda offspring_map do_flip st.
+    eda_wf eda block_insts ==>
+    dfs_good_state block_insts st ==>
+    dfs_good_state block_insts
+      (dfs_step block_insts order eda offspring_map do_flip st)
+Proof
+  simp[dfs_good_state_def] >> rpt strip_tac >>
+  simp[Once dfs_step_def] >>
+  Cases_on `st.ds_stack` >> gvs[] >>
+  Cases_on `h` >> gvs[listTheory.EVERY_DEF, listTheory.EVERY_APPEND]
+  >> rename1 `DfsProcess inst` >>
+  IF_CASES_TAC >> gvs[] >>
+  IF_CASES_TAC >> gvs[] >>
+  simp[LET_THM, listTheory.EVERY_APPEND, listTheory.EVERY_MAP,
+       listTheory.EVERY_MEM] >>
+  rpt strip_tac >>
+  TRY (fs[sort_children_mem] >> metis_tac[inst_all_deps_mem]) >>
+  TRY (simp[from_block_def] >>
+       BasicProvers.every_case_tac >> simp[] >> metis_tac[]) >>
+  TRY (BasicProvers.every_case_tac >> simp[flip_operands_is_pseudo]) >>
+  gvs[listTheory.EVERY_MEM, flip_operands_is_pseudo]
+QED
+
+(* FUNPOW preserves good_state *)
+Theorem dfs_funpow_preserves_good:
+  !n block_insts order eda offspring_map do_flip st.
+    eda_wf eda block_insts ==>
+    dfs_good_state block_insts st ==>
+    dfs_good_state block_insts
+      (FUNPOW (dfs_step block_insts order eda offspring_map do_flip) n st)
+Proof
+  Induct >> simp[arithmeticTheory.FUNPOW_0] >>
+  rpt strip_tac >> simp[arithmeticTheory.FUNPOW_SUC] >>
+  irule dfs_step_preserves_good >> simp[]
+QED
+
+(* Initial state is good *)
+Theorem init_dfs_state_good:
+  !entries block_insts.
+    EVERY (\i. MEM i block_insts) entries ==>
+    dfs_good_state block_insts
+      <| ds_stack := MAP DfsProcess entries;
+         ds_output := []; ds_visited := [] |>
+Proof
+  rw[dfs_good_state_def, listTheory.EVERY_MAP, listTheory.EVERY_MEM] >>
+  rpt strip_tac >> gvs[listTheory.MEM_MAP]
+QED
+
+Theorem schedule_output_from_block:
+  !block_insts order eda offspring_map entries i.
+    eda_wf eda block_insts ==>
+    EVERY (\i. MEM i block_insts) entries ==>
+    MEM i (schedule_from_entries block_insts order eda offspring_map entries) ==>
+    from_block block_insts i /\ ~is_pseudo i.inst_opcode
+Proof
+  rw[schedule_from_entries_def, LET_THM] >>
+  `dfs_good_state block_insts
+     (FUNPOW (dfs_step block_insts order eda offspring_map T)
+        ((LENGTH block_insts + 1) * (LENGTH block_insts + 1))
+        <| ds_stack := MAP DfsProcess entries;
+           ds_output := []; ds_visited := [] |>)` by
+    (irule dfs_funpow_preserves_good >> simp[] >>
+     irule init_dfs_state_good >> simp[]) >>
+  gvs[dfs_good_state_def, listTheory.EVERY_MEM]
+QED
+
+(* ===== build_eda produces well-formed EDA ===== *)
+
+(* Effect tracking well-formedness: all stored instructions are from block
+   and non-pseudo (build_eda only processes non-pseudo instructions) *)
+Definition et_wf_def:
+  et_wf et block_insts <=>
+    (!eff w. FLOOKUP et.et_last_write eff = SOME w ==>
+             MEM w block_insts /\ ~is_pseudo w.inst_opcode) /\
+    (!eff rs r. FLOOKUP et.et_all_reads eff = SOME rs /\ MEM r rs ==>
+                MEM r block_insts /\ ~is_pseudo r.inst_opcode)
+End
+
+(* Helper: second FOLDL (reads) preserves et_last_write *)
+Theorem read_foldl_last_write:
+  !effs acc inst.
+    (FOLDL (\acc reff.
+       acc with et_all_reads :=
+         acc.et_all_reads |+ (reff, et_get_reads acc reff ++ [inst]))
+       acc effs).et_last_write = acc.et_last_write
+Proof
+  Induct >> simp[]
+QED
+
+(* Helper: write FOLDL stores inst in last_write, everything else from et *)
+Theorem write_foldl_last_write:
+  !effs et inst eff w.
+    FLOOKUP (FOLDL (\acc weff.
+       <| et_last_write := acc.et_last_write |+ (weff, inst);
+          et_all_reads := acc.et_all_reads |+ (weff, []) |>)
+       et effs).et_last_write eff = SOME w ==>
+    w = inst \/ FLOOKUP et.et_last_write eff = SOME w
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  first_x_assum (qspecl_then
+    [`<| et_last_write := et.et_last_write |+ (h, inst);
+         et_all_reads := et.et_all_reads |+ (h, []) |>`,
+     `inst`, `eff`, `w`] mp_tac) >>
+  simp[] >> strip_tac >> gvs[finite_mapTheory.FLOOKUP_UPDATE] >>
+  BasicProvers.every_case_tac >> gvs[]
+QED
+
+(* Helper: write FOLDL clears reads *)
+Theorem write_foldl_all_reads:
+  !effs et inst eff rs.
+    FLOOKUP (FOLDL (\acc weff.
+       <| et_last_write := acc.et_last_write |+ (weff, inst);
+          et_all_reads := acc.et_all_reads |+ (weff, []) |>)
+       et effs).et_all_reads eff = SOME rs ==>
+    rs = [] \/ FLOOKUP et.et_all_reads eff = SOME rs
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  first_x_assum (qspecl_then
+    [`<| et_last_write := et.et_last_write |+ (h, inst);
+         et_all_reads := et.et_all_reads |+ (h, []) |>`,
+     `inst`, `eff`, `rs`] mp_tac) >>
+  simp[] >> strip_tac >> gvs[finite_mapTheory.FLOOKUP_UPDATE] >>
+  BasicProvers.every_case_tac >> gvs[]
+QED
+
+(* Helper: read FOLDL stores inst in reads, rest from input *)
+Theorem read_foldl_all_reads:
+  !effs acc inst eff rs r.
+    FLOOKUP (FOLDL (\acc reff.
+       acc with et_all_reads :=
+         acc.et_all_reads |+ (reff, et_get_reads acc reff ++ [inst]))
+       acc effs).et_all_reads eff = SOME rs /\ MEM r rs ==>
+    r = inst \/ (?rs0. FLOOKUP acc.et_all_reads eff = SOME rs0 /\ MEM r rs0)
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  first_x_assum (qspecl_then
+    [`acc with et_all_reads :=
+        acc.et_all_reads |+ (h, et_get_reads acc h ++ [inst])`,
+     `inst`, `eff`, `rs`, `r`] mp_tac) >>
+  simp[] >> strip_tac >> gvs[finite_mapTheory.FLOOKUP_UPDATE, et_get_reads_def] >>
+  BasicProvers.every_case_tac >> gvs[listTheory.MEM_APPEND]
+QED
+
+(* compute_effect_deps: deps come from et, and et' stores inst.
+   Non-pseudo: deps from et are non-pseudo (et_wf), et' stores inst (non-pseudo). *)
+Theorem compute_effect_deps_wf:
+  !et inst deps et' block_insts.
+    compute_effect_deps et inst = (deps, et') /\
+    et_wf et block_insts /\
+    MEM inst block_insts /\ ~is_pseudo inst.inst_opcode ==>
+    (!d. MEM d deps ==> MEM d block_insts /\ ~is_pseudo d.inst_opcode) /\
+    et_wf et' block_insts
+Proof
+  rpt gen_tac \\ strip_tac \\
+  fs[compute_effect_deps_def, LET_THM] \\
+  rpt (pairarg_tac \\ fs[]) \\
+  fs[et_wf_def] \\
+  conj_tac
+  >- (rpt strip_tac \\
+      gvs[listTheory.MEM_FLAT, listTheory.MEM_MAP, listTheory.MEM_nub,
+          listTheory.MEM_APPEND, et_get_reads_def,
+          listTheory.MEM_FILTER, optionTheory.IS_SOME_EXISTS] \\
+      BasicProvers.every_case_tac \\ gvs[] \\ metis_tac[])
+  \\ rpt strip_tac \\ rpt BasicProvers.VAR_EQ_TAC
+  \\ fs[read_foldl_last_write]
+  \\ TRY (drule write_foldl_last_write \\ strip_tac \\ gvs[] \\ metis_tac[])
+  \\ drule_all read_foldl_all_reads \\ strip_tac \\ gvs[]
+  \\ TRY (metis_tac[])
+  \\ drule_all write_foldl_all_reads \\ strip_tac \\ gvs[] \\ metis_tac[]
+QED
+
+Triviality build_eda_foldl_inv:
+  !non_phis block_insts acc et.
+    et_wf et block_insts /\
+    (!id deps dep. FLOOKUP acc id = SOME deps /\ MEM dep deps ==>
+                   MEM dep block_insts /\ ~is_pseudo dep.inst_opcode) /\
+    EVERY (\i. MEM i block_insts /\ ~is_pseudo i.inst_opcode) non_phis ==>
+    !id deps dep.
+      FLOOKUP (FST (FOLDL (\(acc_map, et) inst.
+        (\(deps, et'). (acc_map |+ (inst.inst_id, deps), et'))
+          (compute_effect_deps et inst))
+        (acc, et) non_phis)) id = SOME deps /\ MEM dep deps ==>
+      MEM dep block_insts /\ ~is_pseudo dep.inst_opcode
+Proof
+  Induct
+  >- (simp[] >> metis_tac[])
+  >> rpt gen_tac >> strip_tac
+  >> fs[listTheory.EVERY_DEF]
+  >> Cases_on `compute_effect_deps et h`
+  >> rename1 `compute_effect_deps et h = (nd, ne)`
+  >> `(!d. MEM d nd ==> MEM d block_insts /\ ~is_pseudo d.inst_opcode) /\
+      et_wf ne block_insts` by
+       (irule compute_effect_deps_wf >> qexistsl [`et`, `h`] >> simp[])
+  >> first_x_assum (qspecl_then [`block_insts`, `acc |+ (h.inst_id, nd)`, `ne`] mp_tac)
+  >> impl_tac
+  >- (rpt strip_tac
+      >- simp[]
+      >> gvs[finite_mapTheory.FLOOKUP_UPDATE]
+      >> BasicProvers.every_case_tac >> gvs[] >> metis_tac[])
+  >> simp[]
+QED
+
+Theorem build_eda_wf:
+  !block_insts. eda_wf (build_eda block_insts) block_insts
+Proof
+  simp[eda_wf_def, build_eda_def, LET_THM] >>
+  gen_tac >>
+  mp_tac (Q.SPECL [`FILTER (\ i. ~is_pseudo i.inst_opcode) block_insts`,
+                    `block_insts`, `FEMPTY`, `empty_effect_track`]
+          build_eda_foldl_inv) >>
+  impl_tac
+  >- simp[et_wf_def, empty_effect_track_def, finite_mapTheory.FLOOKUP_DEF,
+          listTheory.EVERY_FILTER, listTheory.EVERY_MEM]
+  >> metis_tac[]
+QED
+
+(* ===== add_chain_deps preserves eda_wf ===== *)
+
+Triviality add_chain_deps_foldl_wf:
+  !matching block_insts acc prev.
+    eda_wf acc block_insts /\
+    EVERY (\i. MEM i block_insts /\ ~is_pseudo i.inst_opcode) matching /\
+    (!p. prev = SOME p ==>
+         MEM p block_insts /\ ~is_pseudo p.inst_opcode) ==>
+    eda_wf (FST (FOLDL (\(acc, prev) inst.
+      let old_deps = case FLOOKUP acc inst.inst_id of
+                       NONE => [] | SOME ds => ds in
+      let new_deps = case prev of
+                       NONE => old_deps
+                     | SOME p => if MEM p old_deps then old_deps
+                                 else p :: old_deps in
+      (acc |+ (inst.inst_id, new_deps), SOME inst))
+    (acc, prev) matching)) block_insts
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  gvs[listTheory.EVERY_DEF] >>
+  first_x_assum irule >> simp[] >>
+  simp[eda_wf_def] >> rpt strip_tac >>
+  gvs[finite_mapTheory.FLOOKUP_UPDATE] >>
+  Cases_on `h.inst_id = id` >> gvs[] >>
+  Cases_on `prev` >> gvs[] >>
+  BasicProvers.every_case_tac >> gvs[eda_wf_def] >>
+  metis_tac[]
+QED
+
+Theorem add_chain_deps_wf:
+  !P block_insts eda.
+    eda_wf eda block_insts ==>
+    eda_wf (add_chain_deps P block_insts eda) block_insts
+Proof
+  rw[add_chain_deps_def, LET_THM] >>
+  irule (SRULE [LET_THM] add_chain_deps_foldl_wf) >>
+  simp[listTheory.EVERY_FILTER, listTheory.EVERY_MEM,
+       listTheory.MEM_FILTER]
+QED
+
+(* ===== add_barrier_deps preserves eda_wf ===== *)
+
+(* Helper: membership in FOLDL that adds list elements *)
+Triviality foldl_add_mem:
+  !prev init x.
+    MEM x (FOLDL (\ds (p:instruction). if MEM p ds then ds else p :: ds)
+             init prev) ==>
+    MEM x init \/ MEM x prev
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  Cases_on `MEM h init` >> gvs[] >>
+  first_x_assum drule >> strip_tac >> gvs[]
+QED
+
+(* Pass 1 wf: add_deps_on_barrier only adds last_bar as dep *)
+Triviality add_deps_on_barrier_foldl_wf:
+  !non_phis block_insts acc last_bar.
+    eda_wf acc block_insts /\
+    EVERY (\i. MEM i block_insts /\ ~is_pseudo i.inst_opcode) non_phis /\
+    (!b. last_bar = SOME b ==>
+         MEM b block_insts /\ ~is_pseudo b.inst_opcode) ==>
+    eda_wf (FST (FOLDL (\(acc, last_bar) inst.
+      let old_deps = case FLOOKUP acc inst.inst_id of
+                       NONE => [] | SOME ds => ds in
+      if is_barrier inst then
+        (acc, SOME inst)
+      else
+        let new_deps = case last_bar of
+                         NONE => old_deps
+                       | SOME b => if MEM b old_deps then old_deps
+                                   else b :: old_deps in
+        (acc |+ (inst.inst_id, new_deps), last_bar))
+    (acc, last_bar) non_phis)) block_insts
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  gvs[listTheory.EVERY_DEF] >>
+  Cases_on `is_barrier h` >> gvs[] >>
+  first_x_assum irule >> simp[] >>
+  irule eda_wf_update >>
+  Cases_on `last_bar` >> gvs[] >>
+  BasicProvers.every_case_tac >> gvs[] >>
+  simp[listTheory.EVERY_DEF] >>
+  gvs[eda_wf_def, listTheory.EVERY_MEM] >>
+  metis_tac[]
+QED
+
+Theorem add_deps_on_barrier_wf:
+  !block_insts eda.
+    eda_wf eda block_insts ==>
+    eda_wf (add_deps_on_barrier block_insts eda) block_insts
+Proof
+  rw[add_deps_on_barrier_def] >>
+  irule (SRULE [LET_THM] add_deps_on_barrier_foldl_wf) >>
+  simp[listTheory.EVERY_FILTER, listTheory.EVERY_MEM,
+       listTheory.MEM_FILTER]
+QED
+
+(* Pass 2 wf: add_deps_from_barrier adds prev_insts as deps for barriers *)
+Triviality add_deps_from_barrier_foldl_wf:
+  !non_phis block_insts acc prev_insts.
+    eda_wf acc block_insts /\
+    EVERY (\i. MEM i block_insts /\ ~is_pseudo i.inst_opcode) non_phis /\
+    EVERY (\i. MEM i block_insts /\ ~is_pseudo i.inst_opcode) prev_insts ==>
+    eda_wf (FST (FOLDL (\(acc, prev_insts) inst.
+      if is_barrier inst then
+        let old_deps = case FLOOKUP acc inst.inst_id of
+                         NONE => [] | SOME ds => ds in
+        let new_deps = FOLDL (\ds p.
+              if MEM p ds then ds else p :: ds) old_deps prev_insts in
+        (acc |+ (inst.inst_id, new_deps), prev_insts ++ [inst])
+      else
+        (acc, prev_insts ++ [inst]))
+    (acc, prev_insts) non_phis)) block_insts
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  gvs[listTheory.EVERY_DEF] >>
+  Cases_on `is_barrier h` >> gvs[] >>
+  first_x_assum irule >>
+  simp[listTheory.EVERY_APPEND, listTheory.EVERY_DEF] >>
+  irule eda_wf_update >>
+  `!x. MEM x (FOLDL (\ds p. if MEM p ds then ds else p :: ds)
+         (case FLOOKUP acc h.inst_id of NONE => [] | SOME ds => ds)
+         prev_insts) ==>
+       MEM x block_insts /\ ~is_pseudo x.inst_opcode` by
+    (rpt strip_tac >> drule foldl_add_mem >> strip_tac >> gvs[] >>
+     BasicProvers.every_case_tac >> gvs[] >>
+     gvs[listTheory.EVERY_MEM] >> metis_tac[eda_wf_def]) >>
+  simp[listTheory.EVERY_MEM]
+QED
+
+Theorem add_deps_from_barrier_wf:
+  !block_insts eda.
+    eda_wf eda block_insts ==>
+    eda_wf (add_deps_from_barrier block_insts eda) block_insts
+Proof
+  rw[add_deps_from_barrier_def] >>
+  irule (SRULE [LET_THM] add_deps_from_barrier_foldl_wf) >>
+  simp[listTheory.EVERY_FILTER, listTheory.EVERY_MEM,
+       listTheory.MEM_FILTER]
+QED
+
+Theorem add_barrier_deps_wf:
+  !block_insts eda.
+    eda_wf eda block_insts ==>
+    eda_wf (add_barrier_deps block_insts eda) block_insts
+Proof
+  rw[add_barrier_deps_def] >>
+  irule add_deps_from_barrier_wf >>
+  irule add_deps_on_barrier_wf >> simp[]
+QED
+
+Theorem build_full_eda_wf:
+  !block_insts. eda_wf (build_full_eda block_insts) block_insts
+Proof
+  rw[build_full_eda_def, add_alloca_deps_def, add_abort_deps_def] >>
+  irule add_chain_deps_wf >>
+  irule add_barrier_deps_wf >>
+  irule add_chain_deps_wf >>
+  simp[build_eda_wf]
+QED
+
+(* ===== entry_instructions are from block_insts ===== *)
+
+Theorem entry_instructions_mem:
+  !block_insts order eda.
+    EVERY (\i. MEM i block_insts) (entry_instructions block_insts order eda)
+Proof
+  rw[entry_instructions_def, LET_THM, listTheory.EVERY_FILTER,
+     listTheory.EVERY_MEM, listTheory.MEM_FILTER]
+QED
+
+(* ===== dft_block output non-pseudos are from original block ===== *)
+
+Theorem dft_block_from_orig:
+  !order bb i.
+    MEM i (FILTER (\i. ~is_pseudo i.inst_opcode)
+             (dft_block order bb).bb_instructions) ==>
+    from_block bb.bb_instructions i
+Proof
+  rpt strip_tac >>
+  fs[dft_block_def, LET_THM, listTheory.MEM_FILTER, listTheory.MEM_APPEND]
+  (* pseudo case: contradicts ~is_pseudo *)
+  >- gvs[listTheory.MEM_FILTER]
+  (* scheduled case *)
+  >> metis_tac[schedule_output_from_block, build_full_eda_wf, entry_instructions_mem]
+QED
+
+(* ===== Phis are preserved by dft_block ===== *)
+
+Theorem dft_block_phis:
+  !order bb.
+    FILTER (\i. is_pseudo i.inst_opcode) (dft_block order bb).bb_instructions =
+    FILTER (\i. is_pseudo i.inst_opcode) bb.bb_instructions
+Proof
+  rw[dft_block_def, LET_THM, rich_listTheory.FILTER_APPEND] >>
+  simp[rich_listTheory.FILTER_FILTER] >>
+  `FILTER (\i. is_pseudo i.inst_opcode)
+    (schedule_from_entries bb.bb_instructions order
+      (build_full_eda bb.bb_instructions)
+      (build_offspring_map bb.bb_instructions order)
+      (entry_instructions bb.bb_instructions order
+        (build_full_eda bb.bb_instructions))) = []` suffices_by simp[] >>
+  simp[listTheory.FILTER_EQ_NIL, listTheory.EVERY_MEM] >>
+  rpt strip_tac >>
+  metis_tac[schedule_output_from_block, build_full_eda_wf, entry_instructions_mem]
+QED
+
+

--- a/venom/passes/dft/proofs/dftTopoSortScript.sml
+++ b/venom/passes/dft/proofs/dftTopoSortScript.sml
@@ -1,0 +1,1227 @@
+(*
+ * DFT Topological Sort — DFS output respects data dependencies.
+ *
+ * Key result: schedule_output_producer_before
+ *   In the DFS output, every instruction's data-dep producer
+ *   (producing_inst result, in the ORIGINAL block order) appears earlier.
+ *
+ * This is used to prove defs_before_uses (dft_block order bb).bb_instructions.
+ *
+ * Requires eda_topo_compatible: all deps (data + EDA) respect the
+ * original block instruction order. build_eda always satisfies this.
+ *)
+
+Theory dftTopoSort
+Ancestors
+  dftStructural dftDefs venomExecSemantics
+  venomInst passSharedDefs
+  list rich_list sorting
+  finite_map pred_set pair arithmetic
+  combin option
+Libs
+  BasicProvers
+
+(* ===== defs_before_uses: defined here, used by dftCorrectness ===== *)
+
+Definition defs_before_uses_def:
+  defs_before_uses insts <=>
+    !j var prod.
+      j < LENGTH insts /\
+      MEM (Var var) (EL j insts).inst_operands /\
+      producing_inst insts var = SOME prod ==>
+      ?i. i < j /\ EL i insts = prod
+End
+
+(* Weakened: only non-pseudo users need producers before them.
+   defs_before_uses is FALSE for DFT output blocks with PARAM(Var x)
+   where x is defined by a non-pseudo instruction (PARAM(Var x) always
+   errors at runtime, so this case is semantically irrelevant).
+   non_pseudo_defs_before_uses suffices for all scheduling properties. *)
+Definition np_defs_before_uses_def:
+  np_defs_before_uses insts <=>
+    !j var prod.
+      j < LENGTH insts /\
+      MEM (Var var) (EL j insts).inst_operands /\
+      ~is_pseudo (EL j insts).inst_opcode /\
+      producing_inst insts var = SOME prod ==>
+      ?i. i < j /\ EL i insts = prod
+End
+
+Theorem defs_before_implies_np:
+  !insts. defs_before_uses insts ==> np_defs_before_uses insts
+Proof
+  rw[defs_before_uses_def, np_defs_before_uses_def] >> metis_tac[]
+QED
+
+(* ===== Core property: every producing_inst result appears before user ===== *)
+
+Definition output_producer_before_def:
+  output_producer_before bi output <=>
+    !k var prod.
+      k < LENGTH output /\
+      MEM (Var var) (EL k output).inst_operands /\
+      producing_inst bi var = SOME prod /\
+      ~is_pseudo prod.inst_opcode ==>
+      ?m. m < k /\ (EL m output).inst_id = prod.inst_id
+End
+
+(* output_eda_before: eda deps appear earlier in output *)
+Definition output_eda_before_def:
+  output_eda_before eda output <=>
+    !k d.
+      k < LENGTH output /\
+      MEM d (case FLOOKUP eda (EL k output).inst_id of
+               NONE => [] | SOME ds => ds) /\
+      ~is_pseudo d.inst_opcode ==>
+      ?m. m < k /\ (EL m output).inst_id = d.inst_id
+End
+
+(* ===== EDA topo compatibility: all deps respect block order ===== *)
+
+Definition eda_topo_compatible_def:
+  eda_topo_compatible bi eda order <=>
+    !inst dep.
+      MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+      MEM dep (inst_all_deps bi order eda inst) /\
+      ~is_pseudo dep.inst_opcode ==>
+      ?i j. i < j /\ j < LENGTH bi /\ i < LENGTH bi /\
+            EL i bi = dep /\ EL j bi = inst
+End
+
+(* ===== Stack emit ids (must be defined before stack_well_ordered) ===== *)
+
+Definition stack_emit_ids_def:
+  stack_emit_ids [] = [] /\
+  stack_emit_ids (DfsEmit inst :: rest) = inst.inst_id :: stack_emit_ids rest /\
+  stack_emit_ids (DfsProcess _ :: rest) = stack_emit_ids rest
+End
+
+Triviality stack_emit_ids_append[local]:
+  !l1 l2. stack_emit_ids (l1 ++ l2) =
+           stack_emit_ids l1 ++ stack_emit_ids l2
+Proof
+  Induct >> simp[stack_emit_ids_def] >>
+  Cases >> simp[stack_emit_ids_def]
+QED
+
+Triviality stack_emit_ids_map_process[local]:
+  !entries. stack_emit_ids (MAP DfsProcess entries) = []
+Proof
+  Induct >> simp[stack_emit_ids_def]
+QED
+
+(* ===== Stack well-ordered: key invariant ===== *)
+
+(* Strengthened: DfsEmit entries' data deps must be in resolved AND
+   not in stack_emit_ids of the rest (entries below).
+   DfsProcess entries' data deps must not be in stack_emit_ids of rest. *)
+
+Definition stack_well_ordered_def:
+  stack_well_ordered [] resolved bi order eda = T /\
+  stack_well_ordered (DfsProcess inst :: rest) resolved bi order eda =
+    ((!dep. ~is_pseudo inst.inst_opcode /\
+            MEM dep (inst_all_deps bi order eda inst) /\
+            ~is_pseudo dep.inst_opcode ==>
+            ~MEM dep.inst_id (stack_emit_ids rest)) /\
+     stack_well_ordered rest (inst.inst_id :: resolved) bi order eda) /\
+  stack_well_ordered (DfsEmit inst :: rest) resolved bi order eda =
+    ((!dep. MEM dep (inst_all_deps bi order eda inst) /\
+            ~is_pseudo dep.inst_opcode ==>
+            MEM dep.inst_id resolved /\
+            ~MEM dep.inst_id (stack_emit_ids rest)) /\
+     stack_well_ordered rest (inst.inst_id :: resolved) bi order eda)
+End
+
+(* ===== stack_well_ordered helpers ===== *)
+
+Triviality stack_well_ordered_mono[local]:
+  !stk res1 blk ord eda res2.
+    stack_well_ordered stk res1 blk ord eda /\
+    (!x. MEM x res1 ==> MEM x res2) ==>
+    stack_well_ordered stk res2 blk ord eda
+Proof
+  Induct_on `stk` >> rw[stack_well_ordered_def] >>
+  Cases_on `h` >> gvs[stack_well_ordered_def] >>
+  first_x_assum irule >>
+  qexists_tac `i.inst_id :: res1` >> rw[] >> metis_tac[]
+QED
+
+Triviality stack_well_ordered_cong[local]:
+  !stk res1 blk ord eda res2.
+    stack_well_ordered stk res1 blk ord eda /\
+    (!x. MEM x res1 <=> MEM x res2) ==>
+    stack_well_ordered stk res2 blk ord eda
+Proof
+  rpt strip_tac >> irule stack_well_ordered_mono >>
+  qexists_tac `res1` >> metis_tac[]
+QED
+
+Triviality ALL_DISTINCT_MAP_INJ_IMP[local]:
+  !l (f:'a -> 'b) x y.
+    ALL_DISTINCT (MAP f l) /\ MEM x l /\ MEM y l /\ (f x = f y) ==> (x = y)
+Proof
+  rpt strip_tac >> gvs[MEM_EL] >>
+  `EL n (MAP f l) = EL n' (MAP f l)` by simp[EL_MAP] >>
+  `n = n'` by metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP] >>
+  gvs[]
+QED
+
+(* ===== Flip operands preserves data deps ===== *)
+
+Triviality flip_operands_mem_ops[local]:
+  !inst op. MEM op (flip_operands inst).inst_operands ==>
+            MEM op inst.inst_operands
+Proof
+  rw[flip_operands_def] >>
+  BasicProvers.every_case_tac >> gvs[LET_THM]
+QED
+
+Triviality flip_not_terminator[local]:
+  !inst. is_terminator (flip_operands inst).inst_opcode =
+         is_terminator inst.inst_opcode
+Proof
+  gen_tac >> rw[flip_operands_def] >>
+  BasicProvers.every_case_tac >> simp[LET_THM] >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_comparator_def, flip_comparison_opcode_def, is_terminator_def]
+QED
+
+Triviality map_the_filter_some_mono[local]:
+  !l1 l2 f.
+    (!x. MEM x l1 ==> MEM x l2) ==>
+    !dep. MEM dep (MAP THE (FILTER IS_SOME (MAP f l1))) ==>
+          MEM dep (MAP THE (FILTER IS_SOME (MAP f l2)))
+Proof
+  Induct_on `l1` >> simp[] >> rpt strip_tac >>
+  Cases_on `f h` >> gvs[] >>
+  simp[MEM_MAP, MEM_FILTER] >>
+  qexists_tac `SOME dep` >> simp[] >>
+  qexists_tac `h` >> simp[]
+QED
+
+Triviality flip_operands_data_deps_subset[local]:
+  !bi order inst dep.
+    MEM dep (inst_data_deps bi order (flip_operands inst)) ==>
+    MEM dep (inst_data_deps bi order inst)
+Proof
+  rw[inst_data_deps_def, LET_THM, MEM_nub, MEM_APPEND,
+     flip_not_terminator]
+  >- (disj1_tac >> irule map_the_filter_some_mono >>
+      qexists_tac `(flip_operands inst).inst_operands` >>
+      simp[flip_operands_mem_ops])
+  >- simp[]
+  >- (irule map_the_filter_some_mono >>
+      qexists_tac `(flip_operands inst).inst_operands` >>
+      simp[flip_operands_mem_ops])
+QED
+
+Triviality data_deps_subset_all_deps[local]:
+  !bi order eda inst dep.
+    MEM dep (inst_data_deps bi order inst) ==>
+    MEM dep (inst_all_deps bi order eda inst)
+Proof
+  rw[inst_all_deps_def, LET_THM, MEM_nub, MEM_APPEND]
+QED
+
+(* Combined: data_deps of flip_operands ⊆ inst_all_deps of original *)
+Triviality flip_data_deps_in_all_deps[local]:
+  !bi order eda inst dep.
+    MEM dep (inst_data_deps bi order (flip_operands inst)) ==>
+    MEM dep (inst_all_deps bi order eda inst)
+Proof
+  metis_tac[flip_operands_data_deps_subset, data_deps_subset_all_deps]
+QED
+
+(* Unified: data_deps of (if cond then flip inst else inst) ⊆ all_deps.
+   Eliminates the repeated mp_tac+simp[Abbr]+IF_CASES_TAC pattern in C1/C9. *)
+Triviality maybe_flip_data_deps_in_all_deps[local]:
+  !bi order eda inst dep cond.
+    MEM dep (inst_data_deps bi order
+      (if cond then flip_operands inst else inst)) ==>
+    MEM dep (inst_all_deps bi order eda inst)
+Proof
+  rpt strip_tac >> Cases_on `cond` >> gvs[] >>
+  metis_tac[flip_data_deps_in_all_deps, data_deps_subset_all_deps]
+QED
+
+(* Unified: all_deps of (if cond then flip inst else inst) ⊆ all_deps of inst.
+   flip_operands doesn't change inst_id → eda deps identical.
+   flip_operands data deps ⊆ original data deps. *)
+Triviality maybe_flip_all_deps_in_all_deps[local]:
+  !bi order eda inst dep cond.
+    MEM dep (inst_all_deps bi order eda
+      (if cond then flip_operands inst else inst)) ==>
+    MEM dep (inst_all_deps bi order eda inst)
+Proof
+  rpt strip_tac >> Cases_on `cond` >> gvs[] >>
+  gvs[inst_all_deps_def, LET_THM, MEM_nub, MEM_APPEND] >>
+  metis_tac[flip_operands_data_deps_subset, MEM_nub, flip_operands_inst_id]
+QED
+
+Triviality producing_inst_in_data_deps[local]:
+  !bi order inst var prod.
+    producing_inst bi var = SOME prod /\
+    MEM (Var var) inst.inst_operands ==>
+    MEM prod (inst_data_deps bi order inst)
+Proof
+  rw[inst_data_deps_def, LET_THM, MEM_nub, MEM_APPEND, MEM_MAP,
+     MEM_FILTER] >>
+  TRY disj1_tac >> qexists_tac `SOME prod` >> simp[] >>
+  qexists_tac `Var var` >> simp[operand_producer_def]
+QED
+
+(* Combined: producing_inst result is in inst_all_deps *)
+Triviality producing_inst_in_all_deps[local]:
+  !bi order eda inst var prod.
+    producing_inst bi var = SOME prod /\
+    MEM (Var var) inst.inst_operands ==>
+    MEM prod (inst_all_deps bi order eda inst)
+Proof
+  metis_tac[producing_inst_in_data_deps, data_deps_subset_all_deps]
+QED
+
+(* EDA deps are in inst_all_deps *)
+Triviality eda_dep_in_all_deps[local]:
+  !bi order eda inst d.
+    MEM d (case FLOOKUP eda inst.inst_id of NONE => [] | SOME ds => ds) ==>
+    MEM d (inst_all_deps bi order eda inst)
+Proof
+  rw[inst_all_deps_def, LET_THM, MEM_nub, MEM_APPEND]
+QED
+
+(* ===== producing_inst position lemma ===== *)
+
+Triviality producing_inst_position[local]:
+  !bi var prod.
+    producing_inst bi var = SOME prod ==>
+    ?r. r < LENGTH bi /\ EL r bi = prod
+Proof
+  Induct >> rw[producing_inst_def] >>
+  Cases_on `MEM var h.inst_outputs` >> gvs[]
+  >- (qexists_tac `0` >> simp[])
+  >- (res_tac >> qexists_tac `SUC r` >> simp[])
+QED
+
+(* producing_inst gives a position strictly before the user position
+   when np_defs_before_uses holds and the user is non-pseudo *)
+Triviality producing_inst_before_user[local]:
+  !bi var prod j.
+    np_defs_before_uses bi /\
+    j < LENGTH bi /\
+    MEM (Var var) (EL j bi).inst_operands /\
+    ~is_pseudo (EL j bi).inst_opcode /\
+    producing_inst bi var = SOME prod ==>
+    ?r. r < j /\ EL r bi = prod
+Proof
+  rw[np_defs_before_uses_def] >>
+  first_x_assum (qspecl_then [`j`, `var`, `prod`] mp_tac) >>
+  simp[]
+QED
+
+Triviality producing_inst_mem[local]:
+  !bi var prod. producing_inst bi var = SOME prod ==> MEM prod bi
+Proof
+  rpt strip_tac >> drule producing_inst_position >> strip_tac >>
+  metis_tac[MEM_EL]
+QED
+
+(* General: strictly earlier position in ALL_DISTINCT list → different inst_id *)
+Triviality distinct_pos_neq_id[local]:
+  !bi i j.
+    ALL_DISTINCT (MAP (\k. k.inst_id) bi) /\
+    i < j /\ j < LENGTH bi ==>
+    (EL i bi).inst_id <> (EL j bi).inst_id
+Proof
+  spose_not_then strip_assume_tac >>
+  `i < LENGTH (MAP (\k. k.inst_id) bi) /\
+   j < LENGTH (MAP (\k. k.inst_id) bi)` by simp[] >>
+  `EL i (MAP (\k. k.inst_id) bi) = EL j (MAP (\k. k.inst_id) bi)` by
+    simp[EL_MAP] >>
+  `i = j` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+  gvs[]
+QED
+
+Triviality producing_inst_id_neq_user[local]:
+  !bi var prod j.
+    np_defs_before_uses bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    j < LENGTH bi /\
+    MEM (Var var) (EL j bi).inst_operands /\
+    ~is_pseudo (EL j bi).inst_opcode /\
+    producing_inst bi var = SOME prod ==>
+    prod.inst_id <> (EL j bi).inst_id
+Proof
+  rpt strip_tac >>
+  drule_all producing_inst_before_user >> strip_tac >>
+  `prod.inst_id = (EL r bi).inst_id` by gvs[] >>
+  metis_tac[distinct_pos_neq_id]
+QED
+
+(* flip_operands preserves inst_id *)
+Triviality flip_operands_inst_id[local]:
+  !inst. (flip_operands inst).inst_id = inst.inst_id
+Proof
+  rw[flip_operands_def] >> BasicProvers.every_case_tac >> simp[LET_THM]
+QED
+
+Triviality from_block_inst_id[local]:
+  !bi inst. from_block bi inst ==>
+    ?orig. MEM orig bi /\ inst.inst_id = orig.inst_id
+Proof
+  simp[from_block_def] >> metis_tac[flip_operands_inst_id]
+QED
+
+Triviality from_block_mem_operands[local]:
+  !bi inst var. from_block bi inst /\ MEM (Var var) inst.inst_operands ==>
+    ?orig. MEM orig bi /\ MEM (Var var) orig.inst_operands /\
+           inst.inst_id = orig.inst_id
+Proof
+  simp[from_block_def] >> metis_tac[flip_operands_inst_id, flip_operands_mem_ops]
+QED
+
+(* ===== Block position ordering for stack ===== *)
+
+(* For each non-pseudo DfsProcess/DfsEmit entry on the stack,
+   all stack_emit_ids below it have block positions >= this entry's position.
+   DfsProcess entries that are pseudo contribute no ordering constraint
+   (they are skipped/expanded and don't appear as emit entries). *)
+Definition stack_pos_ordered_def:
+  stack_pos_ordered bi [] = T /\
+  stack_pos_ordered bi (DfsProcess inst :: rest) =
+    ((!x xi yi.
+        ~is_pseudo inst.inst_opcode ==>
+        MEM x (stack_emit_ids rest) /\
+        xi < LENGTH bi /\ (EL xi bi).inst_id = x /\
+        yi < LENGTH bi /\ (EL yi bi).inst_id = inst.inst_id ==>
+        yi <= xi) /\
+     stack_pos_ordered bi rest) /\
+  stack_pos_ordered bi (DfsEmit inst :: rest) =
+    ((!x xi yi.
+        MEM x (stack_emit_ids rest) /\
+        xi < LENGTH bi /\ (EL xi bi).inst_id = x /\
+        yi < LENGTH bi /\ (EL yi bi).inst_id = inst.inst_id ==>
+        yi <= xi) /\
+     stack_pos_ordered bi rest)
+End
+
+Triviality stack_pos_ordered_append[local]:
+  !l1 l2 bi.
+    stack_pos_ordered bi (l1 ++ l2) ==>
+    stack_pos_ordered bi l2
+Proof
+  Induct >> simp[] >>
+  Cases >> simp[stack_pos_ordered_def]
+QED
+
+Triviality stack_pos_ordered_map_process[local]:
+  !entries bi. stack_pos_ordered bi (MAP DfsProcess entries)
+Proof
+  Induct >> simp[stack_pos_ordered_def, stack_emit_ids_map_process]
+QED
+
+(* Key derived lemma: if all stack_emit_ids have positions >= inst_pos,
+   and dep has position dep_pos < inst_pos, then dep not in stack_emit_ids *)
+Triviality pos_ordered_not_in_emit[local]:
+  !bi stack inst_id dep_id.
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    (!x xi yi.
+       MEM x (stack_emit_ids stack) /\
+       xi < LENGTH bi /\ (EL xi bi).inst_id = x /\
+       yi < LENGTH bi /\ (EL yi bi).inst_id = inst_id ==>
+       yi <= xi) /\
+    (?dep_pos inst_pos.
+       dep_pos < inst_pos /\
+       inst_pos < LENGTH bi /\ dep_pos < LENGTH bi /\
+       (EL inst_pos bi).inst_id = inst_id /\
+       (EL dep_pos bi).inst_id = dep_id) ==>
+    ~MEM dep_id (stack_emit_ids stack)
+Proof
+  spose_not_then strip_assume_tac >>
+  `?xi. xi < LENGTH bi /\ (EL xi bi).inst_id = dep_id` by metis_tac[] >>
+  `inst_pos <= xi` by metis_tac[] >>
+  (* xi must equal dep_pos by ALL_DISTINCT *)
+  `EL xi (MAP (\i. i.inst_id) bi) = EL dep_pos (MAP (\i. i.inst_id) bi)` by
+    simp[EL_MAP] >>
+  `xi < LENGTH (MAP (\i. i.inst_id) bi) /\
+   dep_pos < LENGTH (MAP (\i. i.inst_id) bi)` by simp[] >>
+  `xi = dep_pos` by metis_tac[ALL_DISTINCT_EL_IMP] >>
+  (* inst_pos <= dep_pos but dep_pos < inst_pos — contradiction *)
+  gvs[]
+QED
+
+(* ===== DFS topo invariant ===== *)
+
+Definition dfs_topo_inv_def:
+  dfs_topo_inv bi order eda state <=>
+    output_producer_before bi state.ds_output /\
+    output_eda_before eda state.ds_output /\
+    stack_well_ordered state.ds_stack
+      (MAP (\i. i.inst_id) state.ds_output ++ state.ds_visited) bi order eda /\
+    (* output deps' ids not pending in stack *)
+    (!i var prod.
+      MEM i state.ds_output /\
+      MEM (Var var) i.inst_operands /\
+      producing_inst bi var = SOME prod /\
+      ~is_pseudo prod.inst_opcode ==>
+      ~MEM prod.inst_id (stack_emit_ids state.ds_stack)) /\
+    (* output eda deps' ids not pending in stack *)
+    (!i d.
+      MEM i state.ds_output /\
+      MEM d (case FLOOKUP eda i.inst_id of NONE => [] | SOME ds => ds) /\
+      ~is_pseudo d.inst_opcode ==>
+      ~MEM d.inst_id (stack_emit_ids state.ds_stack)) /\
+    ALL_DISTINCT (stack_emit_ids state.ds_stack) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) state.ds_output) /\
+    (!x. MEM x (stack_emit_ids state.ds_stack) ==>
+         MEM x state.ds_visited) /\
+    (!x. MEM x (MAP (\i. i.inst_id) state.ds_output) ==>
+         ~MEM x (stack_emit_ids state.ds_stack)) /\
+    (!x. MEM x (MAP (\i. i.inst_id) state.ds_output) ==>
+         MEM x state.ds_visited) /\
+    (* output elements' producers are visited *)
+    (!i var prod.
+      MEM i state.ds_output /\
+      MEM (Var var) i.inst_operands /\
+      producing_inst bi var = SOME prod /\
+      ~is_pseudo prod.inst_opcode ==>
+      MEM prod.inst_id state.ds_visited) /\
+    (* output elements' eda deps are visited *)
+    (!i d.
+      MEM i state.ds_output /\
+      MEM d (case FLOOKUP eda i.inst_id of NONE => [] | SOME ds => ds) /\
+      ~is_pseudo d.inst_opcode ==>
+      MEM d.inst_id state.ds_visited) /\
+    (* visited non-pseudo inst is in output or pending as DfsEmit *)
+    (!inst. MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+            MEM inst.inst_id state.ds_visited /\
+            ~MEM inst.inst_id (stack_emit_ids state.ds_stack) ==>
+            MEM inst.inst_id (MAP (\i. i.inst_id) state.ds_output)) /\
+    (* block position ordering of stack *)
+    stack_pos_ordered bi state.ds_stack
+End
+
+(* ===== dfs_step preservation ===== *)
+
+(* Visited already: stack shrinks, output + visited unchanged *)
+Triviality topo_inv_drop_visited[local]:
+  !bi order state inst t.
+    dfs_topo_inv bi order eda state /\
+    state.ds_stack = DfsProcess inst :: t /\
+    MEM inst.inst_id state.ds_visited ==>
+    dfs_topo_inv bi order eda (state with ds_stack := t)
+Proof
+  rpt strip_tac >>
+  gvs[dfs_topo_inv_def, stack_well_ordered_def, stack_emit_ids_def,
+      stack_pos_ordered_def] >>
+  rpt conj_tac
+  >- (irule stack_well_ordered_mono >>
+      qexists_tac `inst.inst_id ::
+        MAP (\i. i.inst_id) state.ds_output ++ state.ds_visited` >>
+      simp[MEM_APPEND] >> metis_tac[])
+  >> rpt strip_tac >> res_tac >> res_tac
+QED
+
+(* Pseudo: stack shrinks, pseudo id added to visited *)
+Triviality topo_inv_drop_pseudo[local]:
+  !bi order state inst t.
+    dfs_topo_inv bi order eda state /\
+    state.ds_stack = DfsProcess inst :: t /\
+    is_pseudo inst.inst_opcode /\
+    MEM inst bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    dfs_topo_inv bi order eda
+      (state with <| ds_stack := t;
+                     ds_visited := inst.inst_id :: state.ds_visited |>)
+Proof
+  rpt strip_tac >>
+  fs[dfs_topo_inv_def, stack_well_ordered_def, stack_emit_ids_def,
+     stack_pos_ordered_def] >>
+  rpt conj_tac
+  (* 1: stack_well_ordered — move inst.inst_id from prefix to resolved *)
+  >- (irule stack_well_ordered_cong >>
+      qexists_tac `inst.inst_id ::
+        MAP (\i. i.inst_id) state.ds_output ++ state.ds_visited` >>
+      simp[MEM_APPEND] >> metis_tac[])
+  (* 2: output data deps not on stack — from assumption *)
+  >- (rpt strip_tac >> res_tac)
+  (* 3: output eda deps not on stack — from assumption *)
+  >- (rpt strip_tac >> res_tac)
+  (* 4: output data deps visited — disj2_tac (was already visited) *)
+  >- (rpt strip_tac >> disj2_tac >> res_tac)
+  (* 5: output eda deps visited — disj2_tac (was already visited) *)
+  >- (rpt strip_tac >> disj2_tac >> res_tac)
+  (* 6: visited non-pseudo in output — handle inst.inst_id = case *)
+  >> rpt strip_tac >> gvs[] >>
+  metis_tac[ALL_DISTINCT_MAP_INJ_IMP]
+QED
+
+(* DfsEmit: inst moves from stack head to output tail *)
+Theorem topo_inv_emit[local]:
+  !bi order state inst rest'.
+    dfs_topo_inv bi order eda state /\
+    dfs_good_state bi state /\
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    np_defs_before_uses bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    state.ds_stack = DfsEmit inst :: rest' ==>
+    dfs_topo_inv bi order eda
+      (state with <| ds_stack := rest';
+                     ds_output := state.ds_output ++ [inst] |>)
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `dfs_topo_inv _ _ _ _` mp_tac >>
+  simp[dfs_topo_inv_def, stack_well_ordered_def,
+       stack_emit_ids_def, stack_pos_ordered_def] >>
+  strip_tac >>
+  `from_block bi inst /\ ~is_pseudo inst.inst_opcode` by
+    (gvs[dfs_good_state_def, EVERY_MEM] >>
+     first_x_assum (qspec_then `DfsEmit inst` mp_tac) >> simp[]) >>
+  `?orig. MEM orig bi /\ inst.inst_id = orig.inst_id` by
+    metis_tac[from_block_inst_id] >>
+  rpt conj_tac
+  (* 1: output_producer_before *)
+  >- suspend "G1"
+  (* 2: output_eda_before *)
+  >- suspend "G1_eda"
+  (* 3: stack_well_ordered *)
+  >- (irule stack_well_ordered_cong >>
+      qexists `inst.inst_id ::
+        MAP (\i. i.inst_id) state.ds_output ++ state.ds_visited` >>
+      simp[] >> rpt strip_tac >> gvs[MEM_APPEND] >> metis_tac[])
+  (* 4: output data deps not pending *)
+  >- suspend "G3"
+  (* 5: output eda deps not pending *)
+  >- suspend "G3_eda"
+  (* 6: ALL_DISTINCT (stack_emit_ids) — from assumption, output unchanged *)
+  (* 7: ALL_DISTINCT (MAP inst_id (output ++ [inst])) *)
+  >- (simp[ALL_DISTINCT_APPEND, MEM_MAP, PULL_EXISTS] >>
+      rpt strip_tac >> gvs[] >> res_tac >> gvs[])
+  (* 8: stack_emit_ids ⊆ visited — from assumption *)
+  (* 9: output++[inst] ids not in stack_emit_ids rest' *)
+  >- (rpt strip_tac >> gvs[] >> res_tac >> gvs[])
+  (* 10: output++[inst] ids are visited *)
+  >- (rpt strip_tac >> gvs[] >> res_tac)
+  (* 11: output data deps visited *)
+  >- suspend "G6"
+  (* 12: output eda deps visited *)
+  >- suspend "G6_eda"
+  (* 13: visited non-pseudo in output or is inst *)
+  >> rpt strip_tac >>
+     Cases_on `inst'.inst_id = inst.inst_id` >- simp[] >>
+     disj1_tac >> res_tac
+QED
+
+(* G3: output++[inst] data deps not in stack_emit_ids rest' *)
+Resume topo_inv_emit[G3]:
+  rpt gen_tac >> strip_tac
+  >- (res_tac >> gvs[])
+  >> gvs[] >> metis_tac[producing_inst_in_all_deps]
+QED
+
+(* G3_eda: output++[inst] eda deps not in stack_emit_ids rest' *)
+Resume topo_inv_emit[G3_eda]:
+  rpt gen_tac >> strip_tac
+  >- (res_tac >> gvs[])
+  >> gvs[] >> metis_tac[eda_dep_in_all_deps]
+QED
+
+(* G6: output++[inst] data deps visited *)
+Resume topo_inv_emit[G6]:
+  rpt gen_tac >> strip_tac
+  >- (res_tac >> gvs[])
+  >> gvs[] >> metis_tac[producing_inst_in_all_deps]
+QED
+
+(* G6_eda: output++[inst] eda deps visited *)
+Resume topo_inv_emit[G6_eda]:
+  rpt gen_tac >> strip_tac
+  >- (res_tac >> gvs[])
+  >> gvs[] >> metis_tac[eda_dep_in_all_deps]
+QED
+
+(* G1: output_producer_before for output++[inst] *)
+Resume topo_inv_emit[G1]:
+  simp[output_producer_before_def] >>
+  rpt strip_tac >>
+  Cases_on `k < LENGTH state.ds_output`
+  (* Case 1: k < LENGTH output — use old output_producer_before *)
+  >- (gvs[output_producer_before_def, EL_APPEND1] >>
+      first_x_assum (drule_all_then strip_assume_tac) >>
+      qexists `m` >> simp[EL_APPEND1])
+  (* Case 2: k = LENGTH output (the new inst) *)
+  >> `k = LENGTH state.ds_output` by
+       gvs[EL_APPEND2, LENGTH_APPEND] >>
+     gvs[EL_APPEND2] >>
+     `MEM prod bi` by metis_tac[producing_inst_mem] >>
+     (* dep assumption → not on stack *)
+     `~MEM prod.inst_id (stack_emit_ids rest')` by
+       metis_tac[producing_inst_in_all_deps] >>
+     (* dep assumption → visited (via output⊆visited) *)
+     `MEM prod.inst_id state.ds_visited` by
+       metis_tac[producing_inst_in_all_deps] >>
+     (* prod.inst_id ≠ orig.inst_id *)
+     `MEM (Var var) orig.inst_operands /\ ~is_pseudo orig.inst_opcode` by
+       (qpat_x_assum `from_block _ _` mp_tac >>
+        simp[from_block_def] >> strip_tac >>
+        `j = orig` by metis_tac[ALL_DISTINCT_MAP_INJ_IMP,
+                                 flip_operands_inst_id] >>
+        gvs[] >> metis_tac[flip_operands_mem_ops]) >>
+     `?j. j < LENGTH bi /\ EL j bi = orig` by metis_tac[MEM_EL] >>
+     `prod.inst_id <> orig.inst_id` by
+       (qspecl_then [`bi`,`var`,`prod`,`j`] mp_tac producing_inst_id_neq_user >>
+        gvs[]) >>
+     (* C7: visited + non-pseudo + not-on-stack → in output *)
+     `MEM prod.inst_id (MAP (\i. i.inst_id) state.ds_output)` by
+       (first_x_assum irule >> gvs[]) >>
+     (* MEM in MAP → ∃ element in list with matching id *)
+     pop_assum (strip_assume_tac o REWRITE_RULE [MEM_MAP]) >>
+     `?m. m < LENGTH state.ds_output /\ EL m state.ds_output = y` by
+       metis_tac[MEM_EL] >>
+     qexists `m` >> simp[EL_APPEND1]
+QED
+
+(* G1_eda: output_eda_before for output++[inst] *)
+Resume topo_inv_emit[G1_eda]:
+  simp[output_eda_before_def] >>
+  rpt strip_tac >>
+  Cases_on `k < LENGTH state.ds_output`
+  (* Case 1: k < LENGTH output — use old output_eda_before *)
+  >- (gvs[output_eda_before_def, EL_APPEND1] >>
+      first_x_assum (drule_all_then strip_assume_tac) >>
+      qexists `m` >> simp[EL_APPEND1])
+  (* Case 2: k = LENGTH output (the new inst) — eda dep d in inst_all_deps *)
+  >> `k = LENGTH state.ds_output` by
+       gvs[EL_APPEND2, LENGTH_APPEND] >>
+     gvs[EL_APPEND2] >>
+     (* d is an eda dep of inst (via inst_id = orig.inst_id, so same FLOOKUP) *)
+     `MEM d (inst_all_deps bi order eda inst)` by
+       metis_tac[eda_dep_in_all_deps] >>
+     (* From stack_well_ordered(DfsEmit): d resolved and not on stack *)
+     `~MEM d.inst_id (stack_emit_ids rest')` by
+       (qpat_assum `!dep. MEM dep (inst_all_deps _ _ _ _) /\ _ ==> _`
+          (qspec_then `d` mp_tac) >> simp[]) >>
+     `MEM d.inst_id state.ds_visited` by
+       (qpat_x_assum `!dep. MEM dep (inst_all_deps _ _ _ _) /\ _ ==> _`
+          (qspec_then `d` mp_tac) >> simp[] >> strip_tac >> gvs[] >>
+        res_tac) >>
+     (* Use orig (which IS in bi) for eda_topo_compatible *)
+     `~is_pseudo orig.inst_opcode` by
+       (qpat_x_assum `from_block _ _` mp_tac >>
+        simp[from_block_def] >> rpt strip_tac >> gvs[] >>
+        metis_tac[ALL_DISTINCT_MAP_INJ_IMP, flip_operands_inst_id]) >>
+     (* d ∈ inst_all_deps of orig (same inst_id → same eda FLOOKUP) *)
+     `MEM d (inst_all_deps bi order eda orig)` by
+       metis_tac[eda_dep_in_all_deps] >>
+     `?di dj. di < dj /\ dj < LENGTH bi /\ di < LENGTH bi /\
+              EL di bi = d /\ EL dj bi = orig` by
+       (gvs[eda_topo_compatible_def] >>
+        first_x_assum irule >> gvs[]) >>
+     `d.inst_id <> orig.inst_id` by
+       (`d.inst_id = (EL di bi).inst_id /\
+         orig.inst_id = (EL dj bi).inst_id` by gvs[] >>
+        metis_tac[distinct_pos_neq_id]) >>
+     (* d.inst_id in output (not on stack, visited, non-pseudo) *)
+     `MEM d.inst_id (MAP (\i. i.inst_id) state.ds_output)` by
+       (`MEM d bi` by metis_tac[MEM_EL] >>
+        first_x_assum irule >> gvs[]) >>
+     pop_assum (strip_assume_tac o REWRITE_RULE [MEM_MAP]) >>
+     `?m. m < LENGTH state.ds_output /\ EL m state.ds_output = y` by
+       metis_tac[MEM_EL] >>
+     qexists `m` >> simp[EL_APPEND1]
+QED
+
+Finalise topo_inv_emit
+
+Theorem dfs_step_preserves_topo:
+  !bi order eda offspring_map do_flip state.
+    dfs_topo_inv bi order eda state /\
+    dfs_good_state bi state /\
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    np_defs_before_uses bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    dfs_topo_inv bi order eda
+      (dfs_step bi order eda offspring_map do_flip state)
+Proof
+  rpt strip_tac >>
+  Cases_on `state.ds_stack`
+  (* Empty stack: no-op *)
+  >- simp[dfs_step_def]
+  >> Cases_on `h`
+  (* DfsProcess *)
+  >- (rename1 `DfsProcess inst :: rest'` >>
+      Cases_on `MEM inst.inst_id state.ds_visited`
+      (* Already visited: drop *)
+      >- (simp[dfs_step_def] >>
+          irule topo_inv_drop_visited >> simp[] >> metis_tac[])
+      >> Cases_on `is_pseudo inst.inst_opcode`
+      (* Pseudo: drop + mark visited *)
+      >- (simp[dfs_step_def] >>
+          irule topo_inv_drop_pseudo >> simp[] >>
+          gvs[dfs_good_state_def, EVERY_MEM] >>
+          first_x_assum (qspec_then `DfsProcess inst` mp_tac) >> simp[])
+      (* New non-pseudo: push children + DfsEmit + rest *)
+      >> simp[dfs_step_def, LET_THM] >>
+         qabbrev_tac `children = inst_all_deps bi order eda inst` >>
+         qabbrev_tac `sorted = sort_children bi order eda offspring_map
+                                             inst children` >>
+         qabbrev_tac `inst' = if do_flip /\ is_flippable inst.inst_opcode /\
+                                 sorted <> children
+                              then flip_operands inst else inst` >>
+         simp[dfs_topo_inv_def] >>
+         rpt conj_tac
+         (* 1: output_producer_before — output unchanged *)
+         >- suspend "C0"
+         (* 2: output_eda_before — output unchanged *)
+         >- gvs[dfs_topo_inv_def]
+         (* 3: stack_well_ordered *)
+         >- suspend "C1"
+         (* 4: output data deps not on stack *)
+         >- suspend "C2"
+         (* 5: output eda deps not on stack — same as C2 pattern *)
+         >- suspend "C2_eda"
+         (* 6: ALL_DISTINCT stack_emit_ids *)
+         >- suspend "C3"
+         (* 7: ALL_DISTINCT output ids — output unchanged *)
+         >- gvs[dfs_topo_inv_def]
+         (* 8: stack_emit_ids ⊆ visited *)
+         >- suspend "C4"
+         (* 9: output ids not in stack *)
+         >- suspend "C5"
+         (* 10: output ids in visited *)
+         >- suspend "C6"
+         (* 11: output data deps visited *)
+         >- suspend "C7"
+         (* 12: output eda deps visited — same as C7 pattern *)
+         >- suspend "C7_eda"
+         (* 13: visited non-pseudo in output or pending *)
+         >- suspend "C8"
+         (* 14: stack_pos_ordered *)
+         >> suspend "C9")
+  (* DfsEmit: use helper *)
+  >> (rename1 `DfsEmit inst :: rest'` >>
+      simp[dfs_step_def] >>
+      irule topo_inv_emit >> simp[])
+QED
+
+(* C0: output_producer_before unchanged (output is state.ds_output) *)
+Resume dfs_step_preserves_topo[C0]:
+  (* output is unchanged, so output_producer_before carries over *)
+  gvs[dfs_topo_inv_def]
+QED
+
+(* Shared tactic for non-pseudo case Resume blocks:
+   Establishes MEM inst bi and inst'.inst_id = inst.inst_id *)
+val non_pseudo_setup_tac =
+  `MEM inst bi` by
+    (fs[dfs_good_state_def, EVERY_MEM] >>
+     first_x_assum (qspec_then `DfsProcess inst` mp_tac) >> simp[]) >>
+  `inst'.inst_id = inst.inst_id` by
+    (simp[Abbr `inst'`] >> IF_CASES_TAC >> simp[flip_operands_inst_id]);
+
+(* Shared emit-id simplification for C2-C5, C8 pattern *)
+val emit_id_tac =
+  simp[stack_emit_ids_append, stack_emit_ids_map_process,
+       stack_emit_ids_def] >>
+  `inst'.inst_id = inst.inst_id` by
+    (unabbrev_all_tac >> rw[flip_operands_inst_id]) >>
+  gvs[dfs_topo_inv_def, stack_emit_ids_def] >>
+  metis_tac[];
+
+(* Helper: SWO of DfsProcess prefix ++ suffix *)
+Triviality swo_process_prefix[local]:
+  !l suffix resolved bi order eda.
+    (!si dep. MEM si l /\ ~is_pseudo si.inst_opcode /\
+              MEM dep (inst_all_deps bi order eda si) /\
+              ~is_pseudo dep.inst_opcode ==>
+              ~MEM dep.inst_id (stack_emit_ids suffix)) /\
+    stack_well_ordered suffix
+      (REVERSE (MAP (\i. i.inst_id) l) ++ resolved) bi order eda ==>
+    stack_well_ordered (MAP DfsProcess l ++ suffix) resolved bi order eda
+Proof
+  Induct >> simp[stack_well_ordered_def, REVERSE_DEF] >>
+  rpt strip_tac
+  >- (gvs[stack_emit_ids_append, stack_emit_ids_map_process] >>
+      first_x_assum (qspecl_then [`h`, `dep`] mp_tac) >> simp[])
+  >> last_x_assum irule >> conj_tac
+  >- metis_tac[]
+  >> first_x_assum mp_tac >> rewrite_tac[GSYM APPEND_ASSOC, APPEND]
+QED
+
+(* Helper: var-operand dep has position strictly before non-pseudo user. *)
+Triviality var_dep_earlier_pos[local]:
+  !bi j var prod.
+    np_defs_before_uses bi /\
+    j < LENGTH bi /\ MEM (Var var) (EL j bi).inst_operands /\
+    ~is_pseudo (EL j bi).inst_opcode /\
+    producing_inst bi var = SOME prod ==>
+    ?dep_pos. dep_pos < j /\ dep_pos < LENGTH bi /\ EL dep_pos bi = prod
+Proof
+  rw[np_defs_before_uses_def] >>
+  first_x_assum (qspecl_then [`j`, `var`, `prod`] mp_tac) >>
+  simp[] >> strip_tac >> qexists `i` >> simp[]
+QED
+
+(* Helper: position uniqueness from ALL_DISTINCT inst_ids *)
+Triviality pos_unique[local]:
+  !bi p q.
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    p < LENGTH bi /\ q < LENGTH bi /\
+    (EL p bi).inst_id = (EL q bi).inst_id ==>
+    p = q
+Proof
+  rpt strip_tac >>
+  `p < LENGTH (MAP (\i. i.inst_id) bi)` by simp[] >>
+  `q < LENGTH (MAP (\i. i.inst_id) bi)` by simp[] >>
+  `EL p (MAP (\i. i.inst_id) bi) = EL q (MAP (\i. i.inst_id) bi)` by
+    simp[EL_MAP] >>
+  metis_tac[ALL_DISTINCT_EL_IMP]
+QED
+
+(* Helper: dep of a non-pseudo child of inst has position strictly before inst.
+   Uses eda_topo_compatible to get ordering for non-pseudo deps. *)
+Triviality dep_of_child_earlier_pos[local]:
+  !bi order eda inst si dep.
+    np_defs_before_uses bi /\
+    eda_topo_compatible bi eda order /\
+    eda_wf eda bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) /\
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+    MEM si (inst_all_deps bi order eda inst) /\
+    ~is_pseudo si.inst_opcode /\
+    MEM dep (inst_all_deps bi order eda si) /\
+    ~is_pseudo dep.inst_opcode ==>
+    ?dep_pos inst_pos.
+      dep_pos < inst_pos /\ inst_pos < LENGTH bi /\ dep_pos < LENGTH bi /\
+      EL dep_pos bi = dep /\ EL inst_pos bi = inst
+Proof
+  rpt strip_tac >>
+  `MEM si bi` by metis_tac[inst_all_deps_mem] >>
+  `MEM dep bi` by metis_tac[inst_all_deps_mem] >>
+  `?inst_j. inst_j < LENGTH bi /\ EL inst_j bi = inst` by
+    metis_tac[MEM_EL] >>
+  (* Get ordering from eda_topo_compatible for (inst, si) *)
+  `?si_j inst_j'.
+     si_j < inst_j' /\ inst_j' < LENGTH bi /\ si_j < LENGTH bi /\
+     EL si_j bi = si /\ EL inst_j' bi = inst` by
+    (fs[eda_topo_compatible_def] >>
+     first_x_assum (qspecl_then [`inst`, `si`] mp_tac) >> simp[]) >>
+  `inst_j' = inst_j` by metis_tac[pos_unique] >> gvs[] >>
+  (* Get ordering from eda_topo_compatible for (si, dep) *)
+  `?dep_j si_j'.
+     dep_j < si_j' /\ si_j' < LENGTH bi /\ dep_j < LENGTH bi /\
+     EL dep_j bi = dep /\ EL si_j' bi = EL si_j bi` by
+    (fs[eda_topo_compatible_def] >>
+     first_x_assum (qspecl_then [`EL si_j bi`, `dep`] mp_tac) >> simp[]) >>
+  `si_j < LENGTH bi` by simp[] >>
+  `(EL si_j' bi).inst_id = (EL si_j bi).inst_id` by gvs[] >>
+  `si_j' = si_j` by metis_tac[pos_unique] >>
+  gvs[] >>
+  qexistsl [`dep_j`, `inst_j`] >> simp[]
+QED
+
+(* Core helper: dep of a non-pseudo child of inst can't be inst.inst_id
+   and can't be in emit_ids of the rest of the stack below inst. *)
+Triviality dep_not_in_suffix[local]:
+  !bi order eda inst si dep rest'.
+    np_defs_before_uses bi /\
+    eda_topo_compatible bi eda order /\
+    eda_wf eda bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) /\
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+    MEM si (inst_all_deps bi order eda inst) /\
+    ~is_pseudo si.inst_opcode /\
+    MEM dep (inst_all_deps bi order eda si) /\
+    ~is_pseudo dep.inst_opcode /\
+    stack_pos_ordered bi (DfsProcess inst :: rest') ==>
+    dep.inst_id <> inst.inst_id /\
+    ~MEM dep.inst_id (stack_emit_ids rest')
+Proof
+  rpt strip_tac
+  (* dep.inst_id ≠ inst.inst_id: get positions, derive equality contradiction *)
+  >- (drule_all dep_of_child_earlier_pos >> strip_tac >>
+      `(EL dep_pos bi).inst_id = (EL inst_pos bi).inst_id` by gvs[] >>
+      `dep_pos = inst_pos` by metis_tac[pos_unique] >>
+      gvs[])
+  (* ¬MEM dep.inst_id (stack_emit_ids rest') — contradicts assumption *)
+  >> (drule_all dep_of_child_earlier_pos >> strip_tac >>
+      gvs[stack_pos_ordered_def] >>
+      first_x_assum (qspecl_then [`dep_pos`, `inst_pos`] mp_tac) >>
+      simp[])
+QED
+
+(* C1: stack_well_ordered for new stack *)
+Resume dfs_step_preserves_topo[C1]:
+  non_pseudo_setup_tac >>
+  once_rewrite_tac[GSYM APPEND_ASSOC] >>
+  irule swo_process_prefix >> conj_tac
+  (* Part a: sorted children's data deps not in emit_ids of suffix *)
+  >- (simp[Abbr `sorted`, Abbr `children`,
+           stack_emit_ids_append, stack_emit_ids_def] >>
+      rpt strip_tac >>
+      (`MEM si (inst_all_deps bi order eda inst)` by
+         metis_tac[sort_children_mem] >>
+       gvs[dfs_topo_inv_def] >> metis_tac[dep_not_in_suffix]))
+  (* Part b: [DfsEmit inst'] ++ rest' is well-ordered *)
+  >> (simp[stack_well_ordered_def] >> conj_tac
+      >- (rpt gen_tac >> strip_tac >> suspend "C1_deps")
+      >> suspend "C1_rest")
+QED
+
+
+
+(* C1_deps: inst' data deps are resolved and not in rest' emit_ids *)
+Resume dfs_step_preserves_topo[C1_deps]:
+  (* Goal: MEM dep.inst_id resolved ∧ ¬MEM dep.inst_id (stack_emit_ids rest')
+     where dep ∈ inst_all_deps of inst' *)
+  fs[Abbr `inst'`] >>
+  `MEM dep (inst_all_deps bi order eda inst)` by
+    metis_tac[maybe_flip_all_deps_in_all_deps] >>
+  conj_tac
+  (* MEM dep.inst_id in resolved — via sorted children *)
+  >- (simp[MEM_MAP] >> disj1_tac >> disj1_tac >>
+      qexists `dep` >> simp[Abbr `children`] >>
+      metis_tac[sort_children_mem])
+  (* ¬MEM dep.inst_id (stack_emit_ids rest') *)
+  >> (gvs[dfs_topo_inv_def] >>
+      irule pos_ordered_not_in_emit >>
+      qexistsl [`bi`, `inst.inst_id`] >> simp[] >> conj_tac
+      >- gvs[stack_pos_ordered_def]
+      >> (gvs[eda_topo_compatible_def] >>
+          first_x_assum (qspecl_then [`inst`, `dep`] mp_tac) >>
+          simp[] >> strip_tac >>
+          qexistsl [`i`, `j`] >> simp[]))
+QED
+
+(* C1_rest: rest' well-ordered with larger resolved set *)
+Resume dfs_step_preserves_topo[C1_rest]:
+  fs[dfs_topo_inv_def] >>
+  qpat_x_assum `stack_well_ordered (DfsProcess inst :: rest') _ _ _ _` mp_tac >>
+  simp[stack_well_ordered_def] >> strip_tac >>
+  irule stack_well_ordered_mono >>
+  qexists `inst.inst_id ::
+           (MAP (\i. i.inst_id) state.ds_output ++ state.ds_visited)` >>
+  simp[MEM_APPEND, MEM_REVERSE] >> metis_tac[MEM]
+QED
+
+(* C2-C5, C8 all follow the emit-id simplification pattern *)
+Resume dfs_step_preserves_topo[C2]:
+  emit_id_tac
+QED
+Resume dfs_step_preserves_topo[C2_eda]:
+  emit_id_tac
+QED
+Resume dfs_step_preserves_topo[C3]:
+  emit_id_tac
+QED
+Resume dfs_step_preserves_topo[C4]:
+  emit_id_tac
+QED
+Resume dfs_step_preserves_topo[C5]:
+  emit_id_tac
+QED
+Resume dfs_step_preserves_topo[C6]:
+  gvs[dfs_topo_inv_def]
+QED
+Resume dfs_step_preserves_topo[C7]:
+  gvs[dfs_topo_inv_def] >> metis_tac[]
+QED
+Resume dfs_step_preserves_topo[C7_eda]:
+  gvs[dfs_topo_inv_def] >> metis_tac[]
+QED
+Resume dfs_step_preserves_topo[C8]:
+  emit_id_tac
+QED
+
+(* Helper: stack_pos_ordered for MAP DfsProcess l ++ suffix
+   when suffix is pos_ordered and each l item's position ≤ all emit positions in suffix *)
+Triviality spo_map_process_suffix[local]:
+  !l suffix bi.
+    stack_pos_ordered bi suffix /\
+    (!si x xi yi.
+       MEM si l /\ ~is_pseudo si.inst_opcode /\
+       MEM x (stack_emit_ids suffix) /\
+       xi < LENGTH bi /\ (EL xi bi).inst_id = x /\
+       yi < LENGTH bi /\ (EL yi bi).inst_id = si.inst_id ==>
+       yi <= xi) ==>
+    stack_pos_ordered bi (MAP DfsProcess l ++ suffix)
+Proof
+  Induct >> simp[stack_pos_ordered_def, stack_emit_ids_map_process] >>
+  rpt strip_tac
+  >- (gvs[stack_emit_ids_append, stack_emit_ids_map_process] >>
+      first_x_assum (qspecl_then [`h`, `(EL xi bi).inst_id`,
+                                  `xi`, `yi`] mp_tac) >>
+      simp[])
+  >> first_x_assum irule >> simp[] >> metis_tac[]
+QED
+
+(* Helper: sorted child is a dep of inst → has earlier block position *)
+Triviality sorted_child_earlier_pos[local]:
+  !bi order eda offspring_map inst si.
+    MEM si (sort_children bi order eda offspring_map inst
+              (inst_all_deps bi order eda inst)) /\
+    ~is_pseudo si.inst_opcode /\
+    eda_topo_compatible bi eda order /\
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode ==>
+    ?si_pos inst_pos.
+      si_pos < inst_pos /\ inst_pos < LENGTH bi /\ si_pos < LENGTH bi /\
+      EL si_pos bi = si /\ EL inst_pos bi = inst
+Proof
+  rpt strip_tac >>
+  `MEM si (inst_all_deps bi order eda inst)` by metis_tac[sort_children_mem] >>
+  gvs[eda_topo_compatible_def]
+QED
+
+(* C9: stack_pos_ordered *)
+Resume dfs_step_preserves_topo[C9]:
+  non_pseudo_setup_tac >>
+  once_rewrite_tac[GSYM APPEND_ASSOC] >>
+  irule spo_map_process_suffix >>
+  simp[stack_pos_ordered_def, stack_emit_ids_def] >>
+  gvs[dfs_topo_inv_def, stack_pos_ordered_def] >>
+  simp[Abbr `sorted`, Abbr `children`] >>
+  rpt strip_tac
+  (* sorted child si vs inst.inst_id *)
+  >- (drule_all sorted_child_earlier_pos >> strip_tac >>
+      `yi = si_pos` by metis_tac[pos_unique] >>
+      `xi = inst_pos` by metis_tac[pos_unique] >>
+      simp[])
+  (* sorted child si vs emit_ids in rest' *)
+  >> (drule_all sorted_child_earlier_pos >> strip_tac >>
+      `yi = si_pos` by metis_tac[pos_unique] >>
+      `inst_pos <= xi` by metis_tac[] >>
+      simp[])
+QED
+
+Finalise dfs_step_preserves_topo
+
+(* ===== FUNPOW lifting ===== *)
+
+Triviality dfs_topo_funpow[local]:
+  !n bi order eda offspring_map do_flip state.
+    dfs_topo_inv bi order eda state /\
+    dfs_good_state bi state /\
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    np_defs_before_uses bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    dfs_topo_inv bi order eda
+      (FUNPOW (dfs_step bi order eda offspring_map do_flip) n state)
+Proof
+  Induct >> simp[FUNPOW] >> rpt strip_tac >>
+  first_x_assum irule >>
+  simp[dfs_step_preserves_topo, dfs_step_preserves_good]
+QED
+
+Triviality swo_map_process[local]:
+  !entries resolved bi order.
+    stack_well_ordered (MAP DfsProcess entries) resolved bi order eda
+Proof
+  Induct >> simp[stack_well_ordered_def, stack_emit_ids_map_process]
+QED
+
+Triviality init_topo_inv[local]:
+  !entries bi order eda.
+    dfs_topo_inv bi order eda
+      <| ds_stack := MAP DfsProcess entries;
+         ds_output := []; ds_visited := [] |>
+Proof
+  rw[dfs_topo_inv_def, output_producer_before_def, output_eda_before_def,
+     stack_emit_ids_map_process, swo_map_process,
+     stack_pos_ordered_map_process]
+QED
+
+(* ===== Main results ===== *)
+
+(* The full invariant holds at schedule_from_entries output *)
+Triviality schedule_topo_inv[local]:
+  !bi order eda offspring_map entries.
+    eda_wf eda bi /\
+    eda_topo_compatible bi eda order /\
+    np_defs_before_uses bi /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) /\
+    EVERY (\i. MEM i bi) entries ==>
+    dfs_topo_inv bi order eda
+      (FUNPOW (dfs_step bi order eda offspring_map T)
+         ((LENGTH bi + 1) * (LENGTH bi + 1))
+         <| ds_stack := MAP DfsProcess entries;
+            ds_output := []; ds_visited := [] |>)
+Proof
+  rpt strip_tac >>
+  irule dfs_topo_funpow >>
+  simp[init_topo_inv, init_dfs_state_good]
+QED
+
+(* Every non-pseudo producing instruction appears before its user in
+   the DFS schedule output. *)
+Theorem schedule_output_producer_before:
+  !bi order eda offspring_map entries.
+    eda_wf eda bi ==>
+    eda_topo_compatible bi eda order ==>
+    np_defs_before_uses bi ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    bi <> [] ==>
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    EVERY (\i. MEM i bi) entries ==>
+    output_producer_before bi
+      (schedule_from_entries bi order eda offspring_map entries)
+Proof
+  rw[schedule_from_entries_def, LET_THM] >>
+  drule_all schedule_topo_inv >> simp[dfs_topo_inv_def]
+QED
+
+(* Every non-pseudo EDA dependency appears before its dependent
+   instruction in the DFS schedule output. *)
+Theorem schedule_output_eda_before:
+  !bi order eda offspring_map entries.
+    eda_wf eda bi ==>
+    eda_topo_compatible bi eda order ==>
+    np_defs_before_uses bi ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    bi <> [] ==>
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    EVERY (\i. MEM i bi) entries ==>
+    output_eda_before eda
+      (schedule_from_entries bi order eda offspring_map entries)
+Proof
+  rw[schedule_from_entries_def, LET_THM] >>
+  drule_all schedule_topo_inv >> simp[dfs_topo_inv_def]
+QED
+
+(* The DFS schedule output has no duplicate instruction IDs. *)
+Theorem schedule_output_all_distinct:
+  !bi order eda offspring_map entries.
+    eda_wf eda bi ==>
+    eda_topo_compatible bi eda order ==>
+    np_defs_before_uses bi ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    bi <> [] ==>
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) ==>
+    EVERY (\i. MEM i bi) entries ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id)
+      (schedule_from_entries bi order eda offspring_map entries))
+Proof
+  rw[schedule_from_entries_def, LET_THM] >>
+  drule_all schedule_topo_inv >> simp[dfs_topo_inv_def]
+QED
+
+

--- a/venom/passes/dft/proofs/dftWfScript.sml
+++ b/venom/passes/dft/proofs/dftWfScript.sml
@@ -476,8 +476,9 @@ Triviality inst_in_unique_block:
     bb1 = bb2
 Proof
   rpt strip_tac >>
-  qspecl_then [`\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
-               `bbs`, `bb1`, `bb2`, `id`]
+  qspecl_then [`bbs`,
+               `\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
+               `bb1`, `bb2`, `id`]
     mp_tac all_distinct_flat_map_unique >>
   simp[]
 QED
@@ -526,8 +527,9 @@ Proof
   gvs[] >>
   (* Step 4: Same block: def_bb = bb *)
   `def_bb = bb` by (
-    qspecl_then [`\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
-                 `fn.fn_blocks`, `def_bb`, `bb`, `def_inst.inst_id`]
+    qspecl_then [`fn.fn_blocks`,
+                 `\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
+                 `def_bb`, `bb`, `def_inst.inst_id`]
       mp_tac all_distinct_flat_map_unique >>
     impl_tac >- (
       gvs[fn_inst_ids_distinct_def] >>

--- a/venom/passes/dft/proofs/dftWfScript.sml
+++ b/venom/passes/dft/proofs/dftWfScript.sml
@@ -1,0 +1,1511 @@
+(*
+ * DFT Pass — Well-Formedness Preservation
+ *
+ * Key results:
+ *   terminator_not_dep_target — no instruction depends on terminator
+ *   schedule_terminator_last — terminator is emitted last by schedule
+ *
+ * Used by dftCorrectness to prove dft_block_well_formed.
+ *)
+
+Theory dftWf
+Ancestors
+  dftCompleteness dftStructural dftDefs venomWf
+  dftTopoSort dftScheduleFixed dftIdempotent dftPipelineInvar
+  allocaRemapSSA venomInst
+  list rich_list sorting
+  finite_map pred_set pair arithmetic
+
+(* ================================================================
+   Section 1: No instruction depends on the terminator
+   ================================================================ *)
+
+(* The terminator (LAST bi) is never a dep of any non-pseudo instruction.
+   Proof: eda_topo_compatible says every dep is at a strictly earlier index.
+   LAST bi is at the maximum index PRE(LENGTH bi). If LAST bi were a dep of
+   some instruction, that instruction would need to be at an index > PRE(LENGTH bi),
+   which is impossible since indices are < LENGTH bi. *)
+Theorem terminator_not_dep_target:
+  !bi eda order i.
+    eda_topo_compatible bi eda order /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    bi <> [] /\
+    ~is_pseudo (LAST bi).inst_opcode /\
+    eda_wf eda bi /\
+    MEM i bi /\ ~is_pseudo i.inst_opcode ==>
+    ~MEM (LAST bi).inst_id
+      (MAP (\d. d.inst_id) (inst_all_deps bi order eda i))
+Proof
+  rpt strip_tac >>
+  spose_not_then strip_assume_tac >>
+  gvs[MEM_MAP] >>
+  rename1 `MEM d (inst_all_deps bi order eda i)` >>
+  `MEM d bi` by metis_tac[inst_all_deps_mem] >>
+  (* eda_topo_compatible gives d at earlier index than i *)
+  `~is_pseudo d.inst_opcode` by (
+    `?kd. kd < LENGTH bi /\ EL kd bi = d` by metis_tac[MEM_EL] >>
+    spose_not_then assume_tac >>
+    (* d is pseudo but d.inst_id = (LAST bi).inst_id. Since ALL_DISTINCT
+       on inst_ids, d and LAST bi are at the same index, hence d = LAST bi.
+       But LAST bi is not pseudo — contradiction. *)
+    `LAST bi = EL (PRE (LENGTH bi)) bi` by simp[LAST_EL] >>
+    `PRE (LENGTH bi) < LENGTH bi` by (Cases_on `bi` >> gvs[]) >>
+    `(EL kd bi).inst_id = (EL (PRE (LENGTH bi)) bi).inst_id` by gvs[] >>
+    `EL kd (MAP (\x. x.inst_id) bi) = EL (PRE (LENGTH bi)) (MAP (\x. x.inst_id) bi)` by
+      simp[EL_MAP] >>
+    `kd = PRE (LENGTH bi)` by (
+      qspecl_then [`MAP (\x. x.inst_id) bi`, `kd`, `PRE (LENGTH bi)`] mp_tac
+        ALL_DISTINCT_EL_IMP >> simp[]) >>
+    gvs[]) >>
+  (* eda_topo_compatible: d is at earlier index than i *)
+  `?id j. id < j /\ j < LENGTH bi /\ id < LENGTH bi /\
+          EL id bi = d /\ EL j bi = i` by (
+    gvs[eda_topo_compatible_def]) >>
+  (* d.inst_id = (LAST bi).inst_id, so d is at index PRE(LENGTH bi) *)
+  `PRE (LENGTH bi) < LENGTH bi` by (Cases_on `bi` >> gvs[]) >>
+  `(EL id bi).inst_id = (EL (PRE (LENGTH bi)) bi).inst_id` by
+    gvs[LAST_EL] >>
+  `EL id (MAP (\x. x.inst_id) bi) =
+   EL (PRE (LENGTH bi)) (MAP (\x. x.inst_id) bi)` by simp[EL_MAP] >>
+  `id = PRE (LENGTH bi)` by (
+    qspecl_then [`MAP (\x. x.inst_id) bi`, `id`, `PRE (LENGTH bi)`] mp_tac
+      ALL_DISTINCT_EL_IMP >> simp[]) >>
+  (* id = PRE(LENGTH bi) < j < LENGTH bi → contradiction *)
+  gvs[]
+QED
+
+(* ================================================================
+   Section 2: DFS emits bottom-of-stack element last
+   ================================================================ *)
+
+(* Predicate: no stack item has the given inst_id *)
+Definition id_not_in_stack_def:
+  id_not_in_stack tid [] = T /\
+  id_not_in_stack tid (DfsProcess i :: rest) =
+    (i.inst_id <> tid /\ id_not_in_stack tid rest) /\
+  id_not_in_stack tid (DfsEmit i :: rest) =
+    (i.inst_id <> tid /\ id_not_in_stack tid rest)
+End
+
+Triviality id_not_in_stack_append[simp]:
+  !l1 l2 tid.
+    id_not_in_stack tid (l1 ++ l2) <=>
+    id_not_in_stack tid l1 /\ id_not_in_stack tid l2
+Proof
+  Induct >> simp[id_not_in_stack_def] >>
+  Cases >> simp[id_not_in_stack_def] >> metis_tac[]
+QED
+
+Triviality id_not_in_map_process[simp]:
+  !l tid.
+    id_not_in_stack tid (MAP DfsProcess l) <=>
+    EVERY (\i. i.inst_id <> tid) l
+Proof
+  Induct >> simp[id_not_in_stack_def]
+QED
+
+(* flip_operands preserves inst_id *)
+Triviality flip_id[simp]:
+  (flip_operands i).inst_id = i.inst_id
+Proof
+  simp[flip_operands_def] >>
+  CASE_TAC >> simp[] >> Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[] >> rw[] >> simp[]
+QED
+
+(* Children of any instruction don't have the terminator's id *)
+Triviality children_no_tid:
+  !bi order eda offspring_map top tid.
+    MEM top bi ==> ~is_pseudo top.inst_opcode ==>
+    eda_wf eda bi ==>
+    (!i. MEM i bi /\ ~is_pseudo i.inst_opcode ==>
+         ~MEM tid (MAP (\d. d.inst_id) (inst_all_deps bi order eda i))) ==>
+    EVERY (\x. x.inst_id <> tid)
+      (sort_children bi order eda offspring_map top
+         (inst_all_deps bi order eda top))
+Proof
+  rpt strip_tac >> simp[EVERY_MEM] >> rpt strip_tac >>
+  `MEM x (inst_all_deps bi order eda top)` by
+    metis_tac[sort_children_mem] >>
+  spose_not_then assume_tac >> gvs[] >>
+  first_x_assum (qspec_then `top` mp_tac) >> simp[] >>
+  simp[MEM_MAP] >> qexists_tac `x` >> simp[]
+QED
+
+(* The children + DfsEmit pushed by processing a non-pseudo instruction
+   don't contain tid *)
+Triviality pushed_no_tid:
+  !bi order eda offspring_map top tid.
+    MEM top bi ==> ~is_pseudo top.inst_opcode ==>
+    top.inst_id <> tid ==>
+    eda_wf eda bi ==>
+    (!i. MEM i bi /\ ~is_pseudo i.inst_opcode ==>
+         ~MEM tid (MAP (\d. d.inst_id) (inst_all_deps bi order eda i))) ==>
+    let sorted = sort_children bi order eda offspring_map top
+                   (inst_all_deps bi order eda top) in
+    let inst' = if is_flippable top.inst_opcode /\
+                   sorted <> inst_all_deps bi order eda top
+                then flip_operands top else top in
+    id_not_in_stack tid
+      (MAP DfsProcess sorted ++ [DfsEmit inst'])
+Proof
+  rpt strip_tac >> simp[LET_THM, id_not_in_stack_def] >>
+  conj_tac
+  >- (drule children_no_tid >> rpt (disch_then drule) >>
+      strip_tac >> gvs[id_not_in_map_process])
+  >> (rw[] >> simp[])
+QED
+
+(* Invariant for the DFS FUNPOW. tid = (LAST bi).inst_id.
+   Either:
+   (A) DfsProcess with inst_id = tid is at stack bottom, not visited,
+       and no other stack item has tid
+   (B) DfsEmit with inst_id = tid is at stack bottom, and no other
+       stack item has tid
+   (C) tid has been emitted as LAST output, and stack is empty *)
+Definition bottom_inv_def:
+  bottom_inv tid state <=>
+    (?prefix inst.
+       state.ds_stack = prefix ++ [DfsProcess inst] /\
+       inst.inst_id = tid /\
+       ~is_pseudo inst.inst_opcode /\
+       id_not_in_stack tid prefix /\
+       ~MEM tid state.ds_visited) \/
+    (?prefix inst.
+       state.ds_stack = prefix ++ [DfsEmit inst] /\
+       inst.inst_id = tid /\
+       id_not_in_stack tid prefix) \/
+    (state.ds_output <> [] /\
+     (LAST state.ds_output).inst_id = tid /\
+     state.ds_stack = [])
+End
+
+(* Helper: when the stack top is processed (not the bottom item),
+   the bottom item is preserved and new items above don't contain tid.
+   This factors the common case analysis for Phases A, B, and C. *)
+
+(* dfs_step preserves bottom_inv — helper for pushed items *)
+Triviality pushed_stack_no_tid:
+  !bi order eda offspring_map top tid rest.
+    MEM top bi /\ ~is_pseudo top.inst_opcode /\
+    top.inst_id <> tid /\ eda_wf eda bi /\
+    (!i. MEM i bi /\ ~is_pseudo i.inst_opcode ==>
+         ~MEM tid (MAP (\d. d.inst_id) (inst_all_deps bi order eda i))) /\
+    id_not_in_stack tid rest ==>
+    id_not_in_stack tid
+      (MAP DfsProcess
+         (sort_children bi order eda offspring_map top
+            (inst_all_deps bi order eda top)) ++
+       [DfsEmit (if is_flippable top.inst_opcode /\
+          sort_children bi order eda offspring_map top
+            (inst_all_deps bi order eda top) <>
+          inst_all_deps bi order eda top
+        then flip_operands top else top)] ++ rest)
+Proof
+  rpt strip_tac >>
+  mp_tac (Q.SPECL [`bi`,`order`,`eda`,`offspring_map`,`top`,`tid`]
+            pushed_no_tid) >>
+  simp[LET_THM]
+QED
+
+(* dfs_step preserves bottom_inv when tid is not a dep target.
+   Key: asm_rewrite_tac[dfs_step_def] resolves case on ds_stack
+   using the stack equality from bottom_inv. *)
+Theorem dfs_step_preserves_bottom_inv:
+  !bi order eda offspring_map state tid.
+    bottom_inv tid state ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    (!i. MEM i bi /\ ~is_pseudo i.inst_opcode ==>
+         ~MEM tid (MAP (\d. d.inst_id) (inst_all_deps bi order eda i))) ==>
+    eda_wf eda bi ==>
+    (!inst. MEM (DfsProcess inst) state.ds_stack /\
+            ~MEM inst.inst_id state.ds_visited /\
+            ~is_pseudo inst.inst_opcode ==>
+            MEM inst bi) ==>
+    bottom_inv tid (dfs_step bi order eda offspring_map T state)
+Proof
+  rpt strip_tac >> fs[bottom_inv_def]
+  >- suspend "phaseA"
+  >- suspend "phaseB"
+  >> suspend "phaseC"
+QED
+
+(* Phase A: DfsProcess inst at bottom, inst.inst_id = tid.
+   prefix=[]: inst at top → Phase B (DfsEmit at bottom).
+   prefix=hd::pfx: process hd at top, bottom inst preserved. *)
+Resume dfs_step_preserves_bottom_inv[phaseA]:
+  Cases_on `prefix`
+  (* prefix=[]: inst is at stack top, transitions to Phase B *)
+  >- (gvs[id_not_in_stack_def] >>
+      asm_rewrite_tac[dfs_step_def] >> simp[LET_THM] >>
+      conj_tac
+      >- (IF_CASES_TAC >> simp[])
+      >> (irule children_no_tid >> simp[]))
+  (* prefix=hd::pfx: process hd, bottom stays *)
+  >> (rename1 `hd :: pfx` >>
+      Cases_on `hd`
+      (* DfsProcess at top: top is processed, bottom inst stays *)
+      >- (gvs[id_not_in_stack_def] >>
+          rename1 `DfsProcess top` >>
+          asm_rewrite_tac[dfs_step_def] >> simp[] >>
+          IF_CASES_TAC >> gvs[] >>
+          IF_CASES_TAC >> gvs[] >>
+          rewrite_tac[LET_THM] >> BETA_TAC >>
+          `MEM top bi` by (
+            qpat_x_assum `!inst'. _ ==> MEM inst' bi`
+              (qspec_then `top` mp_tac) >> simp[]) >>
+          conj_tac
+          >- (irule children_no_tid >> simp[])
+          >> (simp[id_not_in_stack_def] >> rw[] >> simp[]))
+      (* DfsEmit at top: simp resolves entirely *)
+      >> (gvs[id_not_in_stack_def] >>
+          asm_rewrite_tac[dfs_step_def] >> simp[]))
+QED
+
+(* Phase B: DfsEmit inst at bottom, inst.inst_id = tid *)
+Resume dfs_step_preserves_bottom_inv[phaseB]:
+  Cases_on `prefix`
+  >- (gvs[id_not_in_stack_def] >>
+      asm_rewrite_tac[dfs_step_def] >> simp[id_not_in_stack_def])
+  >> (rename1 `hd :: pfx` >>
+      Cases_on `hd`
+      (* DfsProcess at top *)
+      >- (gvs[id_not_in_stack_def] >>
+          rename1 `DfsProcess top` >>
+          asm_rewrite_tac[dfs_step_def] >> simp[] >>
+          IF_CASES_TAC >> gvs[] >>
+          IF_CASES_TAC >> gvs[] >>
+          rewrite_tac[LET_THM] >> BETA_TAC >>
+          `MEM top bi` by (
+            qpat_x_assum `!inst'. _ ==> MEM inst' bi`
+              (qspec_then `top` mp_tac) >> simp[]) >>
+          conj_tac
+          >- (irule children_no_tid >> simp[])
+          >> (simp[id_not_in_stack_def] >> rw[] >> simp[]))
+      (* DfsEmit at top *)
+      >> (gvs[id_not_in_stack_def] >>
+          asm_rewrite_tac[dfs_step_def] >> simp[]))
+QED
+
+(* Phase C: already emitted, stack empty — dfs_step does nothing *)
+Resume dfs_step_preserves_bottom_inv[phaseC]:
+  gvs[dfs_step_def]
+QED
+
+Finalise dfs_step_preserves_bottom_inv
+
+(* The stack items hypothesis is also preserved by dfs_step *)
+Theorem dfs_step_stack_from_bi:
+  !bi order eda offspring_map state.
+    eda_wf eda bi ==>
+    (!inst. MEM (DfsProcess inst) state.ds_stack /\
+            ~MEM inst.inst_id state.ds_visited /\
+            ~is_pseudo inst.inst_opcode ==> MEM inst bi) ==>
+    (!inst. MEM (DfsProcess inst)
+              (dfs_step bi order eda offspring_map T state).ds_stack /\
+            ~MEM inst.inst_id
+              (dfs_step bi order eda offspring_map T state).ds_visited /\
+            ~is_pseudo inst.inst_opcode ==>
+            MEM inst bi)
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `MEM _ (dfs_step _ _ _ _ _ _).ds_stack` mp_tac >>
+  qpat_x_assum `~MEM _ (dfs_step _ _ _ _ _ _).ds_visited` mp_tac >>
+  Cases_on `state.ds_stack`
+  >- (asm_rewrite_tac[dfs_step_def] >> simp[])
+  >> rename1 `_ = hd :: rest` >>
+     Cases_on `hd`
+  >- suspend "DfsProcess"
+  >> suspend "DfsEmit"
+QED
+
+Resume dfs_step_stack_from_bi[DfsProcess]:
+  rename1 `_ = DfsProcess top :: _` >>
+  asm_rewrite_tac[dfs_step_def] >> simp[] >>
+  IF_CASES_TAC >> gvs[] >>
+  IF_CASES_TAC >> gvs[] >>
+  (* visited / pseudo cases may be closed by gvs already *)
+  simp[LET_THM, MEM_APPEND, MEM_MAP] >>
+  rpt strip_tac >> gvs[] >>
+  TRY (first_x_assum irule >> gvs[MEM] >> NO_TAC) >>
+  drule inst_all_deps_mem >>
+  disch_then (qspecl_then [`order`, `top`, `inst`] mp_tac) >>
+  gvs[sort_children_mem]
+QED
+
+Resume dfs_step_stack_from_bi[DfsEmit]:
+  rename1 `_ = DfsEmit top :: _` >>
+  asm_rewrite_tac[dfs_step_def] >> simp[]
+QED
+
+Finalise dfs_step_stack_from_bi
+
+(* FUNPOW preservation *)
+(* Auxiliary: stack_from_bi is preserved by FUNPOW dfs_step *)
+Triviality funpow_stack_from_bi:
+  !n bi order eda offspring_map state.
+    eda_wf eda bi ==>
+    (!inst. MEM (DfsProcess inst) state.ds_stack /\
+            ~MEM inst.inst_id state.ds_visited /\
+            ~is_pseudo inst.inst_opcode ==> MEM inst bi) ==>
+    (!inst. MEM (DfsProcess inst)
+              (FUNPOW (dfs_step bi order eda offspring_map T) n state).ds_stack /\
+            ~MEM inst.inst_id
+              (FUNPOW (dfs_step bi order eda offspring_map T) n state).ds_visited /\
+            ~is_pseudo inst.inst_opcode ==> MEM inst bi)
+Proof
+  Induct >> simp[FUNPOW_SUC] >> rpt strip_tac >>
+  `!inst. MEM (DfsProcess inst)
+            (FUNPOW (dfs_step bi order eda offspring_map T) n state).ds_stack /\
+          ~MEM inst.inst_id
+            (FUNPOW (dfs_step bi order eda offspring_map T) n state).ds_visited /\
+          ~is_pseudo inst.inst_opcode ==> MEM inst bi` by (
+    last_x_assum (qspecl_then [`bi`, `order`, `eda`, `offspring_map`, `state`] mp_tac) >>
+    simp[]) >>
+  qspecl_then [`bi`, `order`, `eda`, `offspring_map`,
+               `FUNPOW (dfs_step bi order eda offspring_map T) n state`]
+    mp_tac dfs_step_stack_from_bi >> simp[]
+QED
+
+Theorem funpow_preserves_bottom_inv:
+  !n bi order eda offspring_map state tid.
+    bottom_inv tid state ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    (!i. MEM i bi /\ ~is_pseudo i.inst_opcode ==>
+         ~MEM tid (MAP (\d. d.inst_id) (inst_all_deps bi order eda i))) ==>
+    eda_wf eda bi ==>
+    (!inst. MEM (DfsProcess inst) state.ds_stack /\
+            ~MEM inst.inst_id state.ds_visited /\
+            ~is_pseudo inst.inst_opcode ==> MEM inst bi) ==>
+    bottom_inv tid
+      (FUNPOW (dfs_step bi order eda offspring_map T) n state)
+Proof
+  Induct >> simp[FUNPOW_SUC] >> rpt strip_tac >>
+  irule dfs_step_preserves_bottom_inv >> simp[] >>
+  `bottom_inv tid (FUNPOW (dfs_step bi order eda offspring_map T) n state)` by (
+    last_x_assum
+      (qspecl_then [`bi`,`order`,`eda`,`offspring_map`,`state`,`tid`] mp_tac) >>
+    simp[]) >>
+  simp[] >>
+  qspecl_then [`n`,`bi`,`order`,`eda`,`offspring_map`,`state`]
+    mp_tac funpow_stack_from_bi >> simp[]
+QED
+
+(* Final: schedule output ends with terminator *)
+Theorem schedule_terminator_last:
+  !bi order eda offspring_map.
+    eda_wf eda bi ==>
+    eda_topo_compatible bi eda order ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) ==>
+    bi <> [] ==>
+    ~is_pseudo (LAST bi).inst_opcode ==>
+    (!i. MEM i bi /\ ~is_pseudo i.inst_opcode ==>
+         ~MEM (LAST bi).inst_id
+           (MAP (\d. d.inst_id) (inst_all_deps bi order eda i))) ==>
+    let entries = entry_instructions bi order eda in
+    entries <> [] ==>
+    LAST entries = LAST bi ==>
+    id_not_in_stack (LAST bi).inst_id
+      (MAP DfsProcess (FRONT entries)) ==>
+    let output = schedule_from_entries bi order eda offspring_map entries in
+      output <> [] /\
+      (LAST output).inst_id = (LAST bi).inst_id
+Proof
+  simp[LET_THM, schedule_from_entries_def] >>
+  rpt (gen_tac ORELSE disch_tac) >>
+  (* Initial state has bottom_inv *)
+  qabbrev_tac `entries = entry_instructions bi order eda` >>
+  qabbrev_tac `final = FUNPOW (dfs_step bi order eda offspring_map T)
+    ((LENGTH bi + 1) * (LENGTH bi + 1))
+    <| ds_stack := MAP DfsProcess entries;
+       ds_output := []; ds_visited := [] |>` >>
+  `bottom_inv (LAST bi).inst_id
+     <| ds_stack := MAP DfsProcess entries;
+        ds_output := []; ds_visited := [] |>` by suspend "init_inv" >>
+  (* After FUNPOW steps, bottom_inv still holds *)
+  `bottom_inv (LAST bi).inst_id final` by suspend "funpow_inv" >>
+  (* Final state has empty stack *)
+  `final.ds_stack = []` by suspend "stack_empty" >>
+  (* From bottom_inv + empty stack: phase C holds *)
+  gvs[bottom_inv_def, id_not_in_stack_def]
+QED
+
+Resume schedule_terminator_last[init_inv]:
+  simp[bottom_inv_def] >> disj1_tac >>
+  qexistsl_tac [`MAP DfsProcess (FRONT entries)`,
+                 `LAST entries`] >>
+  `entries = FRONT entries ++ [LAST entries]` by
+    metis_tac[APPEND_FRONT_LAST] >>
+  qpat_x_assum `entries = _` (fn th =>
+    rewrite_tac[Once th]) >>
+  simp[id_not_in_map_process]
+QED
+
+Resume schedule_terminator_last[funpow_inv]:
+  qunabbrev_tac `final` >>
+  irule funpow_preserves_bottom_inv >> simp[] >>
+  rpt strip_tac >>
+  `MEM inst entries` by (
+    gvs[MEM_MAP] >> Cases_on `y` >> gvs[]) >>
+  qunabbrev_tac `entries` >>
+  imp_res_tac (SRULE [EVERY_MEM] entry_instructions_mem)
+QED
+
+Resume schedule_terminator_last[stack_empty]:
+  qunabbrev_tac `final` >> qunabbrev_tac `entries` >>
+  qspecl_then [`bi`, `order`, `eda`, `offspring_map`]
+    mp_tac schedule_all_visited >>
+  simp[LET_THM]
+QED
+
+Finalise schedule_terminator_last
+
+(* ================================================================
+   Section 3: eda_topo_compatible for original blocks
+   ================================================================ *)
+
+(* MEM in block implies MEM in fn_insts_blocks *)
+(* fn_inst_ids_distinct + same inst_id in two blocks ==> same block *)
+Triviality inst_in_unique_block:
+  !bbs bb1 bb2 id.
+    ALL_DISTINCT (FLAT (MAP (\bb. MAP (\i. i.inst_id)
+                                      bb.bb_instructions) bbs)) /\
+    MEM bb1 bbs /\ MEM bb2 bbs /\
+    MEM id (MAP (\i. i.inst_id) bb1.bb_instructions) /\
+    MEM id (MAP (\i. i.inst_id) bb2.bb_instructions) ==>
+    bb1 = bb2
+Proof
+  rpt strip_tac >>
+  qspecl_then [`\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
+               `bbs`, `bb1`, `bb2`, `id`]
+    mp_tac all_distinct_flat_map_unique >>
+  simp[]
+QED
+
+(* ALL_DISTINCT of FLAT (MAP f l) implies ALL_DISTINCT of f x for MEM x l *)
+Triviality all_distinct_flat_map_el:
+  !f l x. ALL_DISTINCT (FLAT (MAP f l)) /\ MEM x l ==>
+           ALL_DISTINCT (f x)
+Proof
+  gen_tac >> Induct >> simp[] >>
+  rpt strip_tac >> gvs[ALL_DISTINCT_APPEND]
+QED
+
+Theorem wf_fn_block_inst_ids_distinct:
+  !fn bb. wf_function fn /\ MEM bb fn.fn_blocks ==>
+    ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions)
+Proof
+  rpt strip_tac >>
+  gvs[wf_function_def, fn_inst_ids_distinct_def] >>
+  drule_all all_distinct_flat_map_el >> simp[]
+QED
+
+(* wf_ssa implies defs_before_uses for each block *)
+Theorem wf_ssa_defs_before_uses:
+  !fn bb.
+    wf_ssa fn /\ wf_function fn /\ MEM bb fn.fn_blocks ==>
+    defs_before_uses bb.bb_instructions
+Proof
+  rw[wf_ssa_def, wf_function_def, defs_before_uses_def] >>
+  rpt strip_tac >>
+  rename1 `producing_inst _ var = SOME prod` >>
+  (* Step 1: prod defines var in bb *)
+  drule_all producing_inst_unique >> strip_tac >>
+  (* Step 2: def_dominates_uses gives def_bb, def_inst *)
+  qpat_x_assum `def_dominates_uses _` mp_tac >>
+  simp[def_dominates_uses_def] >>
+  disch_then (qspecl_then [`bb`, `EL j bb.bb_instructions`, `var`] mp_tac) >>
+  (impl_tac >- simp[EL_MEM]) >>
+  strip_tac >>
+  (* Step 3: SSA uniqueness: prod = def_inst *)
+  `MEM prod (fn_insts fn)` by
+    (simp[fn_insts_def] >> irule mem_fn_insts_blocks >> metis_tac[]) >>
+  `MEM def_inst (fn_insts fn)` by
+    (simp[fn_insts_def] >> irule mem_fn_insts_blocks >> metis_tac[]) >>
+  `prod = def_inst` by metis_tac[ssa_unique_output] >>
+  gvs[] >>
+  (* Step 4: Same block: def_bb = bb *)
+  `def_bb = bb` by (
+    qspecl_then [`\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
+                 `fn.fn_blocks`, `def_bb`, `bb`, `def_inst.inst_id`]
+      mp_tac all_distinct_flat_map_unique >>
+    impl_tac >- (
+      gvs[fn_inst_ids_distinct_def] >>
+      simp[MEM_MAP] >> metis_tac[]) >>
+    simp[]) >>
+  gvs[] >>
+  (* Step 5: same-block ordering gives i < j' with EL j' bi = EL j bi *)
+  first_x_assum (K ALL_TAC) >> (* drop dominance *)
+  rename1 `i' < j'` >>
+  (* j' = j since inst IDs distinct within block *)
+  `j' = j` by (
+    `ALL_DISTINCT (MAP (\i. i.inst_id) bb.bb_instructions)` by (
+      qspecl_then [`\bb. MAP (\i. i.inst_id) bb.bb_instructions`,
+                   `fn.fn_blocks`, `bb`]
+        mp_tac all_distinct_flat_map_el >>
+      gvs[fn_inst_ids_distinct_def]) >>
+    `(EL j' bb.bb_instructions).inst_id =
+     (EL j bb.bb_instructions).inst_id` by gvs[] >>
+    `EL j' (MAP (\i. i.inst_id) bb.bb_instructions) =
+     EL j (MAP (\i. i.inst_id) bb.bb_instructions)` by
+      gvs[EL_MAP] >>
+    metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP]) >>
+  qexists `i'` >> gvs[]
+QED
+
+(* Data deps from operands point backward (defs_before_uses gives ordering) *)
+Triviality operand_dep_backward:
+  !bi inst dep v.
+    defs_before_uses bi /\
+    MEM inst bi /\
+    MEM (Var v) inst.inst_operands /\
+    producing_inst bi v = SOME dep ==>
+    ?i j. i < j /\ j < LENGTH bi /\ i < LENGTH bi /\
+          EL i bi = dep /\ EL j bi = inst
+Proof
+  rpt strip_tac >>
+  `?j. j < LENGTH bi /\ EL j bi = inst` by metis_tac[MEM_EL] >>
+  gvs[defs_before_uses_def] >>
+  first_x_assum (qspecl_then [`j`, `v`, `dep`] mp_tac) >>
+  simp[] >> strip_tac >>
+  qexistsl [`i`, `j`] >> simp[]
+QED
+
+(* producing_inst result precedes the terminator (last position) *)
+Triviality producing_inst_before_terminator:
+  !bi v dep.
+    bi <> [] /\
+    is_terminator (LAST bi).inst_opcode /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) /\
+    producing_inst bi v = SOME dep /\
+    ~is_terminator dep.inst_opcode ==>
+    ?i. i < PRE (LENGTH bi) /\ EL i bi = dep
+Proof
+  rpt strip_tac >>
+  drule_all producing_inst_unique >> strip_tac >>
+  `?i. i < LENGTH bi /\ EL i bi = dep` by metis_tac[MEM_EL] >>
+  qexists `i` >> simp[] >>
+  spose_not_then assume_tac >>
+  `i = PRE (LENGTH bi)` by simp[] >>
+  gvs[LAST_EL]
+QED
+
+(* ================================================================
+   Section 4: EDA deps point backward
+   ================================================================ *)
+
+(* compute_effect_deps: et' entries come from inst or old et *)
+Triviality compute_effect_deps_et_update:
+  !et inst deps et'.
+    compute_effect_deps et inst = (deps, et') ==>
+    (!eff w. FLOOKUP et'.et_last_write eff = SOME w ==>
+       w = inst \/ FLOOKUP et.et_last_write eff = SOME w) /\
+    (!eff rs r. FLOOKUP et'.et_all_reads eff = SOME rs /\ MEM r rs ==>
+       r = inst \/ ?rs0. FLOOKUP et.et_all_reads eff = SOME rs0 /\ MEM r rs0)
+Proof
+  rpt gen_tac >> strip_tac >>
+  gvs[compute_effect_deps_def, LET_THM] >>
+  conj_tac
+  >- (rpt strip_tac >> fs[read_foldl_last_write] >>
+      drule write_foldl_last_write >> simp[])
+  >> rpt strip_tac >>
+  drule read_foldl_all_reads >> disch_then drule >> strip_tac >> gvs[] >>
+  drule write_foldl_all_reads >> strip_tac >> gvs[]
+QED
+
+(* compute_effect_deps: all deps come from et entries *)
+Triviality compute_effect_deps_from_et:
+  !et inst deps et'.
+    compute_effect_deps et inst = (deps, et') ==>
+    !d. MEM d deps ==>
+      (?eff. FLOOKUP et.et_last_write eff = SOME d) \/
+      (?eff rs. FLOOKUP et.et_all_reads eff = SOME rs /\ MEM d rs)
+Proof
+  rpt gen_tac >> strip_tac >>
+  gvs[compute_effect_deps_def, LET_THM] >>
+  rpt strip_tac >>
+  gvs[MEM_nub, MEM_APPEND, MEM_FLAT, MEM_MAP, MEM_FILTER,
+      optionTheory.IS_SOME_EXISTS, et_get_reads_def] >>
+  BasicProvers.every_case_tac >> gvs[] >> metis_tac[]
+QED
+
+(* FOLDL invariant for build_eda: positional backward property.
+   After processing prefix, deps point to earlier prefix elements,
+   and et entries are from the prefix. *)
+Triviality build_eda_foldl_backward:
+  !suffix prefix acc et.
+    (* et entries are from prefix *)
+    (!eff w. FLOOKUP et.et_last_write eff = SOME w ==>
+       ?i. i < LENGTH prefix /\ EL i prefix = w) /\
+    (!eff rs r. FLOOKUP et.et_all_reads eff = SOME rs /\ MEM r rs ==>
+       ?i. i < LENGTH prefix /\ EL i prefix = r) /\
+    (* map deps point to earlier positions in prefix *)
+    (!j deps dep. j < LENGTH prefix /\
+       FLOOKUP acc (EL j prefix).inst_id = SOME deps /\ MEM dep deps ==>
+       ?i. i < j /\ EL i prefix = dep) /\
+    (* suffix is the rest of non_phis *)
+    ALL_DISTINCT (MAP (\i. i.inst_id) (prefix ++ suffix)) ==>
+    let result = FST (FOLDL (\(acc_map, et) inst.
+      let (deps, et') = compute_effect_deps et inst in
+      (acc_map |+ (inst.inst_id, deps), et'))
+      (acc, et) suffix) in
+    !j deps dep. j < LENGTH (prefix ++ suffix) /\
+      FLOOKUP result (EL j (prefix ++ suffix)).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i (prefix ++ suffix) = dep
+Proof
+  Induct
+  (* base case: suffix = [] *)
+  >- (rewrite_tac[APPEND_NIL, FOLDL, LET_THM, FST] >>
+      rpt strip_tac >> metis_tac[])
+  >> rpt gen_tac >> strip_tac
+  >> rename1 `h :: suffix`
+  >> Cases_on `compute_effect_deps et h`
+  >> rename1 `compute_effect_deps et h = (nd, ne)`
+  >> simp[Once FOLDL, LET_THM]
+  >> first_x_assum (qspecl_then
+       [`prefix ++ [h]`, `acc |+ (h.inst_id, nd)`, `ne`] mp_tac)
+  >> rewrite_tac[GSYM APPEND_ASSOC, APPEND]
+  >> simp_tac std_ss [LENGTH_APPEND, LENGTH, ADD_CLAUSES]
+  >> impl_tac
+  >- (rpt conj_tac
+      (* 1: et_last_write entries from prefix ++ [h] *)
+      >- (rpt strip_tac >>
+          drule_all compute_effect_deps_et_update >> strip_tac >>
+          first_x_assum drule >> strip_tac
+          >- (qexists `LENGTH prefix` >>
+              simp[EL_APPEND2, EL_APPEND1])
+          >> first_x_assum drule >> strip_tac >>
+          qexists `i` >> simp[EL_APPEND1])
+      (* 2: et_all_reads entries from prefix ++ [h] *)
+      >- (rpt strip_tac >>
+          drule_all compute_effect_deps_et_update >> strip_tac >>
+          first_x_assum drule >> disch_then drule >> strip_tac
+          >- (qexists `LENGTH prefix` >>
+              simp[EL_APPEND2, EL_APPEND1])
+          >> first_x_assum (qspecl_then [`eff`, `rs0`, `r`] mp_tac) >>
+          simp[] >> strip_tac >>
+          qexists `i` >> simp[EL_APPEND1])
+      (* 3: map deps backward for prefix ++ [h] *)
+      >- (rpt strip_tac >>
+          Cases_on `j < LENGTH prefix`
+          >- (fs[EL_APPEND1, FLOOKUP_UPDATE] >>
+              `(EL j prefix).inst_id <> h.inst_id` by (
+                spose_not_then assume_tac >>
+                qpat_x_assum `ALL_DISTINCT _` mp_tac >>
+                simp[MAP_APPEND, ALL_DISTINCT_APPEND, MEM_MAP] >>
+                metis_tac[MEM_EL]) >>
+              fs[] >> first_x_assum drule_all >> strip_tac >>
+              qexists `i` >> simp[EL_APPEND1])
+          >> `j = LENGTH prefix` by (
+               `j < LENGTH prefix + 1` by fs[] >> simp[]) >>
+          fs[EL_APPEND2, FLOOKUP_UPDATE] >>
+          drule compute_effect_deps_from_et >>
+          disch_then (qspec_then `dep` mp_tac) >> simp[] >>
+          strip_tac
+          >- (first_x_assum drule >> strip_tac >>
+              qexists `i` >> simp[EL_APPEND1])
+          >> first_x_assum (qspecl_then [`eff`, `rs`, `dep`] mp_tac) >>
+          simp[] >> strip_tac >>
+          qexists `i` >> simp[EL_APPEND1])
+      (* 4: ALL_DISTINCT *)
+      >> simp[])
+  >> simp[]
+QED
+
+(* build_eda satisfies backward property on non_phis *)
+Triviality build_eda_backward:
+  !bi.
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) bi in
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) ==>
+    !j deps dep. j < LENGTH non_phis /\
+      FLOOKUP (build_eda bi) (EL j non_phis).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i non_phis = dep
+Proof
+  rpt gen_tac >> simp[LET_THM, build_eda_def] >> rpt strip_tac >>
+  qspecl_then
+    [`FILTER (\i. ~is_pseudo i.inst_opcode) bi`, `[]`,
+     `FEMPTY`, `empty_effect_track`]
+    mp_tac build_eda_foldl_backward >>
+  rewrite_tac[APPEND_NIL, LET_THM] >>
+  simp[empty_effect_track_def, FLOOKUP_DEF] >>
+  disch_then match_mp_tac >>
+  fs[empty_effect_track_def, FLOOKUP_DEF]
+QED
+
+(* FILTER preserves relative order: if i < j in FILTER P l,
+   the corresponding positions in l also satisfy i' < j'. *)
+Triviality filter_el_mono:
+  !P (l:'a list) i j. i < j /\ j < LENGTH (FILTER P l) ==>
+    ?i' j'. i' < j' /\ j' < LENGTH l /\
+            EL i' l = EL i (FILTER P l) /\ EL j' l = EL j (FILTER P l)
+Proof
+  gen_tac >> Induct >- simp[] >>
+  rw[FILTER] >> rename1 `h :: t` >>
+  Cases_on `P h` >> gvs[]
+  >- ((* P h: FILTER = h :: FILTER P t *)
+    Cases_on `i` >> gvs[]
+    >- suspend "case_zero"
+    >- suspend "case_suc")
+  >> suspend "case_not_P"
+QED
+
+Resume filter_el_mono[case_zero]:
+  `j - 1 < LENGTH (FILTER P t)` by
+    (Cases_on `j` >> gvs[]) >>
+  `MEM (EL (j - 1) (FILTER P t)) t` by
+    (imp_res_tac EL_MEM >> fs[MEM_FILTER]) >>
+  pop_assum (strip_assume_tac o REWRITE_RULE [MEM_EL]) >>
+  rename1 `n < LENGTH t` >>
+  qexistsl [`0`, `n + 1`] >>
+  Cases_on `j` >> gvs[EL_CONS, PRE_SUB1]
+QED
+
+Resume filter_el_mono[case_suc]:
+  rename1 `SUC i' < j` >>
+  first_x_assum (qspecl_then [`i'`, `j - 1`] mp_tac) >>
+  (impl_tac >- simp[]) >>
+  strip_tac >>
+  rename [`i_t < j_t`, `j_t < LENGTH t`] >>
+  qexistsl [`i_t + 1`, `j_t + 1`] >>
+  simp[] >> Cases_on `j` >> gvs[EL_CONS, PRE_SUB1]
+QED
+
+Resume filter_el_mono[case_not_P]:
+  first_x_assum (qspecl_then [`i`, `j`] mp_tac) >> simp[] >>
+  strip_tac >>
+  rename [`i_t < j_t`, `j_t < LENGTH t`] >>
+  qexistsl [`i_t + 1`, `j_t + 1`] >> simp[GSYM ADD1]
+QED
+
+Finalise filter_el_mono
+
+(* If p is in the prefix and h follows it in FILTER P non_phis,
+   then p appears before h in non_phis (by filter_el_mono). *)
+Triviality filter_last_prefix_before:
+  !P non_phis prefix h suffix j.
+    prefix ++ h :: suffix = FILTER P non_phis /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) /\
+    prefix <> [] /\
+    j < LENGTH non_phis /\
+    (EL j non_phis).inst_id = h.inst_id ==>
+    ?i. i < j /\ EL i non_phis = LAST prefix
+Proof
+  rpt strip_tac >>
+  (* LAST prefix is at index PRE(LENGTH prefix) in prefix *)
+  `?k. k < LENGTH prefix /\ EL k prefix = LAST prefix` by
+    (qexists `PRE (LENGTH prefix)` >> Cases_on `prefix` >> gvs[LAST_EL]) >>
+  (* Translate to indices in FILTER P non_phis *)
+  `EL k (FILTER P non_phis) = LAST prefix` by
+    (`EL k (prefix ++ h :: suffix) = EL k prefix` by simp[EL_APPEND1] >>
+     metis_tac[]) >>
+  `EL (LENGTH prefix) (FILTER P non_phis) = h` by
+    (qpat_x_assum `_ = FILTER P non_phis` (SUBST1_TAC o SYM) >>
+     simp[EL_APPEND2]) >>
+  `LENGTH prefix < LENGTH (FILTER P non_phis)` by
+    (`LENGTH (FILTER P non_phis) = LENGTH prefix + SUC (LENGTH suffix)`
+       by metis_tac[LENGTH_APPEND, LENGTH] >> simp[]) >>
+  (* filter_el_mono: k < LENGTH prefix → ∃i' j'. i' < j' in non_phis *)
+  qspecl_then [`P`, `non_phis`, `k`, `LENGTH prefix`]
+    mp_tac filter_el_mono >> simp[] >> strip_tac >>
+  (* j' indexes h in non_phis; j = j' by ALL_DISTINCT *)
+  `j = j'` by (
+    `EL j (MAP (\i. i.inst_id) non_phis) =
+     EL j' (MAP (\i. i.inst_id) non_phis)` by simp[EL_MAP] >>
+    metis_tac[ALL_DISTINCT_EL_IMP, LENGTH_MAP]) >>
+  qexists `i'` >> simp[]
+QED
+
+(* FOLDL invariant for add_chain_deps.
+   matching = prefix ++ suffix (already processed ++ remaining).
+   prev = LAST_OPTION prefix.
+   All deps in acc point backward in non_phis. *)
+(* Helper: one step of add_chain_deps preserves backward property.
+   new_acc updates acc at h.inst_id with possibly LAST prefix prepended. *)
+Triviality chain_dep_update_backward:
+  !prefix h suffix non_phis acc.
+    prefix ++ h :: suffix = FILTER P non_phis /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) /\
+    (!j deps dep. j < LENGTH non_phis /\
+       FLOOKUP acc (EL j non_phis).inst_id = SOME deps /\
+       MEM dep deps ==>
+       ?i. i < j /\ EL i non_phis = dep) ==>
+    let old_deps = case FLOOKUP acc h.inst_id of NONE => [] | SOME ds => ds;
+        prev = if prefix = [] then NONE else SOME (LAST prefix);
+        new_deps = case prev of
+                     NONE => old_deps
+                   | SOME p => if MEM p old_deps then old_deps
+                               else p :: old_deps;
+        new_acc = acc |+ (h.inst_id, new_deps)
+    in
+    !j deps dep. j < LENGTH non_phis /\
+      FLOOKUP new_acc (EL j non_phis).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i non_phis = dep
+Proof
+  rpt strip_tac
+  >> simp_tac std_ss [LET_THM]
+  >> rpt strip_tac
+  >> Cases_on `(EL j non_phis).inst_id = h.inst_id`
+  >- (gvs[FLOOKUP_UPDATE] >>
+      Cases_on `prefix = []` >> gvs[] >>
+      Cases_on `FLOOKUP acc h.inst_id` >> gvs[] >>
+      suspend "hit")
+  >> gvs[FLOOKUP_UPDATE]
+QED
+
+Resume chain_dep_update_backward[hit]:
+  markerLib.RESUME_TAC
+  >> rpt strip_tac
+  >> qpat_x_assum `_ = FILTER P _` mp_tac
+  >> rewrite_tac[GSYM APPEND_ASSOC, APPEND]
+  >> strip_tac
+  (* Subgoal 1 (NONE): dep = LAST prefix *)
+  >> TRY (irule filter_last_prefix_before >> metis_tac[] >> NO_TAC)
+  (* Subgoal 2 (SOME x): case split on MEM in the if-then-else *)
+  >> Cases_on `MEM (LAST prefix) x` >> gvs[]
+  (* ¬MEM case remains; gvs mangled FILTER asm, recover h::suffix form *)
+  >> qpat_x_assum `_ = FILTER P _` mp_tac
+  >> rewrite_tac[GSYM APPEND_ASSOC, APPEND] >> strip_tac
+  >> irule filter_last_prefix_before >> metis_tac[]
+QED
+
+Finalise chain_dep_update_backward
+
+Triviality add_chain_deps_foldl_backward:
+  !suffix prefix acc prev non_phis.
+    (prefix ++ suffix = FILTER P non_phis) /\
+    (prev = if prefix = [] then NONE else SOME (LAST prefix)) /\
+    (!j deps dep. j < LENGTH non_phis /\
+       FLOOKUP acc (EL j non_phis).inst_id = SOME deps /\
+       MEM dep deps ==>
+       ?i. i < j /\ EL i non_phis = dep) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) ==>
+    let result = FST (FOLDL
+      (\(acc,prev) inst.
+        let old_deps =
+              case FLOOKUP acc inst.inst_id of NONE => [] | SOME ds => ds;
+            new_deps =
+              case prev of
+                NONE => old_deps
+              | SOME p => if MEM p old_deps then old_deps
+                          else p::old_deps
+        in (acc |+ (inst.inst_id, new_deps), SOME inst))
+      (acc, prev) suffix) in
+    !j deps dep. j < LENGTH non_phis /\
+      FLOOKUP result (EL j non_phis).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i non_phis = dep
+Proof
+  Induct
+  >- (rewrite_tac[APPEND_NIL, FOLDL, LET_THM, FST] >>
+      rpt strip_tac >> metis_tac[])
+  >> rpt gen_tac >> strip_tac
+  >> rename1 `h :: suffix`
+  >> simp[Once FOLDL, LET_THM]
+  >> qmatch_goalsub_abbrev_tac `FOLDL _ (new_acc, SOME h) suffix`
+  >> first_x_assum (qspecl_then
+       [`prefix ++ [h]`, `new_acc`, `SOME h`, `non_phis`] mp_tac)
+  >> rewrite_tac[GSYM APPEND_ASSOC, APPEND]
+  >> simp[LAST_APPEND_CONS]
+  >> impl_tac
+  >- suspend "foldl_step"
+  >> simp[]
+QED
+
+Resume add_chain_deps_foldl_backward[foldl_step]:
+  conj_tac
+  >- (qpat_x_assum `_ = FILTER P _` mp_tac >>
+      rewrite_tac[GSYM APPEND_ASSOC, APPEND] >> simp[])
+  >> simp[Abbr `new_acc`]
+  >> match_mp_tac (SIMP_RULE std_ss [LET_THM] chain_dep_update_backward)
+  >> metis_tac[]
+QED
+
+Finalise add_chain_deps_foldl_backward
+
+(* add_chain_deps preserves backward property. *)
+Triviality add_chain_deps_backward:
+  !P bi eda.
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) bi in
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) /\
+    (!j deps dep. j < LENGTH non_phis /\
+       FLOOKUP eda (EL j non_phis).inst_id = SOME deps /\
+       MEM dep deps ==>
+       ?i. i < j /\ EL i non_phis = dep) ==>
+    !j deps dep. j < LENGTH non_phis /\
+      FLOOKUP (add_chain_deps P bi eda) (EL j non_phis).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i non_phis = dep
+Proof
+  rpt gen_tac >> simp[LET_THM, add_chain_deps_def] >> rpt strip_tac >>
+  qspecl_then
+    [`FILTER P (FILTER (\i. ~is_pseudo i.inst_opcode) bi)`, `[]`,
+     `eda`, `NONE`, `FILTER (\i. ~is_pseudo i.inst_opcode) bi`]
+    mp_tac add_chain_deps_foldl_backward >>
+  rewrite_tac[APPEND_NIL, LET_THM] >>
+  simp[] >> disch_then drule_all >> simp[]
+QED
+
+(* Helper: updating acc at h preserves the backward property *)
+Triviality barrier_dep_update_backward:
+  !prefix h suffix last_bar acc.
+    ALL_DISTINCT (MAP (\i. i.inst_id) (prefix ++ h :: suffix)) /\
+    ~is_barrier h /\
+    (!b. last_bar = SOME b ==>
+       ?k. k < LENGTH prefix /\ EL k (prefix ++ h :: suffix) = b) /\
+    (!j deps dep. j < LENGTH (prefix ++ h :: suffix) /\
+       FLOOKUP acc (EL j (prefix ++ h :: suffix)).inst_id = SOME deps /\
+       MEM dep deps ==> ?i. i < j /\ EL i (prefix ++ h :: suffix) = dep)
+    ==>
+    let old_deps = case FLOOKUP acc h.inst_id of NONE => [] | SOME ds => ds;
+        new_deps = case last_bar of
+                     NONE => old_deps
+                   | SOME b => if MEM b old_deps then old_deps
+                               else b :: old_deps;
+        new_acc = acc |+ (h.inst_id, new_deps)
+    in
+    !j deps dep. j < LENGTH (prefix ++ h :: suffix) /\
+      FLOOKUP new_acc (EL j (prefix ++ h :: suffix)).inst_id = SOME deps /\
+      MEM dep deps ==> ?i. i < j /\ EL i (prefix ++ h :: suffix) = dep
+Proof
+  rpt gen_tac >> strip_tac >>
+  simp_tac std_ss [LET_THM] >> rpt strip_tac >>
+  Cases_on `(EL j (prefix ++ h :: suffix)).inst_id = h.inst_id`
+  >- suspend "h_case"
+  >> suspend "other_case"
+QED
+
+Resume barrier_dep_update_backward[other_case]:
+  gvs[FLOOKUP_UPDATE] >>
+  first_x_assum (qspecl_then [`j`, `deps`, `dep`] mp_tac) >> simp[]
+QED
+
+Resume barrier_dep_update_backward[h_case]:
+  `j = LENGTH prefix` by (
+    qspecl_then [`MAP (\i. i.inst_id) (prefix ++ h :: suffix)`,
+                 `j`, `LENGTH prefix`] mp_tac ALL_DISTINCT_EL_IMP >>
+    simp[EL_MAP, EL_LENGTH_APPEND_0] >> strip_tac >>
+    first_x_assum irule >> fs[]) >>
+  gvs[FLOOKUP_UPDATE, EL_APPEND2] >>
+  Cases_on `last_bar` >> Cases_on `FLOOKUP acc h.inst_id`
+  >- suspend "none_none"
+  >- suspend "none_some"
+  >- suspend "some_none"
+  >> suspend "some_some"
+QED
+
+Resume barrier_dep_update_backward[none_none]:
+  gvs[]
+QED
+
+Resume barrier_dep_update_backward[none_some]:
+  gvs[] >> rename1 `FLOOKUP acc h.inst_id = SOME old_ds` >>
+  first_x_assum (qspecl_then [`LENGTH prefix`, `old_ds`, `dep`] mp_tac) >>
+  simp[EL_APPEND2]
+QED
+
+Resume barrier_dep_update_backward[some_none]:
+  gvs[] >> qexists `k` >> simp[]
+QED
+
+Resume barrier_dep_update_backward[some_some]:
+  gvs[] >> rename1 `FLOOKUP acc h.inst_id = SOME old_ds` >>
+  Cases_on `MEM dep old_ds`
+  >- (first_x_assum (qspecl_then [`LENGTH prefix`, `old_ds`, `dep`] mp_tac) >>
+      simp[EL_APPEND2])
+  >> qpat_x_assum `MEM dep (if _ then _ else _)` mp_tac >>
+  IF_CASES_TAC >> simp[] >> strip_tac >> gvs[] >>
+  qexists `k` >> gvs[]
+QED
+
+Finalise barrier_dep_update_backward
+
+(* add_deps_on_barrier backward: all added deps point backward.
+   Helper: FOLDL induction on suffix of non_phis. *)
+Triviality add_deps_on_barrier_foldl_backward:
+  !suffix prefix nps last_bar acc.
+    nps = prefix ++ suffix /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) nps) /\
+    (!b. last_bar = SOME b ==>
+       ?k. k < LENGTH prefix /\ EL k nps = b) /\
+    (!j deps dep. j < LENGTH nps /\
+       FLOOKUP acc (EL j nps).inst_id = SOME deps /\
+       MEM dep deps ==> ?i. i < j /\ EL i nps = dep) ==>
+    !j deps dep. j < LENGTH nps /\
+      FLOOKUP (FST (FOLDL (\(acc, last_bar) inst.
+        if is_barrier inst then (acc, SOME inst)
+        else
+          (acc |+ (inst.inst_id,
+             case last_bar of
+               NONE => (case FLOOKUP acc inst.inst_id of
+                          NONE => [] | SOME ds => ds)
+             | SOME b =>
+                 if MEM b (case FLOOKUP acc inst.inst_id of
+                             NONE => [] | SOME ds => ds)
+                 then (case FLOOKUP acc inst.inst_id of
+                         NONE => [] | SOME ds => ds)
+                 else b :: (case FLOOKUP acc inst.inst_id of
+                              NONE => [] | SOME ds => ds)),
+           last_bar))
+      (acc, last_bar) suffix)) (EL j nps).inst_id = SOME deps /\
+      MEM dep deps ==> ?i. i < j /\ EL i nps = dep
+Proof
+  Induct
+  >- (rewrite_tac[FOLDL, FST] >> rpt strip_tac >> metis_tac[])
+  >> rpt gen_tac >> strip_tac >>
+  rename1 `h :: suffix'` >>
+  simp[Once FOLDL] >>
+  Cases_on `is_barrier h`
+  >- suspend "barrier"
+  >> suspend "non_barrier"
+QED
+
+Resume add_deps_on_barrier_foldl_backward[barrier]:
+  (* Barrier case: acc unchanged, last_bar becomes SOME h *)
+  simp[] >>
+  first_x_assum (qspecl_then [`prefix ++ [h]`, `prefix ++ h :: suffix'`,
+                              `SOME h`, `acc`] mp_tac) >>
+  rewrite_tac[GSYM APPEND_ASSOC, APPEND] >>
+  impl_tac
+  >- (qpat_x_assum `nps = _` SUBST_ALL_TAC >>
+      rpt conj_tac >> simp[]
+      >- (rpt strip_tac >>
+          qexists `LENGTH prefix` >> simp[EL_APPEND2, EL_APPEND1]))
+  >> simp[]
+QED
+
+Resume add_deps_on_barrier_foldl_backward[non_barrier]:
+  simp[] >>
+  qmatch_goalsub_abbrev_tac `FOLDL _ (new_acc, last_bar) suffix'` >>
+  first_x_assum (qspecl_then [`prefix ++ [h]`, `prefix ++ h :: suffix'`,
+                              `last_bar`, `new_acc`] mp_tac) >>
+  rewrite_tac[GSYM APPEND_ASSOC, APPEND] >>
+  impl_tac
+  >- suspend "nb_impl"
+  >> simp[]
+QED
+
+Resume add_deps_on_barrier_foldl_backward[nb_impl]:
+  qpat_x_assum `nps = _` SUBST_ALL_TAC >>
+  conj_tac >- simp[] >>
+  conj_tac
+  >- (rpt strip_tac >>
+      first_x_assum drule >> strip_tac >>
+      qexists `k` >> simp[])
+  >> simp[Abbr `new_acc`] >>
+  rpt strip_tac >>
+  irule (SRULE [LET_THM] (SIMP_RULE (srw_ss()) [] barrier_dep_update_backward)) >>
+  fs[MAP_APPEND, MAP] >>
+  qexistsl [`acc`, `deps`, `last_bar`] >> simp[]
+QED
+
+Finalise add_deps_on_barrier_foldl_backward
+
+Triviality add_deps_on_barrier_backward:
+  !bi eda.
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) bi in
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) /\
+    (!j deps dep. j < LENGTH non_phis /\
+       FLOOKUP eda (EL j non_phis).inst_id = SOME deps /\
+       MEM dep deps ==>
+       ?i. i < j /\ EL i non_phis = dep) ==>
+    !j deps dep. j < LENGTH non_phis /\
+      FLOOKUP (add_deps_on_barrier bi eda) (EL j non_phis).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i non_phis = dep
+Proof
+  rpt gen_tac >> simp[LET_THM, add_deps_on_barrier_def] >> rpt strip_tac >>
+  irule add_deps_on_barrier_foldl_backward >>
+  simp[] >>
+  qexistsl [`eda`, `deps`, `NONE`,
+            `[]`, `FILTER (\i. ~is_pseudo i.inst_opcode) bi`] >>
+  simp[]
+QED
+
+Triviality foldl_add_mem:
+  !prev init x.
+    MEM x (FOLDL (\ds (p:instruction). if MEM p ds then ds else p :: ds)
+             init prev) ==>
+    MEM x init \/ MEM x prev
+Proof
+  Induct >> simp[] >> rpt strip_tac >>
+  Cases_on `MEM h init` >> gvs[] >>
+  first_x_assum drule >> strip_tac >> gvs[]
+QED
+
+(* FOLDL lemma for add_deps_from_barrier backward property *)
+Triviality add_deps_from_barrier_foldl_backward:
+  !to_process prefix nps prev_insts acc.
+    nps = prefix ++ to_process /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) nps) /\
+    (!p. MEM p prev_insts ==>
+       ?k. k < LENGTH prefix /\ EL k nps = p) /\
+    (!j' deps' dep'. j' < LENGTH nps /\
+       FLOOKUP acc (EL j' nps).inst_id = SOME deps' /\
+       MEM dep' deps' ==> ?i'. i' < j' /\ EL i' nps = dep') ==>
+    !j' deps' dep'. j' < LENGTH nps /\
+      FLOOKUP (FST (FOLDL (\(acc, prev_insts) inst.
+        if is_barrier inst then
+          let old_deps = case FLOOKUP acc inst.inst_id of
+                           NONE => [] | SOME ds => ds in
+          let new_deps = FOLDL (\ds p.
+                if MEM p ds then ds else p :: ds) old_deps prev_insts in
+          (acc |+ (inst.inst_id, new_deps), prev_insts ++ [inst])
+        else
+          (acc, prev_insts ++ [inst]))
+      (acc, prev_insts) to_process)) (EL j' nps).inst_id = SOME deps' /\
+      MEM dep' deps' ==> ?i'. i' < j' /\ EL i' nps = dep'
+Proof
+  Induct
+  >- (rewrite_tac[APPEND_NIL, FOLDL, LET_THM, FST] >>
+      rpt strip_tac >> metis_tac[])
+  >> rpt gen_tac >> strip_tac
+  >> rename1 `h :: to_process`
+  >> Cases_on `is_barrier h`
+  (* Barrier case *)
+  >- (simp[Once FOLDL, LET_THM] >>
+      qmatch_goalsub_abbrev_tac `FOLDL _ (new_acc, new_prev) to_process` >>
+      first_x_assum (qspecl_then
+           [`prefix ++ [h]`, `nps`, `new_prev`, `new_acc`] mp_tac) >>
+      rewrite_tac[GSYM APPEND_ASSOC, APPEND] >> simp[] >>
+      (impl_tac >- suspend "barrier_step") >>
+      simp[])
+  (* Non-barrier case *)
+  >> (simp[Once FOLDL, LET_THM] >>
+      qmatch_goalsub_abbrev_tac `FOLDL _ (new_acc, new_prev) to_process` >>
+      first_x_assum (qspecl_then
+           [`prefix ++ [h]`, `nps`, `new_prev`, `new_acc`] mp_tac) >>
+      rewrite_tac[GSYM APPEND_ASSOC, APPEND] >> simp[] >>
+      (impl_tac >- suspend "non_barrier_step") >>
+      simp[])
+QED
+
+Resume add_deps_from_barrier_foldl_backward[non_barrier_step]:
+  simp[Abbr `new_prev`, Abbr `new_acc`] >>
+  gen_tac >> disch_tac >>
+  qpat_x_assum `_ \/ _` strip_assume_tac
+  >- (qpat_x_assum `!q. MEM q prev_insts ==> _`
+        (qspec_then `p` mp_tac) >>
+      simp[] >> strip_tac >> qexists `k` >> simp[])
+  >> (gvs[] >> qexists `LENGTH prefix` >> simp[EL_LENGTH_APPEND])
+QED
+
+Resume add_deps_from_barrier_foldl_backward[barrier_step]:
+  simp[Abbr `new_prev`, Abbr `new_acc`, LET_THM] >>
+  conj_tac
+  (* MEM conjunct — same pattern as non-barrier *)
+  >- (gen_tac >> disch_tac >>
+      qpat_x_assum `_ \/ _` strip_assume_tac
+      >- (qpat_x_assum `!q. MEM q prev_insts ==> _`
+            (qspec_then `p` mp_tac) >>
+          simp[] >> strip_tac >> qexists `k` >> simp[])
+      >> (gvs[] >> qexists `LENGTH prefix` >> simp[EL_LENGTH_APPEND]))
+  (* FLOOKUP conjunct *)
+  >> suspend "flookup_conj"
+QED
+
+Resume add_deps_from_barrier_foldl_backward[flookup_conj]:
+  rpt gen_tac >> strip_tac >>
+  Cases_on `(EL j' (prefix ++ h::to_process)).inst_id = h.inst_id`
+  >- (
+    `j' = LENGTH prefix` by (
+      gvs[] >>
+      qspecl_then [`MAP (\i. i.inst_id) (prefix ++ h::to_process)`,
+                   `j'`, `LENGTH prefix`] mp_tac ALL_DISTINCT_EL_IMP >>
+      (impl_tac >- (
+        RULE_ASSUM_TAC (PURE_REWRITE_RULE [GSYM APPEND_ASSOC, APPEND]) >>
+        simp[MAP_APPEND, MAP]
+      )) >>
+      simp[EL_MAP, EL_APPEND2]
+    ) >>
+    gvs[FLOOKUP_UPDATE] >>
+    RULE_ASSUM_TAC (PURE_REWRITE_RULE [GSYM APPEND_ASSOC, APPEND]) >>
+    Cases_on `FLOOKUP acc h.inst_id` >> gvs[] >>
+    drule foldl_add_mem >> disch_then strip_assume_tac >> gvs[] >>
+    first_x_assum drule >> strip_tac >> qexists `k` >> simp[]
+  )
+  >> (
+    gvs[FLOOKUP_UPDATE] >>
+    RULE_ASSUM_TAC (PURE_REWRITE_RULE [GSYM APPEND_ASSOC, APPEND]) >>
+    first_x_assum (qspecl_then [`j'`, `deps'`, `dep'`] mp_tac) >> simp[]
+  )
+QED
+
+Finalise add_deps_from_barrier_foldl_backward
+
+(* add_deps_from_barrier backward: all added deps point backward *)
+Triviality add_deps_from_barrier_backward:
+  !bi eda.
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) bi in
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) /\
+    (!j deps dep. j < LENGTH non_phis /\
+       FLOOKUP eda (EL j non_phis).inst_id = SOME deps /\
+       MEM dep deps ==>
+       ?i. i < j /\ EL i non_phis = dep) ==>
+    !j deps dep. j < LENGTH non_phis /\
+      FLOOKUP (add_deps_from_barrier bi eda) (EL j non_phis).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i non_phis = dep
+Proof
+  rpt gen_tac >> simp[LET_THM, add_deps_from_barrier_def] >> rpt strip_tac >>
+  qabbrev_tac `nps = FILTER (\i. ~is_pseudo i.inst_opcode) bi` >>
+  qspecl_then [`nps`, `[]`, `nps`, `[]`, `eda`] mp_tac
+    add_deps_from_barrier_foldl_backward >>
+  simp[]
+QED
+
+(* add_barrier_deps backward *)
+Triviality add_barrier_deps_backward:
+  !bi eda.
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) bi in
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) /\
+    (!j deps dep. j < LENGTH non_phis /\
+       FLOOKUP eda (EL j non_phis).inst_id = SOME deps /\
+       MEM dep deps ==>
+       ?i. i < j /\ EL i non_phis = dep) ==>
+    !j deps dep. j < LENGTH non_phis /\
+      FLOOKUP (add_barrier_deps bi eda) (EL j non_phis).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i non_phis = dep
+Proof
+  rpt gen_tac >> simp[LET_THM, add_barrier_deps_def] >> rpt strip_tac >>
+  irule (SRULE [LET_THM] add_deps_from_barrier_backward) >>
+  simp[] >>
+  qexistsl [`deps`, `add_deps_on_barrier bi eda`] >>
+  simp[] >>
+  MATCH_MP_TAC (SRULE [LET_THM] add_deps_on_barrier_backward) >>
+  simp[]
+QED
+
+(* build_full_eda backward property *)
+Triviality build_full_eda_backward:
+  !bi.
+    let non_phis = FILTER (\i. ~is_pseudo i.inst_opcode) bi in
+    ALL_DISTINCT (MAP (\i. i.inst_id) non_phis) ==>
+    !j deps dep. j < LENGTH non_phis /\
+      FLOOKUP (build_full_eda bi) (EL j non_phis).inst_id = SOME deps /\
+      MEM dep deps ==>
+      ?i. i < j /\ EL i non_phis = dep
+Proof
+  rpt gen_tac >> simp[LET_THM] >> rpt strip_tac >>
+  qabbrev_tac `nps = FILTER (\i. ~is_pseudo i.inst_opcode) bi` >>
+  (* Step 1: build_eda satisfies backward *)
+  `!j deps dep. j < LENGTH nps /\
+     FLOOKUP (build_eda bi) (EL j nps).inst_id = SOME deps /\
+     MEM dep deps ==> ?i. i < j /\ EL i nps = dep` by
+    (mp_tac (SRULE [LET_THM] build_eda_backward) >>
+     disch_then (qspec_then `bi` mp_tac) >>
+     simp[Abbr `nps`]) >>
+  (* Step 2: add_abort_deps preserves backward *)
+  `!j deps dep. j < LENGTH nps /\
+     FLOOKUP (add_abort_deps bi (build_eda bi)) (EL j nps).inst_id = SOME deps /\
+     MEM dep deps ==> ?i. i < j /\ EL i nps = dep` by
+    (rewrite_tac[add_abort_deps_def] >>
+     mp_tac (SRULE [LET_THM] add_chain_deps_backward) >>
+     disch_then (qspecl_then
+       [`\i. opcode_fail_class i.inst_opcode <> NoFail`, `bi`, `build_eda bi`] mp_tac) >>
+     simp[Abbr `nps`]) >>
+  (* Step 3: add_barrier_deps preserves backward *)
+  `!j deps dep. j < LENGTH nps /\
+     FLOOKUP (add_barrier_deps bi (add_abort_deps bi (build_eda bi)))
+       (EL j nps).inst_id = SOME deps /\
+     MEM dep deps ==> ?i. i < j /\ EL i nps = dep` by
+    (mp_tac (SRULE [LET_THM] add_barrier_deps_backward) >>
+     disch_then (qspecl_then [`bi`, `add_abort_deps bi (build_eda bi)`] mp_tac) >>
+     simp[Abbr `nps`]) >>
+  (* Step 4: add_alloca_deps preserves backward *)
+  `!j deps dep. j < LENGTH nps /\
+     FLOOKUP (build_full_eda bi) (EL j nps).inst_id = SOME deps /\
+     MEM dep deps ==> ?i. i < j /\ EL i nps = dep` by
+    (rewrite_tac[build_full_eda_def, add_alloca_deps_def] >>
+     mp_tac (SRULE [LET_THM] add_chain_deps_backward) >>
+     disch_then (qspecl_then
+       [`\i. is_alloca_op i.inst_opcode`, `bi`,
+        `add_barrier_deps bi (add_abort_deps bi (build_eda bi))`] mp_tac) >>
+     simp[Abbr `nps`]) >>
+  metis_tac[]
+QED
+
+
+(* EDA deps (from build_full_eda) point backward *)
+Theorem eda_deps_backward:
+  !bi inst dep deps.
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+    FLOOKUP (build_full_eda bi) inst.inst_id = SOME deps /\
+    MEM dep deps /\ ~is_pseudo dep.inst_opcode ==>
+    ?i j. i < j /\ j < LENGTH bi /\ i < LENGTH bi /\
+          EL i bi = dep /\ EL j bi = inst
+Proof
+  rpt strip_tac >>
+  qabbrev_tac `nps = FILTER (\i. ~is_pseudo i.inst_opcode) bi` >>
+  (* inst is in non_phis *)
+  `MEM inst nps` by simp[Abbr `nps`, MEM_FILTER] >>
+  `?j_nps. j_nps < LENGTH nps /\ EL j_nps nps = inst` by
+    metis_tac[MEM_EL] >>
+  (* ALL_DISTINCT inst_ids for non_phis *)
+  `ALL_DISTINCT (MAP (\i. i.inst_id) nps)` by
+    (simp[Abbr `nps`] >> irule all_distinct_map_filter >> simp[]) >>
+  (* Apply build_full_eda_backward: dep at earlier position in nps *)
+  mp_tac (SRULE [LET_THM] build_full_eda_backward) >>
+  disch_then (qspec_then `bi` mp_tac) >>
+  simp[Abbr `nps`] >> strip_tac >>
+  first_x_assum (qspecl_then [`j_nps`, `deps`, `dep`] mp_tac) >>
+  simp[] >> strip_tac >>
+  rename1 `i_nps < j_nps` >>
+  (* Lift positions from nps to bi using filter_el_mono *)
+  qspecl_then [`\i. ~is_pseudo i.inst_opcode`, `bi`, `i_nps`, `j_nps`]
+    mp_tac filter_el_mono >>
+  simp[] >> strip_tac >>
+  qexistsl [`i'`, `j'`] >> simp[]
+QED
+
+(* Generalized: eda_topo_compatible from block properties alone.
+   No dependency on fn or MEM bb fn.fn_blocks. *)
+Theorem eda_topo_compatible_gen:
+  !bi order.
+    bi <> [] /\
+    is_terminator (LAST bi).inst_opcode /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    defs_before_uses bi ==>
+    eda_topo_compatible bi (build_full_eda bi) order
+Proof
+  rpt strip_tac >>
+  simp[eda_topo_compatible_def, inst_all_deps_def, LET_THM] >>
+  rpt strip_tac >>
+  gvs[MEM_nub, MEM_APPEND]
+  (* data deps case *)
+  >- (fs[inst_data_deps_def, LET_THM, MEM_nub] >>
+      gvs[MEM_APPEND, MEM_MAP, MEM_FILTER]
+      >- ((* var_deps case *)
+        rename1 `MEM op inst.inst_operands` >>
+        Cases_on `op` >> gvs[operand_producer_def] >>
+        rename1 `producing_inst bi v` >>
+        Cases_on `producing_inst bi v` >> gvs[] >>
+        irule operand_dep_backward >>
+        metis_tac[])
+      >> (* order_deps case *)
+      Cases_on `is_terminator inst.inst_opcode` >> gvs[MEM_FILTER, MEM_MAP] >>
+      rename1 `IS_SOME (producing_inst bi w)` >>
+      Cases_on `producing_inst bi w` >> gvs[] >>
+      rename1 `producing_inst bi w = SOME dep` >>
+      `~is_terminator dep.inst_opcode` by (
+        spose_not_then assume_tac >>
+        drule_all producing_inst_unique >> strip_tac >>
+        `?k. k < LENGTH bi /\ EL k bi = dep` by metis_tac[MEM_EL] >>
+        `k = PRE (LENGTH bi)` by metis_tac[] >>
+        `?j. j < LENGTH bi /\ EL j bi = inst` by metis_tac[MEM_EL] >>
+        `j = PRE (LENGTH bi)` by metis_tac[] >>
+        gvs[]) >>
+      drule_all producing_inst_before_terminator >> strip_tac >>
+      `?j. j < LENGTH bi /\ EL j bi = inst` by metis_tac[MEM_EL] >>
+      `j = PRE (LENGTH bi)` by metis_tac[] >>
+      qexistsl [`i`, `j`] >> simp[])
+  (* eda deps case *)
+  >> (Cases_on `FLOOKUP (build_full_eda bi) inst.inst_id` >> gvs[] >>
+      irule eda_deps_backward >> metis_tac[])
+QED
+
+(* Weaker: defs_before_uses only for non-pseudo users.
+   Sufficient for eda_topo_compatible because it only quantifies
+   over non-pseudo instructions. *)
+(* non_pseudo_defs_before_uses = np_defs_before_uses from dftTopoSort *)
+(* TODO: pure alias for np_defs_before_uses — consider using
+   np_defs_before_uses directly and removing this indirection *)
+Definition non_pseudo_defs_before_uses_def:
+  non_pseudo_defs_before_uses = np_defs_before_uses
+End
+
+Triviality defs_before_implies_non_pseudo:
+  !insts. defs_before_uses insts ==> non_pseudo_defs_before_uses insts
+Proof
+  rw[non_pseudo_defs_before_uses_def, defs_before_uses_def,
+     np_defs_before_uses_def] >> metis_tac[]
+QED
+
+Triviality operand_dep_backward_weak:
+  !bi inst dep v.
+    non_pseudo_defs_before_uses bi /\
+    MEM inst bi /\ ~is_pseudo inst.inst_opcode /\
+    MEM (Var v) inst.inst_operands /\
+    producing_inst bi v = SOME dep ==>
+    ?i j. i < j /\ j < LENGTH bi /\ i < LENGTH bi /\
+          EL i bi = dep /\ EL j bi = inst
+Proof
+  rpt strip_tac >>
+  `?j. j < LENGTH bi /\ EL j bi = inst` by metis_tac[MEM_EL] >>
+  gvs[non_pseudo_defs_before_uses_def, np_defs_before_uses_def] >>
+  first_x_assum (qspecl_then [`j`, `v`, `dep`] mp_tac) >>
+  simp[] >> strip_tac >>
+  qexistsl [`i`, `j`] >> simp[]
+QED
+
+(* eda_topo_compatible from non_pseudo_defs_before_uses
+   — identical proof to eda_topo_compatible_gen but weaker hypothesis *)
+Theorem eda_topo_compatible_gen_weak:
+  !bi order.
+    bi <> [] /\
+    is_terminator (LAST bi).inst_opcode /\
+    (!k. k < LENGTH bi /\ is_terminator (EL k bi).inst_opcode ==>
+         k = PRE (LENGTH bi)) /\
+    ALL_DISTINCT (MAP (\i. i.inst_id) bi) /\
+    non_pseudo_defs_before_uses bi ==>
+    eda_topo_compatible bi (build_full_eda bi) order
+Proof
+  rpt strip_tac >>
+  simp[eda_topo_compatible_def, inst_all_deps_def, LET_THM] >>
+  rpt strip_tac >>
+  gvs[MEM_nub, MEM_APPEND]
+  (* data deps case *)
+  >- (fs[inst_data_deps_def, LET_THM, MEM_nub] >>
+      gvs[MEM_APPEND, MEM_MAP, MEM_FILTER]
+      >- ((* var_deps case *)
+        rename1 `MEM op inst.inst_operands` >>
+        Cases_on `op` >> gvs[operand_producer_def] >>
+        rename1 `producing_inst bi v` >>
+        Cases_on `producing_inst bi v` >> gvs[] >>
+        irule operand_dep_backward_weak >>
+        metis_tac[])
+      >> (* order_deps case *)
+      Cases_on `is_terminator inst.inst_opcode` >> gvs[MEM_FILTER, MEM_MAP] >>
+      rename1 `IS_SOME (producing_inst bi w)` >>
+      Cases_on `producing_inst bi w` >> gvs[] >>
+      rename1 `producing_inst bi w = SOME dep` >>
+      `~is_terminator dep.inst_opcode` by (
+        spose_not_then assume_tac >>
+        drule_all producing_inst_unique >> strip_tac >>
+        `?k. k < LENGTH bi /\ EL k bi = dep` by metis_tac[MEM_EL] >>
+        `k = PRE (LENGTH bi)` by metis_tac[] >>
+        `?j. j < LENGTH bi /\ EL j bi = inst` by metis_tac[MEM_EL] >>
+        `j = PRE (LENGTH bi)` by metis_tac[] >>
+        gvs[]) >>
+      drule_all producing_inst_before_terminator >> strip_tac >>
+      `?j. j < LENGTH bi /\ EL j bi = inst` by metis_tac[MEM_EL] >>
+      `j = PRE (LENGTH bi)` by metis_tac[] >>
+      qexistsl [`i`, `j`] >> simp[])
+  (* eda deps case *)
+  >> (Cases_on `FLOOKUP (build_full_eda bi) inst.inst_id` >> gvs[] >>
+      irule eda_deps_backward >> metis_tac[])
+QED
+
+(* Combined: eda_topo_compatible for original block — corollary of gen *)
+Theorem eda_topo_compatible_original:
+  !fn bb order.
+    wf_ssa fn /\ wf_function fn /\ MEM bb fn.fn_blocks ==>
+    eda_topo_compatible bb.bb_instructions
+      (build_full_eda bb.bb_instructions) order
+Proof
+  rpt strip_tac >>
+  irule eda_topo_compatible_gen >>
+  `bb_well_formed bb` by (gvs[wf_function_def, EVERY_MEM]) >>
+  gvs[bb_well_formed_def] >>
+  conj_tac >- (irule wf_fn_block_inst_ids_distinct >> metis_tac[]) >>
+  irule wf_ssa_defs_before_uses >> metis_tac[]
+QED
+
+


### PR DESCRIPTION
_co-authored by claude opus 4.6_

## DFT Pass — Correctness Proof Structure

Proof infrastructure for the Depth-First Traversal (DFT) instruction scheduling pass. DFT reorders non-pseudo instructions within each basic block according to a topological sort of their dependency graph, preserving pseudos (PHI/PARAM) as a prefix.

### Shared infrastructure changes

- **venomEffects**: Mark ALLOCA as reading/writing `Eff_MSIZE` — prevents reordering with memory-extending ops
- **venomWf**: Add `pseudos_prefix` / `fn_pseudos_prefix` predicates (all pseudo instructions form a prefix of each block). Defined separately from `bb_well_formed` to avoid rebuilding `execEquivProofs` (~30 min). Remove unused `split_labels_fresh_def`
- **stateEquiv**: Clarifying comment on `lift_result` semantics

### DFT definitions (`dftDefsScript.sml`)

EDA (Extended Dependency Analysis) construction, offspring maps, entry instruction identification, DFS scheduling, and the block/function-level transforms (`dft_block`, `dft_fn`).

### Proof files (12 theories, ~15.7k LOC)

| Theory | LOC | Description |
|--------|-----|-------------|
| dftStructural | 604 | Labels, bb_well_formed preservation |
| dftWf | 1511 | wf_function, wf_ssa, inst_wf preservation |
| dftBlockSim | 916 | exec_block simulation via run_insts |
| dftCommutation | 692 | bi_independent instruction commutation |
| dftPermSim | 1227 | Permutation simulation (run_insts_perm_lift) |
| dftCompleteness | 770 | Schedule outputs all non-pseudo instructions |
| dftPipelineInvar | 985 | FUNPOW loop invariant |
| dftIdempotent | 539 | dft_block idempotence |
| dftTopoSort | 1227 | topo_sorted helpers |
| dftScheduleFixed | 88 | Schedule fixpoint |
| dftCorrectness | 7153 | Top-level dft_pass_correct |

### Counterexample

`dft_pass_correct_is_false` proves the theorem is **false** without `pseudos_prefix`: the block `[ASSERT(0w), PARAM(0)->x, STOP]` aborts on the original but errors after DFT moves the PARAM before the ASSERT. `dft_pass_correct` now requires `fn_pseudos_prefix fn` as a precondition.

### Proof fixes (latest commits)

- **accounts gap**: Added helper lemmas (`effect_free_account_read_opcodes`, `account_read_output_agree`) for BALANCE/SELFBALANCE/EXTCODESIZE/EXTCODEHASH output agreement when `vs_accounts` sub-fields differ (e.g., SSTORE modifies `.storage` but not `.balance/.nonce/.code`)
- **abort_compatible**: Added to `ext_bi_independent_def` and propagated through `invoke_commute_eq`, `independent_commute_eq_ext`, `step_swap_ok_ext_invoke_one_out` — required because `effects_independent` alone doesn't imply `abort_compatible` (counterexample: `effects_independent INVOKE ASSERT = T` but `abort_compatible INVOKE ASSERT = F`)
- **argument order**: Fixed swapped arguments to `all_distinct_flat_map_unique` in dftWf (2 call sites)
- **pseudos_prefix precondition**: Added `fn_pseudos_prefix fn` to `dft_fn_run_blocks_lift` and `dft_fn_run_function_lift` — `drule_all block_perm_of_exec_block_lift` requires `pseudos_prefix` in assumptions

### Remaining cheats (6)

| Cheat | Blocker |
|-------|---------|
| `push_nonpseudo_past_pseudos` | Needs pseudos_prefix for FRONT decomposition |
| `run_insts_partition_pseudo` | Same |
| `front_full_equiv` | Same — key lemma connecting FRONT equivalence |
| `dft_fn_output_topo_sorted` | Schedule produces topo-sorted output |
| `dft_fn_pseudos_prefix` | DFT preserves fn_pseudos_prefix (dft_block = phis ++ scheduled) |
| `dft_pass_correct` | Top-level, depends on above |
