### PR TITLE
moduleLoweringProps: label-space invariants + top-level stitcher

### DIFF
--- a/lowering/defs/compileEnvScript.sml
+++ b/lowering/defs/compileEnvScript.sml
@@ -12,9 +12,15 @@
  *   type_bounds      — (lo, hi) word256 bounds for type
  *   struct_field_offset — byte offset of struct field
  *   nsid_to_string   — namespace ID to lookup string
+ *   compile_state_ok — well-formedness: bound labels disjoint from future fresh labels
+ *   label_external   — label not bound and not in future fresh-label co-domain
  *
  * Helper:
  *   fresh_var, fresh_label, emit, new_block — compilation monad ops
+ *   fresh_label_output   — canonical shape of compiler-generated labels (@suffix_k)
+ *   fresh_vars_wrt       — compiler var counter ahead of existing venom vars
+ *   bound_labels         — set of labels bound to blocks in compile state
+ *   compiler_labels_future — co-domain of fresh_label for counter values ≥ n
  *)
 
 Theory compileEnv
@@ -379,12 +385,20 @@ Definition fresh_var_def:
      cs with cs_next_var := n + 1)
 End
 
+(* Canonical shape of a compiler-generated label: @<suffix>_<counter>.
+   Factored out so proofs can talk about the label shape abstractly
+   (set membership) rather than decomposing strings. *)
+Definition fresh_label_output_def:
+  fresh_label_output suffix (k:num) =
+    "@" ++ suffix ++ "_" ++ (toString k)
+End
+
 (* Fresh label *)
 Definition fresh_label_def:
   fresh_label suffix (cs:compile_state) =
     let n = cs.cs_next_label in
-    let name = "@" ++ suffix ++ "_" ++ (toString n) in
-    (name, cs with cs_next_label := n + 1)
+    (fresh_label_output suffix n,
+     cs with cs_next_label := n + 1)
 End
 
 (* Fresh instruction ID *)
@@ -482,6 +496,50 @@ Definition fresh_vars_wrt_def:
   fresh_vars_wrt (st:compile_state) (ss:venom_state) ⇔
     ∀ n. n ≥ st.cs_next_var ⇒
       STRING #"%" (toString n) ∉ FDOM ss.vs_vars
+End
+
+(* ===== Label-Space Invariants =====
+   Track which labels the compiler has allocated (via fresh_label) and
+   which labels are currently bound to blocks. Used by module-level
+   correctness to rule out collisions between caller-supplied "external"
+   labels and compiler-generated labels.
+
+   All predicates are set-valued and phrased in terms of the abstract
+   fresh_label_output co-domain; proofs need not do string decomposition. *)
+
+(* Set of labels bound to blocks in the compile state: the current block
+   plus all finalized blocks. *)
+Definition bound_labels_def:
+  bound_labels (st:compile_state) =
+    st.cs_current_bb INSERT set (MAP (λbb. bb.bb_label) st.cs_blocks)
+End
+
+(* Co-domain of fresh_label for counter values ≥ n. These are the labels
+   fresh_label will produce from a state with cs_next_label = n. *)
+Definition compiler_labels_future_def:
+  compiler_labels_future (n:num) =
+    { fresh_label_output s k | s,k | n ≤ k }
+End
+
+(* lbl is external to st: not already bound, and not in the future
+   fresh_label co-domain starting from st. A caller-supplied label that
+   was allocated by a prior fresh_label call (counter < cs_next_label)
+   satisfies this. *)
+Definition label_external_def:
+  label_external (st:compile_state) lbl ⇔
+    lbl ∉ bound_labels st ∧
+    lbl ∉ compiler_labels_future st.cs_next_label
+End
+
+(* Well-formedness invariant on compile_state:
+   - Bound block labels are disjoint from the future fresh_label co-domain
+     (i.e., every bound label was either caller-supplied before any
+     fresh_label allocation, or allocated by a prior fresh_label call).
+   - Block labels are pairwise distinct. *)
+Definition compile_state_ok_def:
+  compile_state_ok (st:compile_state) ⇔
+    DISJOINT (bound_labels st) (compiler_labels_future st.cs_next_label) ∧
+    ALL_DISTINCT (st.cs_current_bb :: MAP (λbb. bb.bb_label) st.cs_blocks)
 End
 
 Definition well_formed_cenv_def:

--- a/lowering/emitHelperPropsScript.sml
+++ b/lowering/emitHelperPropsScript.sml
@@ -896,6 +896,21 @@ Proof
   irule step_ADD >> rw[]
 QED
 
+Theorem emit_op_SHR_correct:
+  ∀ op1 op2 v1 v2 st v st' ss.
+    emit_op SHR [op1; op2] st = (v, st') ∧
+    eval_operand op1 ss = SOME v1 ∧ eval_operand op2 ss = SOME v2 ∧
+    fresh_vars_wrt st ss ⇒
+    ∃ ss'. run_inst_seq (emitted_insts st st') ss = OK ss' ∧
+      eval_operand v ss' = SOME (word_lsr v2 (w2n v1)) ∧
+      same_blocks st st' ∧ fresh_vars_wrt st' ss' ∧
+      (∀ op w. eval_operand op ss = SOME w ⇒ eval_operand op ss' = SOME w) ∧
+      (∀ a. a < LENGTH ss.vs_memory ⇒ EL a ss'.vs_memory = EL a ss.vs_memory) ∧
+      LENGTH ss'.vs_memory = LENGTH ss.vs_memory
+Proof
+  rw[] >> qspecl_then [`SHR`, `\x y. y >>> w2n x`] (ho_match_mp_tac o BETA_RULE) emit_op_pure2_correct >> goal_assum $ drule_at (Pat `emit_op`) >> gvs[] >> irule step_SHR >> rw[]
+QED
+
 Theorem emit_op_MUL_correct:
   ∀ op1 op2 v1 v2 st v st' ss.
     emit_op MUL [op1; op2] st = (v, st') ∧
@@ -1381,6 +1396,17 @@ Proof
   rw[step_inst_base_def, exec_read1_def]
 QED
 
+Theorem step_CALLDATALOAD:
+  ∀ op1 v1 id out ss.
+    eval_operand op1 ss = SOME v1 ⇒
+    step_inst_base (mk_inst id CALLDATALOAD [op1] [out]) ss =
+      OK (update_var out
+        (let data = ss.vs_call_ctx.cc_calldata in
+         word_of_bytes T (0w:bytes32) (TAKE 32 (DROP (w2n v1) data ++ REPLICATE 32 0w))) ss)
+Proof
+  rpt strip_tac >> simp[step_inst_base_def, exec_read1_def, mk_inst_def]
+QED
+
 Theorem step_SSTORE:
   ∀ op1 op2 v1 v2 id ss.
     eval_operand op1 ss = SOME v1 ∧
@@ -1534,6 +1560,36 @@ Proof
   rw[] >> irule emit_op_read1_correct >> gvs[] >>
   goal_assum $ drule_at (Pat `emit_op`) >> gvs[] >>
   irule step_SLOAD >> rw[]
+QED
+
+Theorem emit_op_CALLDATALOAD_correct:
+  ∀ op1 v1 st v st' ss.
+    emit_op CALLDATALOAD [op1] st = (v, st') ∧
+    eval_operand op1 ss = SOME v1 ∧
+    fresh_vars_wrt st ss
+    ⇒
+    ∃ ss'.
+      run_inst_seq (emitted_insts st st') ss = OK ss' ∧
+      eval_operand v ss' = SOME
+        (let data = ss.vs_call_ctx.cc_calldata in
+         word_of_bytes T (0w:bytes32) (TAKE 32 (DROP (w2n v1) data ++ REPLICATE 32 0w))) ∧
+      same_blocks st st' ∧
+      fresh_vars_wrt st' ss' ∧
+      (∀ op w. eval_operand op ss = SOME w ⇒ eval_operand op ss' = SOME w) ∧
+      ss'.vs_memory = ss.vs_memory ∧
+      ss'.vs_accounts = ss.vs_accounts ∧
+      ss'.vs_labels = ss.vs_labels
+Proof
+  rw[] >>
+  mp_tac (Q.SPECL [`CALLDATALOAD`,
+    `\v1 ss. let data = ss.vs_call_ctx.cc_calldata in
+       word_of_bytes T (0w:bytes32) (TAKE 32 (DROP (w2n v1) data ++ REPLICATE 32 0w))`]
+    emit_op_read1_correct) >>
+  simp[] >> disch_then irule >> gvs[] >>
+  goal_assum $ drule_at (Pat `emit_op`) >> gvs[] >>
+  qspecl_then [`op1`, `v1`, `st.cs_next_id`,
+    `STRING #"%" (toString st.cs_next_var)`, `ss`]
+    mp_tac step_CALLDATALOAD >> simp[]
 QED
 
 (* ===== Generic emit_void for write2 opcodes ===== *)

--- a/lowering/emitHelperPropsScript.sml
+++ b/lowering/emitHelperPropsScript.sml
@@ -16,6 +16,10 @@
  *   emitted_insts_emit_op           — what emit_op produces
  *   emitted_insts_emit_void         — what emit_void produces
  *   emitted_insts_chain             — composing emitted_insts through do-blocks
+ *   fresh_label_output_inj          — fresh_label_output is injective
+ *   compile_state_ok_*              — label-space invariant through monad ops
+ *   fresh_label_produces_external    — fresh_label returns an external label
+ *   label_external_mono             — external labels survive extension
  *
  * Helper:
  *   fresh_var_name    — characterize fresh_var output
@@ -2373,4 +2377,143 @@ Theorem run_inst_seq_compose_ok:
 Proof
   rpt strip_tac >>
   drule_all run_inst_seq_emit_extend >> strip_tac >> gvs[]
+QED
+
+(* ===== Label-Space Preservation ===== *)
+(* Preservation of compile_state_ok and label_external across monad ops.
+   These let caller-supplied "external" labels (from earlier fresh_label
+   allocations, or frontend-supplied names) stay external as compilation
+   continues, and let compile_state_ok be carried through module-level
+   compilation proofs. *)
+
+(* fresh_label_output is injective in its arguments. *)
+Theorem fresh_label_output_inj:
+  ∀ s1 k1 s2 k2.
+    fresh_label_output s1 k1 = fresh_label_output s2 k2
+    ⇒ s1 = s2 ∧ k1 = k2
+Proof
+  cheat
+QED
+
+(* Initial compile_state is well-formed for any entry label that is not
+   itself a compiler-generated label (with any counter). The entry label
+   in practice is user/frontend-provided (e.g. "global"). *)
+Theorem compile_state_ok_initial:
+  ∀ entry_lbl.
+    entry_lbl ∉ compiler_labels_future 0
+    ⇒ compile_state_ok (initial_compile_state entry_lbl)
+Proof
+  cheat
+QED
+
+(* emit_op preserves compile_state_ok, bound_labels, and label-space fields
+   (doesn't touch cs_next_label, cs_blocks, or cs_current_bb). *)
+Theorem compile_state_ok_emit_op:
+  ∀ opc ops st v st'.
+    emit_op opc ops st = (v, st') ∧ compile_state_ok st
+    ⇒ compile_state_ok st' ∧
+      bound_labels st' = bound_labels st ∧
+      st'.cs_next_label = st.cs_next_label ∧
+      st'.cs_blocks = st.cs_blocks ∧
+      st'.cs_current_bb = st.cs_current_bb
+Proof
+  cheat
+QED
+
+(* emit_void preserves compile_state_ok, bound_labels, and label-space fields
+   (doesn't touch cs_next_label, cs_blocks, or cs_current_bb). *)
+Theorem compile_state_ok_emit_void:
+  ∀ opc ops st r st'.
+    emit_void opc ops st = (r, st') ∧ compile_state_ok st
+    ⇒ compile_state_ok st' ∧
+      bound_labels st' = bound_labels st ∧
+      st'.cs_next_label = st.cs_next_label ∧
+      st'.cs_blocks = st.cs_blocks ∧
+      st'.cs_current_bb = st.cs_current_bb
+Proof
+  cheat
+QED
+
+(* emit_inst preserves compile_state_ok, bound_labels, and label-space fields
+   (doesn't touch cs_next_label, cs_blocks, or cs_current_bb). *)
+Theorem compile_state_ok_emit_inst:
+  ∀ opc ops outs st r st'.
+    emit_inst opc ops outs st = (r, st') ∧ compile_state_ok st
+    ⇒ compile_state_ok st' ∧
+      bound_labels st' = bound_labels st ∧
+      st'.cs_next_label = st.cs_next_label ∧
+      st'.cs_blocks = st.cs_blocks ∧
+      st'.cs_current_bb = st.cs_current_bb
+Proof
+  cheat
+QED
+
+(* fresh_label: advances counter, returns a label that is external to
+   the pre-state (provable because counter equals old cs_next_label,
+   and compile_state_ok rules out prior binding). *)
+Theorem fresh_label_produces_external:
+  ∀ suffix st lbl st'.
+    fresh_label suffix st = (lbl, st') ∧ compile_state_ok st
+    ⇒ label_external st lbl ∧
+      lbl = fresh_label_output suffix st.cs_next_label ∧
+      st'.cs_next_label = st.cs_next_label + 1 ∧
+      st'.cs_blocks = st.cs_blocks ∧
+      st'.cs_current_bb = st.cs_current_bb ∧
+      bound_labels st' = bound_labels st ∧
+      compile_state_ok st'
+Proof
+  cheat
+QED
+
+(* fresh_var / fresh_id don't touch label-space. *)
+Theorem compile_state_ok_fresh_var:
+  ∀ st v st'.
+    fresh_var st = (v, st') ∧ compile_state_ok st
+    ⇒ compile_state_ok st' ∧
+      bound_labels st' = bound_labels st ∧
+      st'.cs_next_label = st.cs_next_label
+Proof
+  cheat
+QED
+
+Theorem compile_state_ok_fresh_id:
+  ∀ st n st'.
+    fresh_id st = (n, st') ∧ compile_state_ok st
+    ⇒ compile_state_ok st' ∧
+      bound_labels st' = bound_labels st ∧
+      st'.cs_next_label = st.cs_next_label
+Proof
+  cheat
+QED
+
+(* new_block: seals the current block into cs_blocks and switches to
+   the new label. Preserves compile_state_ok iff the new label is
+   external to the pre-state (so it doesn't collide with already-bound
+   blocks and isn't in the future fresh_label co-domain). *)
+Theorem compile_state_ok_new_block:
+  ∀ new_lbl st old st'.
+    new_block new_lbl st = (old, st') ∧
+    compile_state_ok st ∧
+    label_external st new_lbl
+    ⇒ compile_state_ok st' ∧
+      bound_labels st' = new_lbl INSERT bound_labels st ∧
+      st'.cs_next_label = st.cs_next_label ∧
+      st'.cs_current_bb = new_lbl ∧
+      old = st.cs_current_bb
+Proof
+  cheat
+QED
+
+(* Monotonicity: label_external carries through monad extensions whose
+   new bound labels are known. Useful for threading an external-label
+   hypothesis across a do-block of emit_* / fresh_* / new_block calls. *)
+Theorem label_external_mono:
+  ∀ lbl st st'.
+    label_external st lbl ∧
+    bound_labels st ⊆ bound_labels st' ∧
+    st.cs_next_label ≤ st'.cs_next_label ∧
+    lbl ∉ bound_labels st'
+    ⇒ label_external st' lbl
+Proof
+  cheat
 QED

--- a/lowering/moduleLoweringPropsScript.sml
+++ b/lowering/moduleLoweringPropsScript.sml
@@ -8,6 +8,12 @@
  *   compile_entry_checks_correct — nonpayable/calldatasize checks (single-block)
  *   compile_entry_checks_nonpayable_revert — nonpayable revert (derived)
  *   compile_constructor_epilogue_correct — runtime code copy + RETURN (single-block)
+ *   compile_generate_runtime_correct — top-level module correctness (stitching)
+ *
+ * Definitions:
+ *   runtime_input_labels — labels the caller must supply as external
+ *   runtime_inputs_ok — well-formed runtime compilation inputs
+ *   dispatch_labels_covered — selector labels ⊆ external fn entry labels
  *
  * Helper (no standalone correctness — always composed):
  *   compile_decode_args_nil   — empty arg list is no-op
@@ -88,10 +94,24 @@ End
 
 (* Linear dispatch creates blocks that jump to fallback_lbl or fn_labels
    from the selector list. These are external labels (fn bodies, fallback
-   handler) assembled separately. The fragment exits to one of them. *)
+   handler) assembled separately. The fragment exits to one of them.
+
+   HYPOTHESES (added 2026-04-17 after counterexample):
+   - compile_state_ok st: pre-state has well-formed label bindings
+   - label_external st fallback_lbl: fallback label is not already bound
+     in st and wasn't allocated by a future fresh_label (so
+     compile_selector_dispatch_linear cannot reuse it for an internal
+     @dispatch_/@match_/@next_ label)
+   - EVERY (label_external st) (MAP SND selectors): same for per-fn labels
+   - ALL_DISTINCT (fallback_lbl :: MAP SND selectors): no two external
+     labels collide (so JNZ to one doesn't accidentally equal another) *)
 Theorem compile_selector_dispatch_linear_correct:
   ∀ selectors fallback_lbl ss st st' ctx.
     compile_selector_dispatch_linear selectors fallback_lbl st = ((), st') ∧
+    compile_state_ok st ∧
+    label_external st fallback_lbl ∧
+    EVERY (label_external st) (MAP SND selectors) ∧
+    ALL_DISTINCT (fallback_lbl :: MAP SND selectors) ∧
     fresh_vars_wrt st ss ∧
     ¬ss.vs_halted
     ⇒
@@ -100,12 +120,16 @@ Theorem compile_selector_dispatch_linear_correct:
       (ss'.vs_current_bb = fallback_lbl ∨
        MEM ss'.vs_current_bb (MAP SND selectors))
 Proof
+  (* Original proof attempt (pre-hypothesis-fix). Preserved for reference;
+     the chain through emit_op_*_correct + exec_block_inst_seq_jnz is the
+     intended shape after the new hypotheses discharge the label-collision
+     case in run_fragment_blocks.
+
   rpt gen_tac >> strip_tac >>
   qpat_x_assum `compile_selector_dispatch_linear _ _ _ = _` mp_tac >>
   simp[compile_selector_dispatch_linear_def, comp_ignore_bind_def, comp_bind_def] >>
   rpt (pairarg_tac >> simp[]) >>
   strip_tac >>
-  (* Step 1: execute CDS preamble (CALLDATASIZE, LT, ISZERO) *)
   drule_all emit_op_CALLDATASIZE_correct >> strip_tac >>
   rename1 `run_inst_seq (emitted_insts st cs') ss = OK ss1` >>
   drule_at (Pos last) emit_op_LT_correct >>
@@ -113,40 +137,29 @@ Proof
   disch_then (qspec_then `4w` mp_tac) >>
   simp[eval_operand_lit] >> strip_tac >>
   rename1 `run_inst_seq (emitted_insts cs' cs'') ss1 = OK ss2` >>
-  (* Get inst_extends BEFORE consuming the ISZERO equation *)
   imp_res_tac inst_extends_emit_op >>
   imp_res_tac inst_extends_emit_inst >>
   imp_res_tac fresh_label_props >>
-  (* Now apply ISZERO correctness *)
   drule_at (Pos last) emit_op_ISZERO_correct >>
   disch_then drule >> disch_then drule >> strip_tac >>
-  rename1 `run_inst_seq (emitted_insts cs'' cs'³') ss2 = OK ss3` >>
-  (* Compose run_inst_seq: st→cs'→cs''→cs''' *)
-  `run_inst_seq (emitted_insts st cs'') ss = OK ss2` by
-    metis_tac[run_inst_seq_compose_ok] >>
-  `inst_extends st cs''` by metis_tac[inst_extends_trans] >>
-  `run_inst_seq (emitted_insts st cs'³') ss = OK ss3` by
-    metis_tac[run_inst_seq_compose_ok] >>
-  `inst_extends st cs'³'` by metis_tac[inst_extends_trans] >>
-  (* We have: run_inst_seq (emitted_insts st cs'3') ss = OK ss3
-     Entry block: st.cs_current_insts ++ emitted_insts st cs'3' ++ [JNZ_inst]
-     where cs'4' state has JNZ appended (via emit_inst JNZ).
-     But actually the entry block in assemble_blocks st' is the LAST block
-     assembled. The entry label is st.cs_current_bb.
-     
-     The entry block instructions are st.cs_current_insts ++ [CDS, LT, ISZERO, JNZ].
-     We need to use exec_block_inst_seq_jnz to show exec_block produces
-     jump_to (dispatch_lbl or fallback_lbl). *)
-  (* Step 3: Use exec_block_inst_seq_jnz for entry block execution *)
-  cheat >>
-  suspend "main_after_preamble"
+  ... (Step 3: exec_block_inst_seq_jnz, case split on JNZ cond,
+       induction on selectors for dispatch branch) ...
+  *)
+  cheat
 QED
 
-(* Sparse dispatch: same pattern, selectors have trailing-zeroes flag. *)
+(* Sparse dispatch: like linear dispatch but uses bucket-based matching
+   with selectors that carry a trailing-zeroes flag. Exits to
+   fallback_lbl or one of the per-fn labels in selectors.
+   Same label-space hypotheses as linear dispatch. *)
 Theorem compile_selector_dispatch_sparse_correct:
   ∀ selectors bucket_count fallback_lbl ss st st' ctx.
     compile_selector_dispatch_sparse selectors bucket_count fallback_lbl st =
       ((), st') ∧
+    compile_state_ok st ∧
+    label_external st fallback_lbl ∧
+    EVERY (label_external st) (MAP (FST o SND) selectors) ∧
+    ALL_DISTINCT (fallback_lbl :: MAP (FST o SND) selectors) ∧
     fresh_vars_wrt st ss ∧
     ¬ss.vs_halted
     ⇒
@@ -155,7 +168,6 @@ Theorem compile_selector_dispatch_sparse_correct:
       (ss'.vs_current_bb = fallback_lbl ∨
        MEM ss'.vs_current_bb (MAP (FST o SND) selectors))
 Proof
-  gvs[fresh_vars_wrt_def] >>
   cheat
 QED
 
@@ -164,12 +176,17 @@ QED
 (* compile_entry_point_kwargs: inits kwargs + JMP to common_label.
    Replaces standalone compile_init_kwargs_correct — init_kwargs is a
    fragment (no terminator) always composed within entry_point_kwargs
-   or similar wrapper. *)
+   or similar wrapper.
+
+   Label-space hypothesis: common_label is external to st (not yet bound
+   and outside the future fresh_label co-domain). *)
 Theorem compile_entry_point_kwargs_correct:
   ∀ cenv kwarg_vars calldata_offset kwargs_from_calldata common_label
     ss st st' ctx.
     compile_entry_point_kwargs cenv kwarg_vars calldata_offset
                                kwargs_from_calldata common_label st = ((), st') ∧
+    compile_state_ok st ∧
+    label_external st common_label ∧
     fresh_vars_wrt st ss ∧
     ¬ss.vs_halted
     ⇒
@@ -549,4 +566,79 @@ Proof
   drule_at (Pos hd) (Q.ISPEC `\s. s.vs_halted` run_inst_seq_preserves_field) >>
   (impl_tac >- (rpt strip_tac >> res_tac >> fs[])) >>
   simp[]
+QED
+
+(* ===== Top-Level Module Correctness ===== *)
+
+(* Labels the caller must supply as external: selector fn targets,
+   external entry labels, internal fn labels. These must be pairwise
+   distinct and external to st (not already bound, not in future
+   fresh_label co-domain). In practice the frontend allocates these
+   via fresh_label before calling compile_generate_runtime, and
+   cs_next_label is advanced past all of them. *)
+Definition runtime_input_labels_def:
+  runtime_input_labels selectors external_fns internal_fns =
+    MAP (λ(sel,lbl,has_tz). lbl) selectors ++
+    MAP (λ(entry_lbl, cenv, pos_args, min_cds, is_payable,
+            is_nr, nkey, use_trans, is_view, body, ret_type).
+           entry_lbl) external_fns ++
+    MAP (λ(fn_lbl, cenv, params, has_ret_buf, is_nr, nkey, use_trans,
+            is_view, is_ctor, imm_len, body, ret_type).
+           fn_lbl) internal_fns
+End
+
+(* Selector-declared function labels must match up with external_fn
+   entry labels so that a JMP from dispatch lands on an emitted block. *)
+Definition dispatch_labels_covered_def:
+  dispatch_labels_covered selectors external_fns ⇔
+    set (MAP (λ(sel,lbl,_). lbl) selectors) ⊆
+      set (MAP (λ(entry_lbl,_,_,_,_,_,_,_,_,_,_). entry_lbl) external_fns)
+End
+
+Definition runtime_inputs_ok_def:
+  runtime_inputs_ok selectors external_fns internal_fns st ⇔
+    compile_state_ok st ∧
+    EVERY (label_external st)
+          (runtime_input_labels selectors external_fns internal_fns) ∧
+    ALL_DISTINCT (runtime_input_labels selectors external_fns internal_fns) ∧
+    dispatch_labels_covered selectors external_fns
+End
+
+(* Top-level correctness of compile_generate_runtime.
+   Under well-formed inputs (frontend-allocated labels are fresh wrt st,
+   pairwise distinct, selector labels match external_fn labels), the
+   assembled runtime function executes to one of:
+   - Halt ss'              (normal RETURN/STOP from a function body)
+   - Abort Revert_abort    (entry-check failure or explicit REVERT)
+   - IntRet vals ss'       (unusual: an internal function returned to
+                             top level; shouldn't happen for well-typed
+                             modules, but is a legal exec_result shape
+                             given the semantics we have)
+
+   Explicitly excludes Error "out of fuel" (we quantify ∃fuel).
+
+   NOTE: This is the module-level stitching theorem. It consumes the
+   three fragment-level correctness theorems for dispatch/kwargs plus
+   correctness theorems for external/internal function bodies (stated
+   separately; several are still cheated upstream). *)
+Theorem compile_generate_runtime_correct:
+  ∀ selectors external_fns internal_fns fallback_fn dispatch_strategy
+    bucket_count fn_metadata_bytes dense_buckets entry_info
+    st st' ss ctx.
+    compile_generate_runtime selectors external_fns internal_fns
+        fallback_fn dispatch_strategy bucket_count fn_metadata_bytes
+        dense_buckets entry_info st = ((), st') ∧
+    runtime_inputs_ok selectors external_fns internal_fns st ∧
+    fresh_vars_wrt st ss ∧
+    ¬ss.vs_halted
+    ⇒
+    ∃ fuel result.
+      run_blocks fuel ctx (assemble_function st st')
+        (ss with <| vs_current_bb := st.cs_current_bb;
+                     vs_inst_idx := LENGTH st.cs_current_insts |>) = result ∧
+      ((∃ ss'. result = Halt ss') ∨
+       (∃ ss'. result = Abort Revert_abort ss') ∨
+       (∃ vals ss'. result = IntRet vals ss'))
+Proof
+  cheat
 QED

--- a/lowering/moduleLoweringPropsScript.sml
+++ b/lowering/moduleLoweringPropsScript.sml
@@ -42,6 +42,7 @@ Ancestors
   exprLoweringProps
   moduleLowering compileEnv context
   venomExecSemantics venomState venomInst
+  stateEquiv
   abiEncoder
 Libs
   wordsLib
@@ -118,7 +119,15 @@ Theorem compile_selector_dispatch_linear_correct:
     ∃ fuel ss'.
       run_compiled_fragment ctx st st' ss fuel = OK ss' ∧
       (ss'.vs_current_bb = fallback_lbl ∨
-       MEM ss'.vs_current_bb (MAP SND selectors))
+       MEM ss'.vs_current_bb (MAP SND selectors)) ∧
+      (* Preservation for chaining at the top-level stitcher.
+         Linear dispatch is pure ops + JNZ/JMP, no memory writes. *)
+      observable_equiv ss ss' ∧
+      ss'.vs_memory = ss.vs_memory ∧
+      ss'.vs_call_ctx = ss.vs_call_ctx ∧
+      ¬ss'.vs_halted ∧
+      fresh_vars_wrt st' ss' ∧
+      compile_state_ok st'
 Proof
   (* Original proof attempt (pre-hypothesis-fix). Preserved for reference;
      the chain through emit_op_*_correct + exec_block_inst_seq_jnz is the
@@ -166,7 +175,15 @@ Theorem compile_selector_dispatch_sparse_correct:
     ∃ fuel ss'.
       run_compiled_fragment ctx st st' ss fuel = OK ss' ∧
       (ss'.vs_current_bb = fallback_lbl ∨
-       MEM ss'.vs_current_bb (MAP (FST o SND) selectors))
+       MEM ss'.vs_current_bb (MAP (FST o SND) selectors)) ∧
+      (* Sparse dispatch uses CODECOPY to read bucket headers into
+         scratch memory (offset 30w), so vs_memory is NOT preserved.
+         A memory-region preservation predicate is future work. *)
+      observable_equiv ss ss' ∧
+      ss'.vs_call_ctx = ss.vs_call_ctx ∧
+      ¬ss'.vs_halted ∧
+      fresh_vars_wrt st' ss' ∧
+      compile_state_ok st'
 Proof
   cheat
 QED
@@ -190,11 +207,20 @@ Theorem compile_entry_point_kwargs_correct:
     fresh_vars_wrt st ss ∧
     ¬ss.vs_halted
     ⇒
-    ∃ fuel.
-      (∃ ss'. run_compiled_fragment ctx st st' ss fuel = OK ss' ∧
-              ss'.vs_current_bb = common_label) ∨
-      (∃ ss'. run_compiled_fragment ctx st st' ss fuel =
-                Abort Revert_abort ss')
+    ∃ fuel ss'.
+      (run_compiled_fragment ctx st st' ss fuel = OK ss' ∧
+       ss'.vs_current_bb = common_label ∧
+       (* Kwargs writes to kwarg memory regions defined by cenv plus
+          scratch for ABI decode; vs_allocas may also grow via ALLOCA
+          in compile_abi_decode_to_buf. vs_memory is NOT preserved. *)
+       observable_equiv ss ss' ∧
+       ss'.vs_call_ctx = ss.vs_call_ctx ∧
+       ¬ss'.vs_halted ∧
+       fresh_vars_wrt st' ss' ∧
+       compile_state_ok st') ∨
+      (run_compiled_fragment ctx st st' ss fuel = Abort Revert_abort ss'
+       (* Abort state is EVM-rolled back; only returndata observable.
+          Callers use revert_equiv / lift_result, not state preservation. *))
 Proof
   cheat
 QED

--- a/lowering/moduleLoweringPropsScript.sml
+++ b/lowering/moduleLoweringPropsScript.sml
@@ -100,7 +100,46 @@ Theorem compile_selector_dispatch_linear_correct:
       (ss'.vs_current_bb = fallback_lbl ∨
        MEM ss'.vs_current_bb (MAP SND selectors))
 Proof
-  cheat
+  rpt gen_tac >> strip_tac >>
+  qpat_x_assum `compile_selector_dispatch_linear _ _ _ = _` mp_tac >>
+  simp[compile_selector_dispatch_linear_def, comp_ignore_bind_def, comp_bind_def] >>
+  rpt (pairarg_tac >> simp[]) >>
+  strip_tac >>
+  (* Step 1: execute CDS preamble (CALLDATASIZE, LT, ISZERO) *)
+  drule_all emit_op_CALLDATASIZE_correct >> strip_tac >>
+  rename1 `run_inst_seq (emitted_insts st cs') ss = OK ss1` >>
+  drule_at (Pos last) emit_op_LT_correct >>
+  disch_then drule >> disch_then drule >>
+  disch_then (qspec_then `4w` mp_tac) >>
+  simp[eval_operand_lit] >> strip_tac >>
+  rename1 `run_inst_seq (emitted_insts cs' cs'') ss1 = OK ss2` >>
+  (* Get inst_extends BEFORE consuming the ISZERO equation *)
+  imp_res_tac inst_extends_emit_op >>
+  imp_res_tac inst_extends_emit_inst >>
+  imp_res_tac fresh_label_props >>
+  (* Now apply ISZERO correctness *)
+  drule_at (Pos last) emit_op_ISZERO_correct >>
+  disch_then drule >> disch_then drule >> strip_tac >>
+  rename1 `run_inst_seq (emitted_insts cs'' cs'³') ss2 = OK ss3` >>
+  (* Compose run_inst_seq: st→cs'→cs''→cs''' *)
+  `run_inst_seq (emitted_insts st cs'') ss = OK ss2` by
+    metis_tac[run_inst_seq_compose_ok] >>
+  `inst_extends st cs''` by metis_tac[inst_extends_trans] >>
+  `run_inst_seq (emitted_insts st cs'³') ss = OK ss3` by
+    metis_tac[run_inst_seq_compose_ok] >>
+  `inst_extends st cs'³'` by metis_tac[inst_extends_trans] >>
+  (* We have: run_inst_seq (emitted_insts st cs'3') ss = OK ss3
+     Entry block: st.cs_current_insts ++ emitted_insts st cs'3' ++ [JNZ_inst]
+     where cs'4' state has JNZ appended (via emit_inst JNZ).
+     But actually the entry block in assemble_blocks st' is the LAST block
+     assembled. The entry label is st.cs_current_bb.
+     
+     The entry block instructions are st.cs_current_insts ++ [CDS, LT, ISZERO, JNZ].
+     We need to use exec_block_inst_seq_jnz to show exec_block produces
+     jump_to (dispatch_lbl or fallback_lbl). *)
+  (* Step 3: Use exec_block_inst_seq_jnz for entry block execution *)
+  cheat >>
+  suspend "main_after_preamble"
 QED
 
 (* Sparse dispatch: same pattern, selectors have trailing-zeroes flag. *)
@@ -116,6 +155,7 @@ Theorem compile_selector_dispatch_sparse_correct:
       (ss'.vs_current_bb = fallback_lbl ∨
        MEM ss'.vs_current_bb (MAP (FST o SND) selectors))
 Proof
+  gvs[fresh_vars_wrt_def] >>
   cheat
 QED
 
@@ -141,6 +181,9 @@ Theorem compile_entry_point_kwargs_correct:
 Proof
   cheat
 QED
+
+(* Needed for Holmake: mark incomplete theorems *)
+val _ = Feedback.set_trace "Theory.allow_rebinds" 1;
 
 (* ===== Argument Decoding (helpers only) ===== *)
 
@@ -493,3 +536,17 @@ Resume compile_constructor_epilogue_correct[imm_zero]:
 QED
 
 Finalise compile_constructor_epilogue_correct
+
+Theorem run_inst_seq_ok_not_halted:
+  ∀ is ss ss'.
+    run_inst_seq is ss = OK ss' ∧
+    (∀i ss1 ss2. MEM i is ∧ step_inst_base i ss1 = OK ss2 ⇒ (ss2.vs_halted ⇔ ss1.vs_halted)) ∧
+    ¬ss.vs_halted
+    ⇒
+    ¬ss'.vs_halted
+Proof
+  rpt strip_tac >>
+  drule_at (Pos hd) (Q.ISPEC `\s. s.vs_halted` run_inst_seq_preserves_field) >>
+  (impl_tac >- (rpt strip_tac >> res_tac >> fs[])) >>
+  simp[]
+QED


### PR DESCRIPTION
_co-authored by claude sonnet 4.6_

Progress PR for module-level lowering correctness. Adds the label-space
invariant needed to state module-level theorems correctly, the top-level
stitcher theorem, and supporting emit helpers.

## Why

The three remaining fragment-level theorems in `moduleLoweringPropsTheory`
(`compile_selector_dispatch_linear_correct`, `compile_selector_dispatch_sparse_correct`,
`compile_entry_point_kwargs_correct`) were false as stated: a caller-supplied
"external" label (e.g. `fallback_lbl`) could collide with a compiler-generated
label in the assembled blocks, making `run_fragment_blocks` loop until fuel
exhausts. Counterexample: `fallback_lbl = st.cs_current_bb` with empty
selectors — both JNZ branches eventually re-enter the entry block.

Fix: add a label-space invariant to `compile_state` and predicate the
fragment theorems on it.

## Contents

**`lowering/defs/compileEnvScript.sml`** — label-space definitions:

- `fresh_label_output`: factored-out `@<suffix>_<counter>` shape (used by
  both `fresh_label_def` and `compiler_labels_future`)
- `bound_labels`: set of labels currently bound to blocks (current +
  finalized)
- `compiler_labels_future`: co-domain of future `fresh_label` calls
- `label_external`: lbl is not bound and not in future co-domain
- `compile_state_ok`: `DISJOINT (bound, future)` + `ALL_DISTINCT` labels

Everything is set-valued and phrased via the abstract `fresh_label_output`
co-domain, so downstream proofs do not need string decomposition.

**`lowering/emitHelperPropsScript.sml`** — preservation theorems
(statements only, `cheat` bodies):

- `fresh_label_output_inj`
- `compile_state_ok_initial`
- `compile_state_ok_emit_{op,void,inst}` — preserves invariant; strengthened
  to guarantee `cs_blocks` and `cs_current_bb` unchanged
- `fresh_label_produces_external` — key lemma: returned label is external
  to the pre-state (incl. `bound_labels` equality)
- `compile_state_ok_{fresh_var,fresh_id}` — pass through
- `compile_state_ok_new_block` — requires `label_external st new_lbl`;
  concludes `cs_current_bb = new_lbl`
- `label_external_mono` — carry external through state extension

Also adds `emit_op_SHR_correct`, `step_CALLDATALOAD`,
`emit_op_CALLDATALOAD_correct` and `run_inst_seq_ok_not_halted` needed
by the updated fragment theorem statements.

**`lowering/moduleLoweringPropsScript.sml`** — updated statements + new
top-level:

- Three fragment theorems now take `compile_state_ok st`, `label_external`
  hypotheses, and `ALL_DISTINCT` on the label list.
- Fragment OK-branch conclusions strengthened for composition:
  `observable_equiv ss ss'` (EVM-externally visible state preserved),
  `vs_call_ctx` unchanged, `¬vs_halted`, `fresh_vars_wrt st' ss'`,
  `compile_state_ok st'`. Linear dispatch additionally preserves
  `vs_memory`; sparse (CODECOPY to scratch) and kwargs (ABI decode
  writes) do not — a memory-region preservation predicate is left for
  future work.
- `dispatch_labels_covered_def`, `runtime_input_labels_def`,
  `runtime_inputs_ok_def` describe well-formed caller inputs to
  `compile_generate_runtime`.
- `compile_generate_runtime_correct` (top-level stitcher, `cheat` body):
  `run_blocks` on the assembled function halts with `Halt` /
  `Abort Revert_abort` / `IntRet`, never `Error "out of fuel"`. This is
  the theorem the rest of the module-level correctness will consume.

## Scope

All new theorems are stated with `cheat` bodies. No proof work in this
PR; the statements (and the label-space model that makes them true)
are the deliverable.

## Build

```
cd lowering/
VFMDIR=<path> Holmake -j8 --qof moduleLoweringPropsTheory
```

Passes with CHEATED (expected for new statements).

