### PR TITLE
Add lowering memory safety progress theorem

### DIFF
--- a/lowering/defs/loweringAllocaSafeAccessCounterexampleScript.sml
+++ b/lowering/defs/loweringAllocaSafeAccessCounterexampleScript.sml
@@ -1,0 +1,468 @@
+(*
+ * Counterexamples for earlier lowering memory-safety theorem statements.
+ *
+ * The first counterexample shows that alloca_inv alone is not enough to
+ * connect a lowered function's ALLOCA sizes to the runtime vs_allocas table.
+ * A lowered function allocates 32 bytes and stores through the alloca output,
+ * while the adversarial state gives that allocation only one byte.
+ *
+ * The second counterexample keeps the ALLOCA size consistent but assigns the
+ * output variable an out-of-region address, showing that size agreement alone
+ * does not constrain runtime pointer values.
+ *)
+
+Theory loweringAllocaSafeAccessCounterexample
+Ancestors
+  compileVyper vyperCompiler loweringMemSafetyDefs
+  allocaRemapDefs pointerConfinedDefs
+  venomState venomMemDefs venomInst memLocDefs
+  basePtrDefs compileEnv
+  pred_set finite_map list option While sum arithmetic words
+
+(* Compile environment: single MemLoc variable "buf" at offset 0, size 64.
+   ce_var_type = K NONE so cenv_matches_fn and well_typed_lowering
+   hold vacuously (no ALLOCA instruction whose output has a type). *)
+Definition ce6_cenv_def:
+  ce6_cenv : compile_env = <|
+    ce_vars := FEMPTY |+ ("buf", MemLoc 0 64);
+    ce_storage_layout := FEMPTY; ce_module := NONE;
+    ce_struct_fields := FEMPTY; ce_dynarray_capacity := K 0;
+    ce_method_id := K 42; ce_flag_member_id := (λ_ _. 0);
+    ce_flag_n_members := K 0; ce_var_type := K NONE;
+    ce_is_hashmap := K F; ce_event_info := (λ_ . (0, [], []));
+    ce_returns_count := 1; ce_return_buf := NONE;
+    ce_is_external := T;
+    ce_ret_enc_info := AbiPrimWord;
+    ce_ret_dec_info := DecPrimWord NoClamp;
+    ce_max_return_size := 32; ce_is_ctor := F;
+    ce_func_info := (λ_ . (0, 0, []));
+    ce_nonreentrant := (F, 0, F, F); ce_raw_return := F
+  |>
+End
+
+(* External function with a DecDynArray argument.
+   This triggers compile_abi_decode_to_buf → compile_alloc_buffer → ALLOCA + MSTORE[Var].
+   Specifically: ALLOCA [Lit 32w] -> "%21", MSTORE [Var "%21"; Lit 0w] *)
+Definition ce6_ext_fn_def:
+  ce6_ext_fn =
+    ("test_fn", ce6_cenv,
+     [("buf", F, T, 32, DecDynArray (DecBytestring 32) 32 32 T 1)],
+     36, F, F, 0, F, F, [Pass], SOME (BaseT (UintT 256)))
+End
+
+Definition ce6_run_result_def:
+  ce6_run_result =
+    FST (run_lowering [] [ce6_ext_fn] [] NONE Sparse 0 0 [] (K ("",0,F)) "entry")
+End
+
+Definition ce6_fn_def:
+  ce6_fn = HD ce6_run_result.ctx_functions
+End
+
+(* Extract the "test_fn" block — contains the ALLOCA and MSTORE instructions *)
+Definition ce6_bb_def:
+  ce6_bb = HD (FILTER (λbb. bb.bb_label = "test_fn") ce6_fn.fn_blocks)
+End
+
+(* Adversarial state: single alloca aid=0 at (offset=0, size=1) — only 1 byte.
+   The fn's ALLOCA instruction allocates 32 bytes, but vs_allocas can freely differ.
+   Variable "%21" = 0w (within the [0,1) alloca region). *)
+Definition ce6_state_def:
+  ce6_state : venom_state = (init_venom_state "entry") with <|
+    vs_vars := FEMPTY |+ ("%21", 0w);
+    vs_memory := GENLIST (K (0w:word8)) 64;
+    vs_allocas := FEMPTY |+ (0, (0, 1));
+    vs_alloca_next := 1
+  |>
+End
+
+(* ===== Hypotheses of the earlier arbitrary-state statement — all TRUE ===== *)
+
+Theorem ce6_fn_in_run_lowering:
+  MEM ce6_fn (FST (run_lowering [] [ce6_ext_fn] [] NONE Sparse 0 0 [] (K ("",0,F)) "entry")).ctx_functions
+Proof
+  simp[ce6_fn_def, ce6_run_result_def] >> EVAL_TAC
+QED
+
+Theorem ce6_cenv_matches_fn:
+  cenv_matches_fn ce6_cenv ce6_fn
+Proof
+  simp[cenv_matches_fn_def] >> rpt strip_tac >>
+  (* ce6_cenv.ce_var_type = K NONE, so antecedent is always false *)
+  fs[ce6_cenv_def]
+QED
+
+Theorem ce6_alloca_inv:
+  alloca_inv ce6_state
+Proof
+  simp[alloca_inv_def, allocas_non_overlapping_def, alloca_next_valid_def,
+       ce6_state_def] >>
+  conj_tac >- (
+    rpt strip_tac >> fs[FLOOKUP_UPDATE] >> metis_tac[]
+  ) >>
+  rpt strip_tac >> fs[FLOOKUP_UPDATE] >> decide_tac
+QED
+
+Theorem ce6_well_typed_lowering:
+  well_typed_lowering ce6_cenv
+Proof
+  simp[well_typed_lowering_def] >> conj_tac >- (
+    simp[well_formed_cenv_def, ce6_cenv_def] >> conj_tac >- (
+      rpt strip_tac >> fs[FLOOKUP_UPDATE] >> metis_tac[]
+    ) >>
+    rpt strip_tac >> fs[FLOOKUP_UPDATE] >> decide_tac
+  ) >>
+  simp[ce6_cenv_def] >> rpt gen_tac >> strip_tac >> fs[]
+QED
+
+Theorem ce6_memory_bound:
+  ∀aid off asz.
+    FLOOKUP ce6_state.vs_allocas aid = SOME (off, asz) ⇒
+    off + asz ≤ LENGTH ce6_state.vs_memory
+Proof
+  simp[ce6_state_def] >> Cases >> rpt strip_tac >> fs[FLOOKUP_UPDATE] >> decide_tac
+QED
+
+(* ===== Key facts about the fn from run_lowering ===== *)
+
+Theorem ce6_fn_has_alloca:
+  ∃inst. MEM inst (fn_insts ce6_fn) ∧
+    inst.inst_opcode = ALLOCA ∧ inst.inst_operands = [Lit 32w] ∧
+    inst.inst_outputs = ["%21"]
+Proof
+  qexists `<|inst_id := 28; inst_opcode := ALLOCA; inst_operands := [Lit 32w]; inst_outputs := ["%21"]|>` >>
+  simp[ce6_fn_def, ce6_run_result_def, fn_insts_def] >> EVAL_TAC
+QED
+
+Theorem ce6_fn_has_mstore:
+  ∃inst. MEM inst (fn_insts ce6_fn) ∧
+    inst.inst_opcode = MSTORE ∧ inst.inst_operands = [Var "%21"; Lit 0w]
+Proof
+  qexists `<|inst_id := 29; inst_opcode := MSTORE; inst_operands := [Var "%21"; Lit 0w]; inst_outputs := []|>` >>
+  simp[ce6_fn_def, ce6_run_result_def, fn_insts_def] >> EVAL_TAC
+QED
+
+Theorem ce6_fn_has_mstore_write_ops:
+  ∃inst ops. MEM inst ce6_bb.bb_instructions ∧
+    inst.inst_opcode = MSTORE ∧ inst.inst_operands = [Var "%21"; Lit 0w] ∧
+    mem_write_ops inst = SOME ops ∧
+    ops.iao_ofst = Var "%21" ∧ ops.iao_max_size = SOME (Lit 32w)
+Proof
+  qexistsl [
+    `<|inst_id := 29; inst_opcode := MSTORE; inst_operands := [Var "%21"; Lit 0w]; inst_outputs := []|>`,
+    `<|iao_ofst := Var "%21"; iao_size := SOME (Lit 32w); iao_max_size := SOME (Lit 32w)|>`
+  ] >>
+  simp[mem_write_ops_def, ce6_bb_def, ce6_fn_def, ce6_run_result_def] >> EVAL_TAC
+QED
+
+Theorem ce6_bb_in_fn_blocks:
+  MEM ce6_bb ce6_fn.fn_blocks
+Proof
+  simp[ce6_bb_def, ce6_fn_def, ce6_run_result_def] >>
+  EVAL_TAC
+QED
+
+(* ===== alloca_roots + pointer_derived_vars ===== *)
+
+(* First: compute the FILTER of ALLOCA instructions from fn_insts ce6_fn.
+   This gives a singleton list containing just the ALLOCA instruction with output "%21".
+   We extract the concrete instruction via HD for later use. *)
+
+Theorem ce6_alloca_filter:
+  FILTER (\i. i.inst_opcode = ALLOCA) (fn_insts ce6_fn) =
+    [<|inst_id := 28; inst_opcode := ALLOCA;
+       inst_operands := [Lit 32w]; inst_outputs := ["%21"]|>]
+Proof
+  simp[ce6_fn_def, ce6_run_result_def, fn_insts_def, fn_insts_blocks_def] >>
+  EVAL_TAC
+QED
+
+Theorem ce6_alloca_inst:
+  ∀inst. MEM inst (FILTER (\i. i.inst_opcode = ALLOCA) (fn_insts ce6_fn)) ⇒
+    inst = <|inst_id := 28; inst_opcode := ALLOCA;
+             inst_operands := [Lit 32w]; inst_outputs := ["%21"]|>
+Proof
+  rpt strip_tac >> fs[ce6_alloca_filter]
+QED
+
+(* ALLOCA instruction of ce6_fn for convenience. *)
+Definition ce6_alloca_inst_def:
+  ce6_alloca_inst : instruction =
+    <|inst_id := 28; inst_opcode := ALLOCA;
+      inst_operands := [Lit 32w]; inst_outputs := ["%21"]|>
+End
+
+Theorem ce6_alloca_inst_correct:
+  MEM ce6_alloca_inst (fn_insts ce6_fn) ∧
+  ce6_alloca_inst.inst_opcode = ALLOCA ∧
+  inst_output ce6_alloca_inst = SOME "%21"
+Proof
+  simp[ce6_alloca_inst_def, inst_output_def, ce6_fn_def, ce6_run_result_def,
+       fn_insts_def, fn_insts_blocks_def] >>
+  EVAL_TAC
+QED
+
+Theorem ce6_alloca_roots_fwd:
+  ∀out. (∃inst. MEM inst (fn_insts ce6_fn) ∧
+         inst.inst_opcode = ALLOCA ∧ inst_output inst = SOME out) ⇒ out = "%21"
+Proof
+  rpt strip_tac >>
+  `MEM inst (FILTER (\i. i.inst_opcode = ALLOCA) (fn_insts ce6_fn))` by
+    simp[MEM_FILTER] >>
+  drule_all ce6_alloca_inst >> strip_tac >>
+  fs[inst_output_def, ce6_alloca_inst_def]
+QED
+
+Theorem ce6_alloca_roots_bwd:
+  ∃inst. MEM inst (fn_insts ce6_fn) ∧
+    inst.inst_opcode = ALLOCA ∧ inst_output inst = SOME "%21"
+Proof
+  qexists `ce6_alloca_inst` >>
+  metis_tac[ce6_alloca_inst_correct]
+QED
+
+Theorem ce6_alloca_roots:
+  alloca_roots ce6_fn = {"%21"}
+Proof
+  simp[alloca_roots_def, EXTENSION] >>
+  gen_tac >> eq_tac
+  >- metis_tac[ce6_alloca_roots_fwd]
+  >- metis_tac[ce6_alloca_roots_bwd]
+QED
+
+Theorem ce6_pointer_use_step:
+  pointer_use_step ce6_fn ["%21"] = []
+Proof
+  simp[ce6_fn_def, ce6_run_result_def, pointer_use_step_def] >> EVAL_TAC
+QED
+
+Theorem ce6_pointer_use_step_step:
+  pointer_use_step_step ce6_fn ["%21"] = NONE
+Proof
+  simp[ce6_fn_def, ce6_run_result_def, pointer_use_step_step_def, ce6_pointer_use_step] >>
+  once_rewrite_tac[OWHILE_THM] >> simp[ISL, ce6_pointer_use_step] >>
+  once_rewrite_tac[OWHILE_THM] >> simp[ISL]
+QED
+
+Theorem ce6_pointer_use_vars:
+  pointer_use_vars ce6_fn ["%21"] = ["%21"]
+Proof
+  simp[pointer_use_vars_def, ce6_pointer_use_step_step] >>
+  once_rewrite_tac[OWHILE_THM] >>
+  simp[ISL, OUTL, ce6_pointer_use_step_step] >>
+  once_rewrite_tac[OWHILE_THM] >>
+  simp[ISL, OUTL, ce6_pointer_use_step_step]
+QED
+
+Theorem ce6_pointer_derived_vars:
+  pointer_derived_vars ce6_fn (alloca_roots ce6_fn) = {"%21"}
+Proof
+  simp[pointer_derived_vars_def, ce6_alloca_roots, SET_TO_LIST_SING,
+       ce6_pointer_use_vars, LIST_TO_SET]
+QED
+
+Theorem ce6_pointer_derived_contains:
+  "%21" ∈ pointer_derived_vars ce6_fn (alloca_roots ce6_fn)
+Proof
+  simp[ce6_pointer_derived_vars]
+QED
+
+(* ===== State facts ===== *)
+
+Theorem ce6_lookup_var:
+  lookup_var "%21" ce6_state = SOME 0w
+Proof
+  simp[ce6_state_def, lookup_var_def, FLOOKUP_UPDATE]
+QED
+
+Theorem ce6_eval_operand_32:
+  eval_operand (Lit 32w) ce6_state = SOME 32w
+Proof
+  simp[eval_operand_def, ce6_state_def]
+QED
+
+Theorem ce6_w2n_0:
+  w2n (0w:256 word) = 0
+Proof
+  simp[w2n_n2w, LESS_MOD]
+QED
+
+Theorem ce6_w2n_32:
+  w2n (32w:256 word) = 32
+Proof
+  simp[w2n_n2w, LESS_MOD] >>
+  simp[dimword_def, fcpLib.DIMINDEX (Arbnum.fromInt 256)] >>
+  decide_tac
+QED
+
+(* ===== THE COUNTEREXAMPLE: alloca_safe_access FAILS ===== *)
+(* The MSTORE witness writes 32 bytes into an allocation with size 1. *)
+
+Theorem ce6_not_alloca_safe_access:
+  ¬alloca_safe_access ce6_fn (alloca_roots ce6_fn) ce6_state
+Proof
+  simp[alloca_safe_access_def, ce6_pointer_derived_vars, LET_DEF] >>
+  simp[NOT_FORALL_THM, NOT_IMP, GSYM CONJ_ASSOC] >>
+  qexistsl [
+    `ce6_bb`,
+    `<|inst_id := 29; inst_opcode := MSTORE; inst_operands := [Var "%21"; Lit 0w]; inst_outputs := []|>`,
+    `<|iao_ofst := Var "%21"; iao_size := SOME (Lit 32w); iao_max_size := SOME (Lit 32w)|>`,
+    `0w:256 word`, `Lit 32w`, `32w:256 word`,
+    `0:num`, `0:num`, `1:num`
+  ] >>
+  (* All antecedent conjuncts are ground; EVAL handles them.
+     ¬(w2n 0w + w2n 32w ≤ 0 + 1) = ¬(0 + 32 ≤ 1) = T *)
+  simp[mem_write_ops_def, ce6_bb_in_fn_blocks, ce6_state_def,
+       FLOOKUP_UPDATE, lookup_var_def, eval_operand_def,
+       ce6_w2n_0, ce6_w2n_32, ce6_bb_def, ce6_fn_def, ce6_run_result_def] >>
+  EVAL_TAC >> decide_tac
+QED
+
+(* Earlier lowering_alloca_safe_access statement is false. *)
+Theorem lowering_alloca_safe_access_IS_FALSE:
+  ∃selectors ext_fns int_fns fb_fn (dispatch:dispatch_strategy)
+             bucket_count fn_meta_bytes
+             dense_buckets entry_info entry_label fn cenv s.
+    MEM fn (FST (run_lowering selectors ext_fns int_fns fb_fn
+                  dispatch bucket_count fn_meta_bytes
+                  dense_buckets entry_info entry_label)).ctx_functions ∧
+    cenv_matches_fn cenv fn ∧
+    alloca_inv s ∧
+    well_typed_lowering cenv ∧
+    (∀aid off asz.
+       FLOOKUP s.vs_allocas aid = SOME (off, asz) ⇒
+       off + asz ≤ LENGTH s.vs_memory) ∧
+    ¬alloca_safe_access fn (alloca_roots fn) s
+Proof
+  map_every qexists
+    [`[]:(num # string # bool) list`, `[ce6_ext_fn]`,
+     `[]:(string # compile_env # (string # bool) list # bool # bool # num # bool # bool # bool # num # stmt list # type option) list`,
+     `NONE:(compile_env # bool # bool # num # bool # bool # stmt list # type option) option`,
+     `(Sparse:dispatch_strategy)`,
+     `0:num`, `0:num`, `[]:dense_bucket list`,
+     `(K ("",0,F)):num -> string # num # bool`, `"entry"`,
+     `ce6_fn`, `ce6_cenv`, `ce6_state`] >>
+  (* After qexists + strip, each conjunct becomes a separate goal.
+     simp handles most; ce6_memory_bound proves off+asz but goal has asz+off
+     so decide_tac handles the arithmetic. *)
+  rpt strip_tac >-
+    metis_tac[ce6_fn_in_run_lowering] >-
+    metis_tac[ce6_cenv_matches_fn] >-
+    metis_tac[ce6_alloca_inv] >-
+    metis_tac[ce6_well_typed_lowering] >-
+    (rpt strip_tac >> metis_tac[ce6_memory_bound, ADD_COMM]) >>
+  metis_tac[ce6_not_alloca_safe_access]
+QED
+
+
+(* ========================================================================= *
+ * CE7: size agreement without pointer-value agreement is insufficient.
+ *
+ * ce6_fn has ALLOCA [Lit 32w] -> "%21" (inst_id=28).  ce7_state has a
+ * matching allocation entry for inst_id 28, but vs_vars maps "%21" to an
+ * out-of-region address, so ptrs_in_alloca_bounds fails.
+ * ========================================================================= *)
+
+Definition ce7_state_def:
+  ce7_state : venom_state = (init_venom_state "entry") with <|
+    vs_vars := FEMPTY |+ ("%21", 99999w);
+    vs_memory := GENLIST (K (0w:word8)) 64;
+    vs_allocas := FEMPTY |+ (28, (0, 32));
+    vs_alloca_next := 32
+  |>
+End
+
+(* ===== Hypotheses of the earlier size-only statement — all TRUE ===== *)
+
+Theorem ce7_alloca_inv:
+  alloca_inv ce7_state
+Proof
+  simp[alloca_inv_def, allocas_non_overlapping_def, alloca_next_valid_def,
+       ce7_state_def] >>
+  conj_tac >- (
+    rpt strip_tac >> fs[FLOOKUP_UPDATE] >> metis_tac[]
+  ) >>
+  rpt strip_tac >> fs[FLOOKUP_UPDATE] >> decide_tac
+QED
+
+Theorem ce7_alloca_sizes_match:
+  alloca_sizes_match ce6_fn ce7_state
+Proof
+  simp[alloca_sizes_match_def] >> rpt strip_tac >>
+  `MEM inst (FILTER (\i. i.inst_opcode = ALLOCA) (fn_insts ce6_fn))`
+    by simp[MEM_FILTER] >>
+  drule_all ce6_alloca_inst >> strip_tac >>
+  fs[ce6_alloca_inst_def] >>
+  simp[ce7_state_def, FLOOKUP_UPDATE, w2n_n2w] >>
+  simp[dimword_def, fcpLib.DIMINDEX (Arbnum.fromInt 256)] >>
+  qexists `0` >> decide_tac
+QED
+
+Theorem ce7_memory_bound:
+  ∀aid off asz.
+    FLOOKUP ce7_state.vs_allocas aid = SOME (off, asz) ⇒
+    off + asz ≤ LENGTH ce7_state.vs_memory ∧ off + asz < dimword (:256)
+Proof
+  simp[ce7_state_def] >> Cases >> rpt strip_tac >>
+  fs[FLOOKUP_UPDATE] >>
+  simp[dimword_def, fcpLib.DIMINDEX (Arbnum.fromInt 256)] >>
+  decide_tac
+QED
+
+(* ===== THE COUNTEREXAMPLE: ptrs_in_alloca_bounds FAILS ===== *)
+
+Theorem ce7_not_ptrs_in_alloca_bounds:
+  ¬ptrs_in_alloca_bounds ce6_fn (alloca_roots ce6_fn) ce7_state
+Proof
+  simp[ptrs_in_alloca_bounds_def, ce6_pointer_derived_vars, LET_DEF] >>
+  simp[NOT_FORALL_THM, NOT_IMP] >>
+  qexists `99999w:256 word` >>
+  conj_tac >- simp[ce7_state_def, FLOOKUP_UPDATE, lookup_var_def] >>
+  (* Goal: ¬in_alloca_region ce7_state (w2n 99999w) *)
+  simp[w2n_n2w, dimword_def, fcpLib.DIMINDEX (Arbnum.fromInt 256)] >>
+  (* Goal: ¬in_alloca_region ce7_state 99999 *)
+  simp[in_alloca_region_def, NOT_EXISTS_THM] >>
+  rpt gen_tac >>
+  (* Goal: ¬(FLOOKUP ce7_state.vs_allocas aid = SOME (off,sz) ∧ off ≤ 99999 ∧ 99999 < off + sz) *)
+  Cases_on `aid = 28:num` >-
+    simp[ce7_state_def, FLOOKUP_UPDATE] >>
+  simp[ce7_state_def, FLOOKUP_UPDATE]
+QED
+
+(* ===== TOP-LEVEL: lowering_memory_safe IS FALSE ===== *)
+(* Earlier lowering_memory_safe statement is false even with alloca_sizes_match. *)
+
+Theorem lowering_memory_safe_IS_FALSE:
+  ∃selectors ext_fns int_fns fb_fn (dispatch:dispatch_strategy)
+             bucket_count fn_meta_bytes
+             dense_buckets entry_info entry_label fn cenv s.
+    MEM fn (FST (run_lowering selectors ext_fns int_fns fb_fn
+                  dispatch bucket_count fn_meta_bytes
+                  dense_buckets entry_info entry_label)).ctx_functions ∧
+    cenv_matches_fn cenv fn ∧
+    alloca_inv s ∧
+    alloca_sizes_match fn s ∧
+    well_typed_lowering cenv ∧
+    (∀aid off asz.
+       FLOOKUP s.vs_allocas aid = SOME (off, asz) ⇒
+       off + asz ≤ LENGTH s.vs_memory ∧ off + asz < dimword (:256)) ∧
+    ¬ptrs_in_alloca_bounds fn (alloca_roots fn) s
+Proof
+  map_every qexists
+    [`[]:(num # string # bool) list`, `[ce6_ext_fn]`,
+     `[]:(string # compile_env # (string # bool) list # bool # bool # num # bool # bool # bool # num # stmt list # type option) list`,
+     `NONE:(compile_env # bool # bool # num # bool # bool # stmt list # type option) option`,
+     `(Sparse:dispatch_strategy)`,
+     `0:num`, `0:num`, `[]:dense_bucket list`,
+     `(K ("",0,F)):num -> string # num # bool`, `"entry"`,
+     `ce6_fn`, `ce6_cenv`, `ce7_state`] >>
+  rpt strip_tac >-
+    metis_tac[ce6_fn_in_run_lowering] >-
+    metis_tac[ce6_cenv_matches_fn] >-
+    metis_tac[ce7_alloca_inv] >-
+    metis_tac[ce7_alloca_sizes_match] >-
+    metis_tac[ce6_well_typed_lowering] >-
+    metis_tac[ce7_memory_bound, ADD_COMM] >-
+    metis_tac[ce7_memory_bound, ADD_COMM] >>
+  metis_tac[ce7_not_ptrs_in_alloca_bounds]
+QED

--- a/lowering/defs/loweringMemSafetyDefsScript.sml
+++ b/lowering/defs/loweringMemSafetyDefsScript.sml
@@ -8,6 +8,9 @@
  * TOP-LEVEL:
  *   value_within_alloca_size — value's runtime structure fits ALLOCA size
  *   cenv_matches_fn          — compile_env ALLOCA sizes match function
+ *   alloca_sizes_match       — runtime ALLOCA sizes match function
+ *   alloca_outputs_match     — ALLOCA outputs hold runtime base addresses
+ *   state_matches_fn         — ALLOCA sizes and outputs match function
  *   well_typed_lowering      — source well-typed (enables type soundness)
  *   bp_result_is             — base_ptr analysis result validity
  *   reachable_by_execution   — RTC of non-terminating, non-ext-call steps
@@ -65,6 +68,34 @@ Definition cenv_matches_fn_def:
       cenv.ce_var_type out = SOME ty ∧
       evaluate_type tenv ty = SOME tv
       ⇒ type_memory_bytes cenv ty = w2n n
+End
+
+(* Runtime alloca entries have the sizes declared by fn's ALLOCA instructions. *)
+Definition alloca_sizes_match_def:
+  alloca_sizes_match fn s ⇔
+    ∀inst n.
+      MEM inst (fn_insts fn) ∧
+      inst.inst_opcode = ALLOCA ∧
+      inst.inst_operands = [Lit n]
+      ⇒ ∃off. FLOOKUP s.vs_allocas inst.inst_id = SOME (off, w2n n)
+End
+
+(* ALLOCA output variables hold the base address of their runtime entries. *)
+Definition alloca_outputs_match_def:
+  alloca_outputs_match fn s ⇔
+    ∀inst n out off sz.
+      MEM inst (fn_insts fn) ∧
+      inst.inst_opcode = ALLOCA ∧
+      inst.inst_operands = [Lit n] ∧
+      inst_output inst = SOME out ∧
+      FLOOKUP s.vs_allocas inst.inst_id = SOME (off, sz)
+      ⇒ lookup_var out s = SOME (n2w off)
+End
+
+(* Runtime ALLOCA sizes and output values match fn's ALLOCA instructions. *)
+Definition state_matches_fn_def:
+  state_matches_fn fn s ⇔
+    alloca_sizes_match fn s ∧ alloca_outputs_match fn s
 End
 
 (* well_typed_lowering cenv: the Vyper source from which cenv was

--- a/lowering/loweringMemSafetyPropsScript.sml
+++ b/lowering/loweringMemSafetyPropsScript.sml
@@ -1,196 +1,70 @@
 (*
  * Lowering Memory Safety — Properties
  *
- * Theorems establishing that the Vyper→Venom lowering produces code
- * where all memory accesses through alloca-backed pointers stay
- * within their allocated region (alloca_safe_access).
- *
- * Three-layer decomposition:
- *
- *   Layer 1 — Main theorem: lowering_alloca_safe_access
- *     For well-typed Vyper source, the lowered function satisfies
- *     alloca_safe_access at every reachable execution state.
- *     Requires type soundness (eval_preserves_swt) to guarantee
- *     runtime values match declared types, so ALLOCA sizes are
- *     adequate.
- *
- *   Layer 2 — Bridge: bp_ptrs_bounded_imp_alloca_safe_access
- *     Structural bound (base_ptr analysis) implies runtime safety.
- *     bp_ptrs_bounded checks memloc_within_alloca for every alloca-
- *     backed access in the function. bp_ptr_sound connects the
- *     analysis result to runtime state. Together they yield
- *     alloca_safe_access.
- *
- *   Layer 3 — Structural: lowering_bp_ptrs_bounded
- *     The lowering produces code where base_ptr analysis concludes
- *     all accesses are bounded. ALLOCA(N) where N = type_memory_bytes,
- *     pointer arithmetic via ADD with compile-time-bounded offsets.
- *
- * Key lemma: value_type_fits_alloca
- *   value_has_type tv v ⟹ value_within_alloca_size — bridges
- *   Vyper type soundness to Venom ALLOCA sizing.
- *
- * Runtime check correctness:
- *   The lowering emits bounds checks matching Vyper semantics:
- *   - compile_array_subscript: ASSERT(not negative AND idx < length)
- *   - compile_clamp: sub-256-bit range check
- *   - compile_safe_add/sub/mul/div: overflow checks
- *   Type soundness ensures runtime lengths ≤ declared capacity,
- *   so the emitted checks are adequate.
- *
- * TOP-LEVEL:
- *   lowering_alloca_safe_access     — main theorem
- *   bp_ptrs_bounded_imp_alloca_safe_access — analysis→runtime bridge
- *   lowering_bp_ptrs_bounded        — structural bound from lowering
- *   value_type_fits_alloca          — type soundness→memory layout
- *   lowering_step_preserves_safety  — step_preserves_safety for lowered code
+ * Top-level theorems only. Internal proof helpers remain in
+ * loweringMemSafetyProofsTheory.
  *)
 
 Theory loweringMemSafetyProps
 Ancestors
-  loweringMemSafetyDefs basePtrProps vyperTypeSoundness
-  vyperTypeSoundnessDefs vyperTyping
+  loweringMemSafetyProofs loweringMemSafetyDefs allocaRemapDefs
 
-(* ===== Key Lemma: Type Soundness → Memory Layout ===== *)
+(* ===== Type-safety interface ===== *)
 
-(* A well-typed value's runtime structure fits within the ALLOCA
-   sized by type_memory_bytes for the corresponding type.
-   This is the core fact connecting Vyper type soundness to memory
-   safety: the ALLOCA is sized by the declared type capacity (via
-   type_memory_bytes), and type soundness ensures runtime lengths
-   respect those capacities.
-
-   For DynArray[T,N]: value_has_type (ArrayTV tv (Dynamic N)) v ⟹
-     LENGTH vs ≤ N, so the MLOAD'd length word ≤ N and
-     bounds check (idx < len) correctly rejects OOB access.
-   For Bytes[M]: byte data length ≤ M.
-   For String[M]: string length ≤ M.
-   Fixed arrays, structs, base types: structurally exact. *)
 Theorem value_type_fits_alloca:
   ∀cenv tenv ty tv v.
     evaluate_type tenv ty = SOME tv ∧
     value_has_type tv v ∧ well_formed_type_value tv
-    ⇒
-    value_within_alloca_size cenv ty v
+  ⇒ value_within_alloca_size cenv ty v
 Proof
-  cheat
+  ACCEPT_TAC loweringMemSafetyProofsTheory.value_type_fits_alloca
 QED
 
-(* ===== Layer 2: bp_ptrs_bounded → alloca_safe_access ===== *)
+(* ===== Alloca uniqueness ===== *)
 
-(* Structural bounds from base_ptr analysis imply runtime memory safety.
-   Requires:
-   1. bp_ptr_sound: analysis result accurately tracks runtime pointers
-   2. bp_ptrs_bounded: every alloca-backed access is within bounds
-   3. Coverage: all pointer-derived vars are tracked by the analysis
-   4. Memory adequacy: alloca regions fit within vs_memory length *)
-Theorem bp_ptrs_bounded_imp_alloca_safe_access:
-  ∀bp fn s roots.
-    bp_ptr_sound bp s ∧
-    bp_ptrs_bounded bp fn s ∧
-    pointer_derived_vars fn roots ⊆ {v | bp_get_ptrs bp v ≠ []} ∧
-    (∀aid off asz.
-       FLOOKUP s.vs_allocas aid = SOME (off, asz) ⇒
-       off + asz ≤ LENGTH s.vs_memory)
-    ⇒ alloca_safe_access fn roots s
+Theorem alloca_regions_same:
+  ∀s a1 a2 b1 sz1 b2 sz2 x.
+    allocas_non_overlapping s ∧
+    FLOOKUP s.vs_allocas a1 = SOME (b1,sz1) ∧
+    FLOOKUP s.vs_allocas a2 = SOME (b2,sz2) ∧
+    b1 ≤ x ∧ x < b1 + sz1 ∧ b2 ≤ x ∧ x < b2 + sz2
+    ⇒ a1 = a2 ∧ b1 = b2 ∧ sz1 = sz2
 Proof
-  cheat
+  ACCEPT_TAC loweringMemSafetyProofsTheory.alloca_regions_same
 QED
 
-(* ===== Layer 3: Lowering produces structurally bounded pointers ===== *)
+(* ===== Execution safety preservation ===== *)
 
-(* The lowered function's base_ptr analysis result shows all
-   alloca-backed accesses are within bounds.
-   Holds because:
-   1. Lowering emits ALLOCA(N) where N = type_memory_bytes(cenv, ty)
-   2. Pointer arithmetic is ADD(base, Lit offset) where offset is a
-      compile-time constant derived from type layout
-   3. Array accesses go through compile_array_subscript which emits
-      bounds checks (ASSERT valid) before computing the offset
-   4. Bytestring accesses use lengths ≤ declared max (guaranteed by
-      type soundness via value_type_fits_alloca) *)
-Theorem lowering_bp_ptrs_bounded:
-  ∀selectors ext_fns int_fns fb_fn dispatch bucket_count
-    fn_meta_bytes dense_buckets entry_info entry_label
-    fn cenv bp s.
-    MEM fn (FST (run_lowering selectors ext_fns int_fns fb_fn
-                   dispatch bucket_count fn_meta_bytes
-                   dense_buckets entry_info entry_label)).ctx_functions ∧
-    cenv_matches_fn cenv fn ∧
-    alloca_inv s ∧
-    bp_result_is fn bp ∧
-    well_typed_lowering cenv
-    ⇒ bp_ptrs_bounded bp fn s
-Proof
-  cheat
-QED
-
-(* ===== Step Preservation ===== *)
-
-(* The lowered code preserves alloca_safe_access across every
-   non-terminating, non-external-call instruction step.
-   This is the step_preserves_safety oracle specialized to
-   lowered code. *)
-Theorem lowering_step_preserves_safety:
-  ∀selectors ext_fns int_fns fb_fn dispatch bucket_count
-    fn_meta_bytes dense_buckets entry_info entry_label
-    fn cenv roots.
-    MEM fn (FST (run_lowering selectors ext_fns int_fns fb_fn
-                   dispatch bucket_count fn_meta_bytes
-                   dense_buckets entry_info entry_label)).ctx_functions ∧
-    cenv_matches_fn cenv fn ∧
-    well_typed_lowering cenv
-    ⇒ step_preserves_safety fn roots
-Proof
-  cheat
-QED
-
-(* ===== Layer 1: Main Theorem ===== *)
-
-(* For a well-typed Vyper source, the lowered function satisfies
-   alloca_safe_access at the initial execution state.
-   This is the theorem that downstream consumers (concretize_mem_loc,
-   codegen) actually need. It abstracts away all pointer analysis
-   details — consumers only see alloca_safe_access. *)
-Theorem lowering_alloca_safe_access:
-  ∀selectors ext_fns int_fns fb_fn dispatch bucket_count
-    fn_meta_bytes dense_buckets entry_info entry_label
-    fn cenv s.
-    MEM fn (FST (run_lowering selectors ext_fns int_fns fb_fn
-                   dispatch bucket_count fn_meta_bytes
-                   dense_buckets entry_info entry_label)).ctx_functions ∧
-    cenv_matches_fn cenv fn ∧
-    alloca_inv s ∧
-    well_typed_lowering cenv ∧
-    (∀aid off asz.
-       FLOOKUP s.vs_allocas aid = SOME (off, asz) ⇒
-       off + asz ≤ LENGTH s.vs_memory)
-    ⇒ alloca_safe_access fn (alloca_roots fn) s
-Proof
-  cheat
-QED
-
-(* ===== Combined: Safety at every reachable state ===== *)
-
-(* For any state reachable from an initial state satisfying the
-   lowering preconditions, alloca_safe_access holds.
-   Composes lowering_alloca_safe_access (initial) with
-   lowering_step_preserves_safety (preservation). *)
-Theorem lowering_alloca_safe_access_reachable:
-  ∀selectors ext_fns int_fns fb_fn dispatch bucket_count
-    fn_meta_bytes dense_buckets entry_info entry_label
-    fn cenv s s'.
-    MEM fn (FST (run_lowering selectors ext_fns int_fns fb_fn
-                   dispatch bucket_count fn_meta_bytes
-                   dense_buckets entry_info entry_label)).ctx_functions ∧
-    cenv_matches_fn cenv fn ∧
-    alloca_inv s ∧
-    well_typed_lowering cenv ∧
-    (∀aid off asz.
-       FLOOKUP s.vs_allocas aid = SOME (off, asz) ⇒
-       off + asz ≤ LENGTH s.vs_memory) ∧
+Theorem reachable_preserves_safety:
+  ∀fn roots s s'.
+    step_preserves_safety fn roots ∧
+    alloca_safe_access fn roots s ∧
+    ptrs_in_alloca_bounds fn roots s ∧
     reachable_by_execution fn s s'
-    ⇒ alloca_safe_access fn (alloca_roots fn) s'
+    ⇒ alloca_safe_access fn roots s' ∧ ptrs_in_alloca_bounds fn roots s'
 Proof
-  cheat
+  ACCEPT_TAC loweringMemSafetyProofsTheory.reachable_preserves_safety
+QED
+
+(* ===== TOP-LEVEL THEOREM ===== *)
+
+Theorem lowering_memory_safe:
+  ∀selectors ext_fns int_fns fb_fn (dispatch:dispatch_strategy)
+    bucket_count fn_meta_bytes dense_buckets entry_info entry_label
+    fn cenv s0 s.
+    MEM fn (FST (run_lowering selectors ext_fns int_fns fb_fn
+                   dispatch bucket_count fn_meta_bytes
+                   dense_buckets entry_info entry_label)).ctx_functions ∧
+    cenv_matches_fn cenv fn ∧
+    alloca_inv s0 ∧
+    state_matches_fn fn s0 ∧
+    well_typed_lowering cenv ∧
+    (∀aid off asz.
+       FLOOKUP s0.vs_allocas aid = SOME (off,asz) ⇒
+       off + asz ≤ LENGTH s0.vs_memory ∧ off + asz < dimword (:256)) ∧
+    reachable_by_execution fn s0 s
+    ⇒ ptrs_in_alloca_bounds fn (alloca_roots fn) s ∧
+      alloca_safe_access fn (alloca_roots fn) s
+Proof
+  ACCEPT_TAC loweringMemSafetyProofsTheory.lowering_memory_safe
 QED

--- a/lowering/proofs/loweringMemSafetyProofsScript.sml
+++ b/lowering/proofs/loweringMemSafetyProofsScript.sml
@@ -1,0 +1,481 @@
+(*
+ * Lowering Memory Safety — Proofs
+ *
+ * Proofs for theorems in loweringMemSafetyProps.
+ *)
+
+Theory loweringMemSafetyProofs
+Ancestors
+  loweringMemSafetyDefs
+  allocaRemapDefs pointerConfinedDefs
+  vyperTypeSoundness vyperTypeSoundnessDefs vyperTyping vyperValue
+  vyperTypeSoundnessHelpers vyperAST rich_list vyperMisc
+  list option pair
+  venomState venomMemDefs compileVyper words arithmetic
+
+(* ===== value_type_fits_alloca and helpers ===== *)
+
+Theorem evaluate_types_OPT_MMAP:
+  !tenv tys tvs.
+    evaluate_types tenv tys [] = SOME tvs ⇒
+    OPT_MMAP (evaluate_type tenv) tys = SOME tvs
+Proof
+  rpt strip_tac >>
+  gvs[vyperValueTheory.evaluate_types_OPT_MMAP]
+QED
+
+Theorem MEM_type_size_lt_type1_size:
+  ∀ty l. MEM ty l ⇒ type_size ty < type1_size l + 1
+Proof
+  Induct_on `l` >> rpt strip_tac >> Cases_on `MEM ty (h::t)` >>
+  gvs[type_size_def] >> (first_x_assum drule >> strip_tac >> decide_tac)
+QED
+
+Theorem LIST_REL_value_within_alloca_size_IH:
+  ∀l tvs vs cenv tenv.
+    evaluate_types tenv l [] = SOME tvs ∧
+    LIST_REL value_has_type tvs vs ∧
+    EVERY well_formed_type_value tvs ∧
+    (∀ty tv v.
+       type_size ty < type1_size l + 1 ∧
+       evaluate_type tenv ty = SOME tv ∧
+       value_has_type tv v ∧ well_formed_type_value tv
+       ⇒ value_within_alloca_size cenv ty v)
+    ⇒ LIST_REL (value_within_alloca_size cenv) l vs
+Proof
+  rpt gen_tac >> strip_tac >>
+  qpat_x_assum `LIST_REL value_has_type tvs vs` mp_tac >>
+  qpat_x_assum `EVERY well_formed_type_value tvs` mp_tac >>
+  qpat_x_assum `evaluate_types tenv l [] = SOME tvs` mp_tac >>
+  map_every qid_spec_tac [`vs`,`tvs`] >>
+  Induct_on `l` >- (
+    rpt strip_tac >>
+    drule evaluate_types_OPT_MMAP >> strip_tac >>
+    fs[OPT_MMAP_def] >>
+    Cases_on `vs` >> fs[LIST_REL_def]
+  ) >>
+  rpt strip_tac >>
+  drule evaluate_types_OPT_MMAP >> strip_tac >>
+  gvs[OPT_MMAP_def, OPTION_BIND_def, LIST_REL_def] >>
+  conj_tac >- (
+    first_x_assum irule >> simp[type_size_def] >> decide_tac
+  ) >>
+  first_x_assum irule >>
+  rpt strip_tac >- (
+    first_x_assum irule >> simp[type_size_def] >> decide_tac
+  ) >- (
+    simp[vyperValueTheory.evaluate_types_OPT_MMAP] >> metis_tac[APPEND]
+  ) >>
+  simp[]
+QED
+
+Theorem LIST_REL_value_within_alloca_size_MEM:
+  ∀l tvs vs cenv tenv.
+    evaluate_types tenv l [] = SOME tvs ∧
+    LIST_REL value_has_type tvs vs ∧
+    EVERY well_formed_type_value tvs ∧
+    (∀ty tv v.
+       MEM ty l ∧
+       evaluate_type tenv ty = SOME tv ∧
+       value_has_type tv v ∧ well_formed_type_value tv
+       ⇒ value_within_alloca_size cenv ty v)
+    ⇒ LIST_REL (value_within_alloca_size cenv) l vs
+Proof
+  rpt gen_tac >> strip_tac >>
+  qpat_x_assum `LIST_REL value_has_type tvs vs` mp_tac >>
+  qpat_x_assum `EVERY well_formed_type_value tvs` mp_tac >>
+  qpat_x_assum `evaluate_types tenv l [] = SOME tvs` mp_tac >>
+  qid_spec_tac `vs` >> qid_spec_tac `tvs` >>
+  Induct_on `l` >- (
+    rpt strip_tac >>
+    drule evaluate_types_OPT_MMAP >> strip_tac >>
+    fs[OPT_MMAP_def] >>
+    Cases_on `vs` >> fs[LIST_REL_def]
+  ) >>
+  rpt strip_tac >>
+  drule evaluate_types_OPT_MMAP >> strip_tac >>
+  gvs[OPT_MMAP_def, OPTION_BIND_def, LIST_REL_def] >>
+  first_x_assum $ irule >> qexists `t` >>
+  simp[vyperValueTheory.evaluate_types_OPT_MMAP]
+QED
+
+Theorem LIST_REL_value_within_alloca_size_PAIR_MEM:
+  ∀l tvs vs cenv tenv.
+    evaluate_types tenv l [] = SOME tvs ∧
+    LIST_REL value_has_type tvs vs ∧
+    EVERY well_formed_type_value tvs ∧
+    (∀ty tv v.
+       MEM ty l ∧ MEM v vs ∧
+       evaluate_type tenv ty = SOME tv ∧
+       value_has_type tv v ∧ well_formed_type_value tv
+       ⇒ value_within_alloca_size cenv ty v)
+    ⇒ LIST_REL (value_within_alloca_size cenv) l vs
+Proof
+  rpt gen_tac >> strip_tac >>
+  pop_assum mp_tac >>
+  qpat_x_assum `EVERY well_formed_type_value tvs` mp_tac >>
+  qpat_x_assum `LIST_REL value_has_type tvs vs` mp_tac >>
+  qpat_x_assum `evaluate_types tenv l [] = SOME tvs` mp_tac >>
+  map_every qid_spec_tac [`vs`,`tvs`] >>
+  Induct_on `l` >- (
+    rpt strip_tac >>
+    drule evaluate_types_OPT_MMAP >> strip_tac >>
+    fs[OPT_MMAP_def] >>
+    Cases_on `vs` >> fs[LIST_REL_def]
+  ) >>
+  rpt strip_tac >>
+  drule evaluate_types_OPT_MMAP >> strip_tac >>
+  gvs[OPT_MMAP_def, OPTION_BIND_def, LIST_REL_def] >>
+  first_x_assum irule >>
+  simp[vyperValueTheory.evaluate_types_OPT_MMAP] >>
+  rpt strip_tac >>
+  first_x_assum irule >> simp[]
+QED
+
+Theorem LIST_REL_eta_bridge:
+  ∀cenv tys vs.
+    LIST_REL (λa a'. value_within_alloca_size cenv a a') tys vs ⇔
+    LIST_REL (value_within_alloca_size cenv) tys vs
+Proof
+  CONV_TAC (DEPTH_CONV ETA_CONV) >> simp[]
+QED
+
+Theorem evaluate_type_ArrayT_inv:
+  ∀tenv elem_ty bd tv tv0.
+    evaluate_type tenv (ArrayT elem_ty bd) = SOME tv ∧
+    evaluate_type tenv elem_ty = SOME tv0
+  ⇒ tv = ArrayTV tv0 bd
+Proof
+  rpt strip_tac >> fs[evaluate_type_def]
+QED
+
+Theorem evaluate_type_TupleT_inv:
+  ∀tenv tys tv tvs.
+    evaluate_type tenv (TupleT tys) = SOME tv ∧
+    evaluate_types tenv tys [] = SOME tvs
+  ⇒ tv = TupleTV tvs
+Proof
+  rpt gen_tac >> disch_tac >> gvs[Once evaluate_type_def] >> gvs[]
+QED
+
+Theorem evaluate_type_TupleT_SOME:
+  ∀tenv l tv.
+    evaluate_type tenv (TupleT l) = SOME tv ⇒
+    ∃tvs. evaluate_types tenv l [] = SOME tvs ∧ tv = TupleTV tvs
+Proof
+  rpt strip_tac >> Cases_on `evaluate_types tenv l []` >>
+  gvs[evaluate_type_def]
+QED
+
+Theorem evaluate_type_ArrayT_SOME:
+  ∀tenv t bd tv.
+    evaluate_type tenv (ArrayT t bd) = SOME tv ⇒
+    ∃tv0. evaluate_type tenv t = SOME tv0 ∧ tv = ArrayTV tv0 bd
+Proof
+  rpt strip_tac >> Cases_on `evaluate_type tenv t` >>
+  gvs[evaluate_type_def] >> metis_tac[]
+QED
+
+Theorem values_have_types_LIST_REL:
+  ∀tvs vs. values_have_types tvs vs ⇔ LIST_REL value_has_type tvs vs
+Proof
+  Induct_on `tvs` >> Cases_on `vs` >>
+  simp[value_has_type_def, LIST_REL_def]
+QED
+
+Theorem value_type_fits_alloca_dynarray:
+  ∀cenv tenv elem_ty n vs tv tv0.
+    evaluate_type tenv elem_ty = SOME tv0 ∧
+    well_formed_type_value tv0 ∧
+    evaluate_type tenv (ArrayT elem_ty (Dynamic n)) = SOME tv ∧
+    value_has_type tv (ArrayV (DynArrayV vs)) ∧
+    well_formed_type_value tv ∧
+    (∀v tenv' tv'.
+       MEM v vs ∧
+       evaluate_type tenv' elem_ty = SOME tv' ∧
+       value_has_type tv' v ∧ well_formed_type_value tv'
+       ⇒ value_within_alloca_size cenv elem_ty v)
+  ⇒ value_within_alloca_size cenv (ArrayT elem_ty (Dynamic n)) (ArrayV (DynArrayV vs))
+Proof
+  rpt gen_tac >> strip_tac >>
+  simp[Once value_within_alloca_size_def] >>
+  rpt strip_tac >> drule evaluate_type_ArrayT_inv >> strip_tac >>
+  gvs[value_has_type_inv, all_have_type_EVERY] >>
+  simp[EVERY_MEM] >> rpt strip_tac >>
+  first_x_assum drule >> (disch_then drule >> simp[]) >>
+  strip_tac >> first_x_assum irule >> fs[EVERY_MEM]
+QED
+
+Theorem value_type_fits_alloca_tuple:
+  ∀cenv tenv tys vs tv tvs'.
+    evaluate_types tenv tys [] = SOME tvs' ∧
+    EVERY well_formed_type_value tvs' ∧
+    evaluate_type tenv (TupleT tys) = SOME tv ∧
+    value_has_type tv (ArrayV (TupleV vs)) ∧
+    well_formed_type_value tv ∧
+    (∀ty tv1 v.
+       MEM ty tys ∧ MEM v vs ∧
+       evaluate_type tenv ty = SOME tv1 ∧
+       value_has_type tv1 v ∧ well_formed_type_value tv1
+       ⇒ value_within_alloca_size cenv ty v)
+  ⇒ value_within_alloca_size cenv (TupleT tys) (ArrayV (TupleV vs))
+Proof
+  rpt gen_tac >> strip_tac >>
+  fs[value_within_alloca_size_def, value_has_type_inv,
+     values_have_types_LIST_REL, AllCaseEqs()] >>
+  `tv = TupleTV tvs'` by metis_tac[evaluate_type_TupleT_inv] >> fs[] >>
+  conj_tac >- metis_tac[LIST_REL_LENGTH, evaluate_types_OPT_MMAP, OPT_MMAP_LENGTH] >>
+  CONV_TAC(DEPTH_CONV ETA_CONV) >>
+  irule LIST_REL_value_within_alloca_size_PAIR_MEM >>
+  qexistsl [`tenv`,`tvs`] >> simp[] >>
+  rpt strip_tac >> first_x_assum irule >> simp[]
+QED
+
+Theorem baseT_fits_alloca:
+  ∀cenv tenv b tv v.
+    evaluate_type tenv (BaseT b) = SOME tv ∧
+    value_has_type tv v ∧ well_formed_type_value tv
+  ⇒ value_within_alloca_size cenv (BaseT b) v
+Proof
+  rpt gen_tac >> strip_tac >>
+  Cases_on `b` >> Cases_on `v` >>
+  gvs[evaluate_type_def, value_has_type_inv, value_within_alloca_size_def,
+      AllCaseEqs()]
+QED
+
+Theorem TupleTV_ArrayV_TupleV_has_type:
+  ∀tvs vs. value_has_type (TupleTV tvs) (ArrayV (TupleV vs)) ⇒ values_have_types tvs vs
+Proof
+  rpt strip_tac >> gvs[value_has_type_inv, type_value_11]
+QED
+
+Theorem ArrayTV_Dynamic_DynArrayV_has_type:
+  ∀tv0 n vs. value_has_type (ArrayTV tv0 (Dynamic n)) (ArrayV (DynArrayV vs)) ⇒
+    LENGTH vs ≤ n ∧ EVERY (value_has_type tv0) vs
+Proof
+  rpt gen_tac >> strip_tac >> first_x_assum (mp_tac o REWRITE_RULE [value_has_type_inv]) >> simp[all_have_type_EVERY] >> strip_tac >> gvs[type_value_11]
+QED
+
+Theorem ArrayTV_Fixed_TupleV_contra:
+  ∀tv0 n vs. value_has_type (ArrayTV tv0 (Fixed n)) (ArrayV (TupleV vs)) ⇒ F
+Proof
+  rpt gen_tac >> disch_then (strip_assume_tac o SIMP_RULE (srw_ss()) [Once value_has_type_inv]) >> gvs[type_value_distinct]
+QED
+
+Theorem well_formed_type_value_TupleTV_imp:
+  ∀tvs. well_formed_type_value (TupleTV tvs) ⇒ EVERY well_formed_type_value tvs
+Proof
+  rpt strip_tac >> fs[well_formed_type_value_def, ETA_THM]
+QED
+
+Theorem well_formed_type_value_ArrayTV_imp:
+  ∀tv b. well_formed_type_value (ArrayTV tv b) ⇒ well_formed_type_value tv
+Proof
+  rpt strip_tac >> fs[well_formed_type_value_def]
+QED
+
+Theorem value_type_fits_alloca_TupleT:
+  ∀cenv tenv l tv v.
+    evaluate_type tenv (TupleT l) = SOME tv ∧
+    value_has_type tv v ∧ well_formed_type_value tv ∧
+    (∀ty tv' v'.
+       type_size ty < type_size (TupleT l) ∧
+       evaluate_type tenv ty = SOME tv' ∧
+       value_has_type tv' v' ∧ well_formed_type_value tv'
+       ⇒ value_within_alloca_size cenv ty v')
+  ⇒ value_within_alloca_size cenv (TupleT l) v
+Proof
+  rpt strip_tac >>
+  drule evaluate_type_TupleT_SOME >> strip_tac >>
+  qpat_x_assum `tv = TupleTV tvs` SUBST_ALL_TAC >>
+  imp_res_tac well_formed_type_value_TupleTV_imp >>
+  Cases_on `v` >> simp[value_within_alloca_size_def] >>
+  Cases_on `a` >> simp[value_within_alloca_size_def] >>
+  imp_res_tac TupleTV_ArrayV_TupleV_has_type >>
+  simp[values_have_types_LIST_REL] >>
+  conj_tac >- (
+    imp_res_tac values_have_types_length >>
+    drule evaluate_types_OPT_MMAP >> strip_tac >>
+    imp_res_tac OPT_MMAP_LENGTH >> simp[]) >>
+  CONV_TAC(DEPTH_CONV ETA_CONV) >>
+  irule LIST_REL_value_within_alloca_size_IH >>
+  simp[values_have_types_LIST_REL] >>
+  qexistsl [`tenv`,`tvs`] >> simp[] >>
+  conj_tac >- (
+    rpt strip_tac >>
+    first_x_assum irule >>
+    simp[type_size_def] >> decide_tac) >>
+  simp[GSYM values_have_types_LIST_REL]
+QED
+
+Theorem value_type_fits_alloca_ArrayT:
+  ∀cenv tenv t b tv v.
+    evaluate_type tenv (ArrayT t b) = SOME tv ∧
+    value_has_type tv v ∧ well_formed_type_value tv ∧
+    (∀ty tv' v'.
+       type_size ty < type_size (ArrayT t b) ∧
+       evaluate_type tenv ty = SOME tv' ∧
+       value_has_type tv' v' ∧ well_formed_type_value tv'
+       ⇒ value_within_alloca_size cenv ty v')
+  ⇒ value_within_alloca_size cenv (ArrayT t b) v
+Proof
+  rpt strip_tac >>
+  drule evaluate_type_ArrayT_SOME >> strip_tac >>
+  qpat_x_assum `tv = ArrayTV tv0 b` SUBST_ALL_TAC >>
+  imp_res_tac well_formed_type_value_ArrayTV_imp >>
+  Cases_on `v` >> simp[value_within_alloca_size_def] >>
+  Cases_on `a` >> simp[value_within_alloca_size_def] >>
+  Cases_on `b` >> simp[value_within_alloca_size_def] >>
+  TRY (imp_res_tac ArrayTV_Fixed_TupleV_contra >> simp[]) >>
+  imp_res_tac ArrayTV_Dynamic_DynArrayV_has_type >>
+  conj_tac >- simp[] >>
+  simp[EVERY_MEM] >> rpt strip_tac >>
+  first_x_assum irule >>
+  conj_tac >- (simp[type_size_def, bound_size_def] >> decide_tac) >>
+  qexists `tv0` >> simp[] >>
+  gvs[EVERY_MEM]
+QED
+
+Theorem value_type_fits_alloca:
+  ∀cenv tenv ty tv v.
+    evaluate_type tenv ty = SOME tv ∧
+    value_has_type tv v ∧ well_formed_type_value tv
+  ⇒ value_within_alloca_size cenv ty v
+Proof
+  measureInduct_on `type_size ty` >>
+  rpt strip_tac >>
+  Cases_on `ty`
+  >- metis_tac[baseT_fits_alloca]
+  >- (drule evaluate_type_TupleT_SOME >> strip_tac >>
+     qpat_x_assum `tv = TupleTV tvs` SUBST_ALL_TAC >>
+     imp_res_tac well_formed_type_value_TupleTV_imp >>
+     Cases_on `v` >> simp[value_within_alloca_size_def] >>
+     Cases_on `a` >> simp[value_within_alloca_size_def] >>
+     imp_res_tac TupleTV_ArrayV_TupleV_has_type >>
+     simp[values_have_types_LIST_REL] >>
+     conj_tac >- (
+       imp_res_tac values_have_types_length >>
+       drule evaluate_types_OPT_MMAP >> strip_tac >>
+       imp_res_tac OPT_MMAP_LENGTH >> simp[]) >>
+     CONV_TAC(DEPTH_CONV ETA_CONV) >>
+     irule LIST_REL_value_within_alloca_size_IH >>
+     simp[values_have_types_LIST_REL] >>
+     qexistsl [`tenv`,`tvs`] >> simp[] >>
+     conj_tac >- (
+       rpt gen_tac >> strip_tac >>
+       first_x_assum (qspec_then `ty` mp_tac) >>
+       simp[type_size_def] >> strip_tac >>
+       first_x_assum (qspecl_then [`cenv`,`tenv`,`tv`,`v`] mp_tac) >>
+       simp[]) >>
+     simp[GSYM values_have_types_LIST_REL])
+  >- (drule evaluate_type_ArrayT_SOME >> strip_tac >>
+     qpat_x_assum `tv = ArrayTV tv0 b` SUBST_ALL_TAC >>
+     imp_res_tac well_formed_type_value_ArrayTV_imp >>
+     Cases_on `v` >> simp[value_within_alloca_size_def] >>
+     Cases_on `a` >> simp[value_within_alloca_size_def] >>
+     Cases_on `b` >> simp[value_within_alloca_size_def] >>
+     TRY (imp_res_tac ArrayTV_Fixed_TupleV_contra >> simp[]) >>
+     imp_res_tac ArrayTV_Dynamic_DynArrayV_has_type >>
+     conj_tac >- simp[] >>
+     simp[EVERY_MEM] >> rpt strip_tac >>
+     qpat_x_assum `∀y. type_size y < _ ⇒ _` (fn ih => mp_tac (Q.SPEC `t` ih)) >>
+     simp[type_size_def, bound_size_def] >> strip_tac >>
+     first_x_assum (qspecl_then [`cenv`,`tenv`,`tv0`,`v`] mp_tac) >>
+     impl_tac >- (simp[] >> gvs[EVERY_MEM]) >> simp[])
+  >- (qpat_x_assum `∀y. type_size y < _ ⇒ _` kall_tac >>
+     Cases_on `v` >> simp[value_within_alloca_size_def] >> simp[EVERY_MEM])
+  >- (qpat_x_assum `∀y. type_size y < _ ⇒ _` kall_tac >>
+     Cases_on `v` >> simp[value_within_alloca_size_def])
+  >- (qpat_x_assum `∀y. type_size y < _ ⇒ _` kall_tac >>
+     Cases_on `v` >> simp[value_within_alloca_size_def])
+QED
+
+(* ===== General helpers ===== *)
+
+Theorem alloca_regions_same:
+  ∀s a1 a2 b1 sz1 b2 sz2 x.
+    allocas_non_overlapping s ∧
+    FLOOKUP s.vs_allocas a1 = SOME (b1,sz1) ∧
+    FLOOKUP s.vs_allocas a2 = SOME (b2,sz2) ∧
+    b1 ≤ x ∧ x < b1 + sz1 ∧ b2 ≤ x ∧ x < b2 + sz2
+    ⇒ a1 = a2 ∧ b1 = b2 ∧ sz1 = sz2
+Proof
+  rpt strip_tac >> Cases_on `a1 = a2` >- (
+    fs[SOME_11]
+  ) >>
+  fs[allocas_non_overlapping_def] >>
+  first_x_assum (qspecl_then [`a1`,`a2`,`b1`,`sz1`,`b2`,`sz2`] mp_tac) >>
+  simp[] >> strip_tac >> decide_tac
+QED
+
+Theorem RTC_step_preserves:
+  ∀R P.
+    (∀x y. R x y ∧ P x ⇒ P y) ⇒
+    ∀x y. R꙳ x y ⇒ P x ⇒ P y
+Proof
+  rpt gen_tac >> strip_tac >>
+  ho_match_mp_tac relationTheory.RTC_INDUCT >>
+  rpt strip_tac >> simp[] >>
+  metis_tac[]
+QED
+
+Theorem reachable_preserves_safety:
+  ∀fn roots s s'.
+    step_preserves_safety fn roots ∧
+    alloca_safe_access fn roots s ∧
+    ptrs_in_alloca_bounds fn roots s ∧
+    reachable_by_execution fn s s'
+    ⇒ alloca_safe_access fn roots s' ∧ ptrs_in_alloca_bounds fn roots s'
+Proof
+  simp[reachable_by_execution_def] >>
+  rpt gen_tac >> strip_tac >>
+  `∀x y.
+    (λs1 s2. ∃inst bb.
+       MEM bb fn.fn_blocks ∧ MEM inst bb.bb_instructions ∧
+       step_inst_base inst s1 = OK s2 ∧
+       ¬is_terminator inst.inst_opcode ∧ ¬is_ext_call_op inst.inst_opcode)꙳ x y ⇒
+    alloca_safe_access fn roots x ∧ ptrs_in_alloca_bounds fn roots x ⇒
+    alloca_safe_access fn roots y ∧ ptrs_in_alloca_bounds fn roots y`
+  by (
+    ho_match_mp_tac relationTheory.RTC_INDUCT >>
+    simp[] >>
+    rpt strip_tac >>
+    metis_tac[step_preserves_safety_def]) >>
+  metis_tac[]
+QED
+
+Theorem reachable_preserves_alloca_safe_access:
+  ∀fn roots s s'.
+    step_preserves_safety fn roots ∧
+    alloca_safe_access fn roots s ∧
+    ptrs_in_alloca_bounds fn roots s ∧
+    reachable_by_execution fn s s'
+    ⇒ alloca_safe_access fn roots s'
+Proof
+  metis_tac[reachable_preserves_safety]
+QED
+
+(* ===== TOP-LEVEL THEOREM (stub) ===== *)
+
+Theorem lowering_memory_safe:
+  ∀selectors ext_fns int_fns fb_fn (dispatch:dispatch_strategy)
+    bucket_count fn_meta_bytes dense_buckets entry_info entry_label
+    fn cenv s0 s.
+    MEM fn (FST (run_lowering selectors ext_fns int_fns fb_fn
+                   dispatch bucket_count fn_meta_bytes
+                   dense_buckets entry_info entry_label)).ctx_functions ∧
+    cenv_matches_fn cenv fn ∧
+    alloca_inv s0 ∧
+    state_matches_fn fn s0 ∧
+    well_typed_lowering cenv ∧
+    (∀aid off asz.
+       FLOOKUP s0.vs_allocas aid = SOME (off,asz) ⇒
+       off + asz ≤ LENGTH s0.vs_memory ∧ off + asz < dimword (:256)) ∧
+    reachable_by_execution fn s0 s
+    ⇒ ptrs_in_alloca_bounds fn (alloca_roots fn) s ∧
+      alloca_safe_access fn (alloca_roots fn) s
+Proof
+  (* TEMPORARILY CHEATED - progress theorem; requires lowering type-soundness
+     integration and a real execution-safety model. *)
+  cheat
+QED

--- a/venom/analysis/base_ptr/defs/basePtrDefsScript.sml
+++ b/venom/analysis/base_ptr/defs/basePtrDefsScript.sml
@@ -232,7 +232,7 @@ End
  * Matches Python segment_from_ops. *)
 Definition bp_segment_from_ops_def:
   bp_segment_from_ops result (ops : inst_access_ops) =
-    let size = case ops.iao_size of
+    let size = case ops.iao_max_size of
                  SOME (Lit n) => SOME (w2n n)
                | _ => NONE
     in

--- a/venom/analysis/base_ptr/proofs/bpPtrsBoundedCounterexampleScript.sml
+++ b/venom/analysis/base_ptr/proofs/bpPtrsBoundedCounterexampleScript.sml
@@ -1,0 +1,334 @@
+(*
+ * Counterexample: step_preserves_safety is FALSE
+ *
+ * step_preserves_safety says that for any non-terminator, non-ext-call
+ * instruction, stepping preserves alloca_safe_access and ptrs_in_alloca_bounds.
+ *
+ * This is FALSE because a pointer-preserving ADD can produce a value
+ * outside alloca bounds. If ptr=0w (in [0,64)) and k=9999w, then
+ * ADD [Var "ptr"; Var "k"] produces ptr2=9999w, which is NOT in [0,64).
+ * ptrs_in_alloca_bounds fails because the new value is OOB.
+ *
+ * Note: alloca_safe_access is vacuously TRUE in the post-state because
+ * ptr2=9999w is NOT in any alloca region (the memory-access antecedent
+ * requires off <= w2n w < off + asz). So the counterexample falsifies
+ * ptrs_in_alloca_bounds, not alloca_safe_access.
+ *)
+
+Theory bpPtrsBoundedCounterexample
+Ancestors
+  basePtrDefs pointerConfinedDefs allocaRemapDefs venomInst
+  venomExecSemantics venomWf memLocDefs venomInstProofs
+  pred_set finite_map list option While sum arithmetic words
+
+(* Function: ALLOCA 64 -> "ptr", ADD [ptr; k] -> "ptr2", MSTORE [ptr2; data] *)
+Definition ce3_fn_def:
+  ce3_fn : ir_function = <|
+    fn_name := "ce3_test";
+    fn_blocks := [
+      <| bb_label := "entry";
+         bb_instructions := [
+           mk_inst 0 ALLOCA [Lit (n2w 64)] ["ptr"];
+           mk_inst 1 ADD [Var "ptr"; Var "k"] ["ptr2"];
+           mk_inst 2 MSTORE [Var "ptr2"; Var "data"] []
+         ]
+      |>
+    ]
+  |>
+End
+
+(* State: alloca id=0, base=0, size=64; ptr=0w, ptr2=0w, k=9999w, data=0w *)
+Definition ce3_state_def:
+  ce3_state = (init_venom_state "entry") with <|
+    vs_vars := FEMPTY |+ ("ptr", n2w 0) |+ ("ptr2", n2w 0) |+ ("k", n2w 9999) |+ ("data", n2w 0);
+    vs_allocas := FEMPTY |+ (0, (0, 64));
+    vs_memory := REPLICATE 64 (0w:word8);
+    vs_alloca_next := 64
+  |>
+End
+
+(* Post-ADD state: ptr2 updated to 0w + 9999w = 9999w *)
+Definition ce3_v_def:
+  ce3_v = ce3_state with <|
+    vs_vars := ce3_state.vs_vars |+ ("ptr2", n2w 9999)
+  |>
+End
+
+Definition ce3_roots_def:
+  ce3_roots = alloca_roots ce3_fn
+End
+
+Definition ce3_inst_def:
+  ce3_inst = mk_inst 1 ADD [Var "ptr"; Var "k"] ["ptr2"]
+End
+
+Definition ce3_bb_def:
+  ce3_bb : basic_block = <|
+    bb_label := "entry";
+    bb_instructions := [
+      mk_inst 0 ALLOCA [Lit (n2w 64)] ["ptr"];
+      mk_inst 1 ADD [Var "ptr"; Var "k"] ["ptr2"];
+      mk_inst 2 MSTORE [Var "ptr2"; Var "data"] []
+    ]
+  |>
+End
+
+(* ---- Helper lemmas ---- *)
+
+val dimindex_256 = fcpLib.DIMINDEX (Arbnum.fromInt 256)
+
+Theorem ce3_w2n_9999:
+  w2n (9999w:256 word) = 9999
+Proof
+  simp[w2n_n2w, LESS_MOD] >>
+  `dimindex(:64) < dimindex(:256)` by
+    (simp[dimindex_64, dimindex_256] >> decide_tac) >>
+  `dimword(:64) < dimword(:256)` by
+    metis_tac[dimindex_dimword_lt_iso] >>
+  `9999 < dimword(:64)` by (simp[dimword_64] >> decide_tac) >>
+  decide_tac
+QED
+
+Theorem ce3_w2n_0:
+  w2n (0w:256 word) = 0
+Proof
+  simp[w2n_n2w, LESS_MOD]
+QED
+
+Theorem ce3_w2n_32:
+  w2n (32w:256 word) = 32
+Proof
+  simp[w2n_n2w, LESS_MOD] >>
+  `dimindex(:64) < dimindex(:256)` by
+    (simp[dimindex_64, dimindex_256] >> decide_tac) >>
+  `dimword(:64) < dimword(:256)` by
+    metis_tac[dimindex_dimword_lt_iso] >>
+  `32 < dimword(:64)` by (simp[dimword_64] >> decide_tac) >>
+  decide_tac
+QED
+
+Theorem ce3_mem_write_ops_mstore:
+  mem_write_ops (mk_inst 2 MSTORE [Var "ptr2"; Var "data"] []) =
+    SOME <|iao_ofst := Var "ptr2"; iao_size := SOME (Lit 32w);
+            iao_max_size := SOME (Lit 32w)|>
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_alloca_roots:
+  alloca_roots ce3_fn = {"ptr"}
+Proof
+  simp[alloca_roots_def, ce3_fn_def, fn_insts_def, mk_inst_def, inst_output_def, EXTENSION] >>
+  gen_tac >> gvs[fn_insts_blocks_def, MEM, AllCaseEqs()] >> eq_tac >> rpt strip_tac >> gvs[]
+  >- (qexists `<|inst_id := 0; inst_opcode := ALLOCA; inst_operands := [Lit 64w]; inst_outputs := ["ptr"]|>` >> simp[])
+  >> pop_assum mp_tac >> simp[]
+QED
+
+Theorem ce3_pointer_use_step:
+  pointer_use_step ce3_fn ["ptr"] = ["ptr2"]
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_pointer_use_step_step1:
+  pointer_use_step_step ce3_fn ["ptr"] = SOME ["ptr"; "ptr2"]
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_pointer_use_step_step2:
+  pointer_use_step_step ce3_fn ["ptr"; "ptr2"] = NONE
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_pointer_use_vars:
+  pointer_use_vars ce3_fn ["ptr"] = ["ptr"; "ptr2"]
+Proof
+  simp[pointer_use_vars_def] >>
+  once_rewrite_tac[OWHILE_THM] >>
+  simp[ISL, OUTL, ce3_pointer_use_step_step1] >>
+  once_rewrite_tac[OWHILE_THM] >>
+  simp[ISL, OUTL, ce3_pointer_use_step_step2] >>
+  once_rewrite_tac[OWHILE_THM] >>
+  simp[ISL]
+QED
+
+Theorem ce3_pointer_derived_vars:
+  pointer_derived_vars ce3_fn ce3_roots = {"ptr"; "ptr2"}
+Proof
+  simp[pointer_derived_vars_def, ce3_roots_def, ce3_alloca_roots, SET_TO_LIST_SING, ce3_pointer_use_vars, EXTENSION] >>
+  gen_tac >> Cases_on `x = "ptr"` >> Cases_on `x = "ptr2"` >> simp[]
+QED
+
+Theorem ce3_step_inst_base:
+  step_inst_base ce3_inst ce3_state = OK ce3_v
+Proof
+  EVAL_TAC >> simp[WORD_ADD_0]
+QED
+
+Theorem ce3_not_terminator:
+  ¬is_terminator ce3_inst.inst_opcode
+Proof
+  simp[ce3_inst_def, mk_inst_def, is_terminator_def]
+QED
+
+Theorem ce3_not_ext_call_op:
+  ¬is_ext_call_op ce3_inst.inst_opcode
+Proof
+  simp[is_ext_call_op_def, ce3_inst_def, mk_inst_def]
+QED
+
+Theorem ce3_alloca_memory_bound:
+  ∀aid off asz.
+    FLOOKUP ce3_state.vs_allocas aid = SOME (off, asz) ⇒
+    off + asz ≤ LENGTH ce3_state.vs_memory
+Proof
+  strip_tac >> mp_tac ce3_state_def >>
+  simp[FLOOKUP_UPDATE, FLOOKUP_EMPTY] >>
+  Cases_on `aid` >> gvs[] >> decide_tac
+QED
+
+Theorem ce3_lookup_ptr:
+  lookup_var "ptr" ce3_state = SOME (0w:256 word)
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_lookup_ptr2:
+  lookup_var "ptr2" ce3_state = SOME (0w:256 word)
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_lookup_ptr2_v:
+  lookup_var "ptr2" ce3_v = SOME (9999w:256 word)
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_lookup_ptr_v:
+  lookup_var "ptr" ce3_v = SOME (0w:256 word)
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_eval_operand_lit32:
+  eval_operand (Lit 32w) ce3_state = SOME (32w:256 word)
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_eval_operand_lit32_v:
+  eval_operand (Lit 32w) ce3_v = SOME (32w:256 word)
+Proof
+  EVAL_TAC
+QED
+
+(* mem_write_ops and mem_read_ops for all ce3 instructions *)
+Theorem ce3_mem_write_ops_alloca:
+  mem_write_ops (mk_inst 0 ALLOCA [Lit 64w] ["ptr"]) = NONE
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_mem_read_ops_alloca:
+  mem_read_ops (mk_inst 0 ALLOCA [Lit 64w] ["ptr"]) = NONE
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_mem_write_ops_add:
+  mem_write_ops (mk_inst 1 ADD [Var "ptr"; Var "k"] ["ptr2"]) = NONE
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_mem_read_ops_add:
+  mem_read_ops (mk_inst 1 ADD [Var "ptr"; Var "k"] ["ptr2"]) = NONE
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce3_mem_read_ops_mstore:
+  mem_read_ops (mk_inst 2 MSTORE [Var "ptr2"; Var "data"] []) = NONE
+Proof
+  EVAL_TAC
+QED
+
+(* ---- alloca_safe_access for ce3_state ---- *)
+
+Theorem ce3_alloca_safe_access:
+  alloca_safe_access ce3_fn ce3_roots ce3_state
+Proof
+  simp[alloca_safe_access_def, ce3_pointer_derived_vars] >>
+  rpt strip_tac >>
+  gvs[ce3_fn_def, MEM] >>
+  gvs[ce3_mem_write_ops_alloca, ce3_mem_read_ops_alloca] >>
+  gvs[ce3_mem_write_ops_add, ce3_mem_read_ops_add] >>
+  gvs[ce3_mem_write_ops_mstore, ce3_mem_read_ops_mstore,
+      ce3_lookup_ptr2, ce3_w2n_0, ce3_eval_operand_lit32, ce3_w2n_32,
+      ce3_state_def, FLOOKUP_UPDATE, FLOOKUP_EMPTY] >>
+  rpt (BasicProvers.FULL_CASE_TAC >> gvs[]) >> decide_tac
+QED
+
+(* ---- ptrs_in_alloca_bounds for ce3_state ---- *)
+
+Theorem ce3_ptrs_in_alloca_bounds_s:
+  ptrs_in_alloca_bounds ce3_fn ce3_roots ce3_state
+Proof
+  simp[Once ptrs_in_alloca_bounds_def, ce3_pointer_derived_vars] >>
+  rpt strip_tac >> gvs[ce3_lookup_ptr, ce3_lookup_ptr2, ce3_w2n_0] >>
+  simp[Once in_alloca_region_def] >- (qexistsl [`0`,`64`] >> EVAL_TAC) >>
+  simp[Once in_alloca_region_def] >- (qexistsl [`0`,`64`] >> EVAL_TAC)
+QED
+
+(* ---- NOT ptrs_in_alloca_bounds for ce3_v ---- *)
+
+Theorem ce3_not_ptrs_in_alloca_bounds_v:
+  ¬ptrs_in_alloca_bounds ce3_fn ce3_roots ce3_v
+Proof
+  fs[ptrs_in_alloca_bounds_def, in_alloca_region_def, ce3_pointer_derived_vars] >>
+  rpt strip_tac >>
+  qexistsl [`"ptr2"`, `9999w`] >> simp[ce3_lookup_ptr2_v, ce3_w2n_9999] >>
+  rpt strip_tac >>
+  `ce3_v.vs_allocas = FEMPTY |+ (0,(0,64))` by EVAL_TAC >>
+  full_simp_tac bool_ss [FLOOKUP_UPDATE, FLOOKUP_EMPTY] >>
+  Cases_on `aid` >> gvs[] >> decide_tac
+QED
+
+(* ---- alloca_safe_access for ce3_v (vacuously true) ---- *)
+
+Theorem ce3_alloca_safe_access_v:
+  alloca_safe_access ce3_fn ce3_roots ce3_v
+Proof
+  simp[alloca_safe_access_def, ce3_pointer_derived_vars] >>
+  rpt strip_tac >>
+  gvs[ce3_fn_def, MEM] >>
+  gvs[ce3_mem_write_ops_alloca, ce3_mem_read_ops_alloca] >>
+  gvs[ce3_mem_write_ops_add, ce3_mem_read_ops_add] >>
+  gvs[ce3_mem_write_ops_mstore, ce3_mem_read_ops_mstore,
+      ce3_lookup_ptr2_v, ce3_w2n_9999, ce3_eval_operand_lit32_v,
+      ce3_w2n_32, ce3_v_def, ce3_state_def,
+      FLOOKUP_UPDATE, FLOOKUP_EMPTY] >>
+  rpt (BasicProvers.FULL_CASE_TAC >> gvs[]) >> decide_tac
+QED
+
+(* ---- THE COUNTEREXAMPLE ---- *)
+
+Theorem step_preserves_safety_counterexample:
+  ∃fn roots inst bb s v.
+    MEM bb fn.fn_blocks ∧ MEM inst bb.bb_instructions ∧
+    step_inst_base inst s = OK v ∧
+    ¬is_terminator inst.inst_opcode ∧
+    ¬is_ext_call_op inst.inst_opcode ∧
+    alloca_safe_access fn roots s ∧ ptrs_in_alloca_bounds fn roots s ∧
+    ¬(alloca_safe_access fn roots v ∧ ptrs_in_alloca_bounds fn roots v)
+Proof
+  map_every qexists
+    [`ce3_fn`, `ce3_roots`, `ce3_inst`, `ce3_bb`, `ce3_state`, `ce3_v`] >>
+  simp[ce3_fn_def, ce3_inst_def, ce3_bb_def, ce3_step_inst_base,
+       ce3_not_terminator, ce3_not_ext_call_op,
+       ce3_alloca_safe_access, ce3_ptrs_in_alloca_bounds_s,
+       ce3_not_ptrs_in_alloca_bounds_v, ce3_alloca_safe_access_v]
+QED

--- a/venom/analysis/base_ptr/proofs/bridgeCounterexampleScript.sml
+++ b/venom/analysis/base_ptr/proofs/bridgeCounterexampleScript.sml
@@ -1,0 +1,238 @@
+(*
+ * Counterexample: bp_ptrs_bounded does NOT imply alloca_safe_access
+ *
+ * The bridge theorem bp_ptrs_bounded_imp_alloca_safe_access is FALSE:
+ * there exist fn, bp, s, roots where all hypotheses hold but
+ * alloca_safe_access fails.
+ *
+ * Root cause: alloca_safe_access checks runtime values
+ * (eval_operand sz_op s = SOME sz_val ⇒ w2n w + w2n sz_val ≤ off + asz)
+ * while bp_ptrs_bounded only checks compile-time structure
+ * (bp_segment_from_ops gives ml_size = NONE for variable-sized ops,
+ *  and memloc_within_alloca with ml_size = NONE is trivially T).
+ *
+ * The state s is universally quantified with no constraint on vs_vars,
+ * so s can set the size variable to any value, breaking the access bound.
+ *)
+
+Theory bridgeCounterexample
+
+Ancestors
+  basePtrDefs pointerConfinedDefs allocaRemapDefs venomInst
+  venomExecSemantics venomWf memLocDefs venomInstProofs
+  pred_set finite_map list option While sum arithmetic words
+
+(* Minimal function: ALLOCA producing "ptr" + MCOPY with variable size *)
+Definition ce_fn_def:
+  ce_fn : ir_function = <|
+    fn_name := "ce_test";
+    fn_blocks := [
+      <| bb_label := "entry";
+         bb_instructions := [
+           mk_inst 0 ALLOCA [Lit (n2w 64)] ["ptr"];
+           mk_inst 1 MCOPY [Var "ptr"; Var "src"; Var "sz"] []
+         ]
+      |>
+    ]
+  |>
+End
+
+(* State: alloca at id=0, base=0, size=64; "ptr"=0w in alloca region;
+   "sz"=9999w (WAY too large for a 64-byte alloca region) *)
+Definition ce_state_def:
+  ce_state = (init_venom_state "entry") with <|
+    vs_vars := FEMPTY |+ ("ptr", n2w 0) |+ ("sz", n2w 9999) |+ ("src", n2w 0);
+    vs_allocas := FEMPTY |+ (0, (0, 64));
+    vs_memory := REPLICATE 64 (0w:word8);
+    vs_alloca_next := 64
+  |>
+End
+
+(* Base pointer analysis result: "ptr" → alloca 0 at offset 0 *)
+Definition ce_bp_def:
+  ce_bp : (string, ptr list) fmap =
+    FEMPTY |+ ("ptr", [Ptr (Allocation 0) (SOME 0)])
+End
+
+Definition ce_roots_def:
+  ce_roots = alloca_roots ce_fn
+End
+
+(* ---- Verified by EVAL ---- *)
+
+Theorem ce_mem_write_ops_mcopy:
+  mem_write_ops (mk_inst 1 MCOPY [Var "ptr"; Var "src"; Var "sz"] []) =
+    SOME <|iao_ofst := Var "ptr"; iao_size := SOME (Var "sz");
+            iao_max_size := SOME (Var "sz")|>
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce_mem_read_ops_mcopy:
+  mem_read_ops (mk_inst 1 MCOPY [Var "ptr"; Var "src"; Var "sz"] []) =
+    SOME <|iao_ofst := Var "src"; iao_size := SOME (Var "sz");
+            iao_max_size := SOME (Var "sz")|>
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce_bp_segment_from_ops_mcopy_write:
+  bp_segment_from_ops ce_bp
+    <|iao_ofst := Var "ptr"; iao_size := SOME (Var "sz");
+      iao_max_size := SOME (Var "sz")|> =
+    <|ml_offset := SOME 0; ml_size := NONE;
+      ml_alloca := SOME (Allocation 0); ml_volatile := F|>
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce_bp_segment_from_ops_mcopy_read:
+  bp_segment_from_ops ce_bp
+    <|iao_ofst := Var "src"; iao_size := SOME (Var "sz");
+      iao_max_size := SOME (Var "sz")|> =
+    <|ml_offset := NONE; ml_size := NONE;
+      ml_alloca := NONE; ml_volatile := F|>
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce_memloc_within_alloca_write:
+  memloc_within_alloca
+    <|ml_offset := SOME 0; ml_size := NONE;
+      ml_alloca := SOME (Allocation 0); ml_volatile := F|>
+    ce_state ⇔ T
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce_memloc_within_alloca_read:
+  memloc_within_alloca
+    <|ml_offset := NONE; ml_size := NONE;
+      ml_alloca := NONE; ml_volatile := F|>
+    ce_state ⇔ T
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce_pointer_use_step:
+  pointer_use_step ce_fn ["ptr"] = []
+Proof
+  EVAL_TAC
+QED
+
+(* ---- Derived facts ---- *)
+
+Theorem ce_pointer_use_step_step:
+  pointer_use_step_step ce_fn ["ptr"] = NONE
+Proof
+  EVAL_TAC
+QED
+
+Theorem ce_pointer_use_vars:
+  pointer_use_vars ce_fn ["ptr"] = ["ptr"]
+Proof
+  simp[pointer_use_vars_def] >>
+  once_rewrite_tac[OWHILE_THM] >>
+  simp[ISL, OUTL, ce_pointer_use_step_step] >>
+  once_rewrite_tac[OWHILE_THM] >>
+  simp[ISL, OUTL, ce_pointer_use_step_step]
+QED
+
+Theorem ce_alloca_roots:
+  alloca_roots ce_fn = {"ptr"}
+Proof
+  simp[alloca_roots_def, ce_fn_def, fn_insts_def, mk_inst_def, inst_output_def, EXTENSION] >>
+  gen_tac >> gvs[fn_insts_blocks_def, MEM, AllCaseEqs()] >> eq_tac >> rpt strip_tac >> gvs[]
+  >- (qexists `<|inst_id := 0; inst_opcode := ALLOCA; inst_operands := [Lit 64w]; inst_outputs := ["ptr"]|>` >> simp[])
+  >> pop_assum mp_tac >> simp[]
+QED
+
+Theorem ce_pointer_derived_vars:
+  pointer_derived_vars ce_fn ce_roots = {"ptr"}
+Proof
+  simp[pointer_derived_vars_def, ce_roots_def, ce_alloca_roots, SET_TO_LIST_SING, ce_pointer_use_vars]
+QED
+
+Theorem ce_bp_ptr_sound:
+  bp_ptr_sound ce_bp ce_state
+Proof
+  simp[bp_ptr_sound_def] >> gen_tac >> Cases_on `v = "ptr"` >- (gvs[ce_bp_def, bp_get_ptrs_def, ptr_matches_var_def, FLOOKUP_UPDATE, FLOOKUP_EMPTY, ce_state_def] >> EVAL_TAC) >> gvs[ce_bp_def, bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_EMPTY]
+QED
+
+Theorem ce_bp_ptrs_bounded:
+  bp_ptrs_bounded ce_bp ce_fn ce_state
+Proof
+  simp[bp_ptrs_bounded_def] >> rpt strip_tac >> gvs[ce_fn_def, AllCaseEqs()] >>
+  gvs[mem_write_ops_def, mem_read_ops_def, mk_inst_def, AllCaseEqs(),
+      ce_bp_segment_from_ops_mcopy_write, ce_bp_segment_from_ops_mcopy_read,
+      IS_SOME_DEF, ce_memloc_within_alloca_write, ce_memloc_within_alloca_read]
+QED
+
+Theorem ce_pv_subset:
+  pointer_derived_vars ce_fn ce_roots ⊆ {v | bp_get_ptrs ce_bp v ≠ []}
+Proof
+  simp[SUBSET_DEF, ce_pointer_derived_vars, bp_get_ptrs_def, ce_bp_def, FLOOKUP_UPDATE]
+QED
+
+Theorem ce_alloca_memory_bound:
+  ∀aid off asz.
+    FLOOKUP ce_state.vs_allocas aid = SOME (off, asz) ⇒
+    off + asz ≤ LENGTH ce_state.vs_memory
+Proof
+  Cases_on `aid = 0n` >> strip_tac >> gvs[ce_state_def, FLOOKUP_UPDATE]
+QED
+
+(* ---- THE COUNTEREXAMPLE ---- *)
+
+val dimindex_256 = fcpLib.DIMINDEX (Arbnum.fromInt 256)
+
+Theorem ce_w2n_9999:
+  w2n (9999w:256 word) = 9999
+Proof
+  simp[w2n_n2w, LESS_MOD] >>
+  `dimindex(:64) < dimindex(:256)` by
+    (simp[dimindex_64, dimindex_256] >> decide_tac) >>
+  `dimword(:64) < dimword(:256)` by
+    metis_tac[dimindex_dimword_lt_iso] >>
+  `9999 < dimword(:64)` by (simp[dimword_64] >> decide_tac) >>
+  decide_tac
+QED
+
+Theorem ce_w2n_0:
+  w2n (0w:256 word) = 0
+Proof
+  simp[w2n_n2w, LESS_MOD]
+QED
+
+Theorem ce_not_alloca_safe_access:
+  ¬alloca_safe_access ce_fn ce_roots ce_state
+Proof
+  strip_tac >> gvs[alloca_safe_access_def, ce_pointer_derived_vars] >>
+  first_x_assum (qspec_then `<|bb_label := "entry"; bb_instructions := [mk_inst 0 ALLOCA [Lit 64w] ["ptr"]; mk_inst 1 MCOPY [Var "ptr"; Var "src"; Var "sz"] []]|>` assume_tac) >>
+  first_x_assum (qspec_then `mk_inst 1 MCOPY [Var "ptr"; Var "src"; Var "sz"] []` assume_tac) >>
+  first_x_assum (qspec_then `<|iao_ofst := Var "ptr"; iao_size := SOME (Var "sz"); iao_max_size := SOME (Var "sz")|>` assume_tac) >>
+  first_x_assum (qspec_then `0w` assume_tac) >>
+  first_x_assum (qspec_then `Var "sz"` assume_tac) >>
+  first_x_assum (qspec_then `9999w` assume_tac) >>
+  first_x_assum (qspec_then `0` assume_tac) >>
+  first_x_assum (qspec_then `0` assume_tac) >>
+  first_x_assum (qspec_then `64` assume_tac) >>
+  first_x_assum mp_tac >>
+  simp[ce_fn_def, ce_mem_write_ops_mcopy, ce_state_def, FLOOKUP_UPDATE,
+       ce_w2n_9999, ce_w2n_0] >>
+  EVAL_TAC >> decide_tac
+QED
+
+(* ---- FINAL COUNTEREXAMPLE ---- *)
+Theorem bridge_counterexample:
+  bp_ptr_sound ce_bp ce_state ∧
+  bp_ptrs_bounded ce_bp ce_fn ce_state ∧
+  pointer_derived_vars ce_fn ce_roots ⊆ {v | bp_get_ptrs ce_bp v ≠ []} ∧
+  (∀aid off asz.
+     FLOOKUP ce_state.vs_allocas aid = SOME (off, asz) ⇒
+     off + asz ≤ LENGTH ce_state.vs_memory) ∧
+  ¬alloca_safe_access ce_fn ce_roots ce_state
+Proof
+  metis_tac[ce_bp_ptr_sound, ce_bp_ptrs_bounded, ce_pv_subset,
+            ce_alloca_memory_bound, ce_not_alloca_safe_access]
+QED

--- a/venom/analysis/mem_alias/proofs/memAliasProofsScript.sml
+++ b/venom/analysis/mem_alias/proofs/memAliasProofsScript.sml
@@ -1088,7 +1088,7 @@ Proof
       memloc_runtime_region_def]
   >- ((* Lit c *)
       qexists_tac `w2n c` >> simp[] >>
-      Cases_on `ops.iao_size` >> gvs[] >>
+      Cases_on `ops.iao_max_size` >> gvs[] >>
       Cases_on `x` >> gvs[])
   >> (* Var s' *)
   Cases_on `bp_ptr_from_op bp (Var s')` >> gvs[] >>
@@ -1098,6 +1098,6 @@ Proof
   rename1 `Ptr (Allocation aid) (SOME off)` >>
   drule_all bp_ptr_from_op_sound_local >> strip_tac >>
   gvs[] >> qexists_tac `base' + off` >> simp[] >>
-  Cases_on `ops.iao_size` >> gvs[] >>
+  Cases_on `ops.iao_max_size` >> gvs[] >>
   Cases_on `x` >> gvs[]
 QED

--- a/venom/proofs/venomMemProofsScript.sml
+++ b/venom/proofs/venomMemProofsScript.sml
@@ -197,16 +197,16 @@ Proof
   `LENGTH (word_to_bytes val T) = 32` by rw[len_word_to_bytes_256] >>
   `off1 + 32 <= LENGTH expanded` by
     (rw[Abbr `expanded`] >> rw[LENGTH_APPEND, LENGTH_REPLICATE] >> fs[]) >>
-  (* Step 1: splice lemma on the inner TAKE/DROP *)
+  (* Splice lemma on the inner TAKE/DROP. *)
   `TAKE 32 (DROP off2 (TAKE off1 expanded ++ word_to_bytes val T ++
      DROP (off1 + 32) expanded)) = TAKE 32 (DROP off2 expanded)` by
     (irule take_drop_splice_disjoint >> rw[]) >>
-  (* Step 2: lift to padded version via take_cong_append *)
+  (* Lift to the padded version via take_cong_append. *)
   `TAKE 32 (DROP off2 (TAKE off1 expanded ++ word_to_bytes val T ++
      DROP (off1 + 32) expanded) ++ REPLICATE 32 0w) =
    TAKE 32 (DROP off2 expanded ++ REPLICATE 32 0w)` by
     (irule take_cong_append >> rw[]) >>
-  (* Step 3: padding irrelevance *)
+  (* Padding irrelevance. *)
   `TAKE 32 (DROP off2 expanded ++ REPLICATE 32 0w) =
    TAKE 32 (DROP off2 mem ++ REPLICATE 32 0w)` by
     (rw[Abbr `expanded`] >> rw[take_drop_pad_combined]) >>
@@ -467,7 +467,7 @@ Theorem alloca_inv_joint[local]:
 Proof
   ho_match_mp_tac run_defs_ind >> rpt conj_tac >> rpt strip_tac
   >- (
-    (* P0: step_inst *)
+    (* step_inst case *)
     Cases_on `inst.inst_opcode = INVOKE`
     >- (
       ONCE_REWRITE_TAC[step_inst_def] >> simp[] >>
@@ -496,7 +496,7 @@ Proof
     )
   )
   >- (
-    (* P1: exec_block *)
+    (* exec_block case *)
     ONCE_REWRITE_TAC[exec_block_def] >> simp[] >>
     rpt (BasicProvers.TOP_CASE_TAC >> gvs[result_alloca_inv_def]) >>
     (* Remaining: recursive case, ¬is_terminator *)
@@ -507,7 +507,7 @@ Proof
     qexists_tac `v.vs_alloca_next` >> gvs[]
   )
   >- (
-    (* P2: run_blocks *)
+    (* run_blocks case *)
     ONCE_REWRITE_TAC[run_blocks_def] >> simp[] >>
     rpt (BasicProvers.TOP_CASE_TAC >> gvs[result_alloca_inv_def]) >>
     (* Recursive case: exec_block returned OK, not halted *)


### PR DESCRIPTION
_co-authored by claude sonnet 4.6_

## Summary

- Updates base-pointer segment sizing to use `iao_max_size`, so static locations use the maximum access width rather than the nominal size operand.
- Adds a progress statement for lowering memory safety over `reachable_by_execution` states, with the public props theory kept as a thin API layer and helper proofs in `loweringMemSafetyProofs`.
- Adds formal counterexamples documenting why earlier arbitrary-state statements, simple step-preservation, and the base-pointer boundedness bridge are too weak for must-safety.
- Leaves internal-call `vs_allocas` semantics unchanged; cross-function memory-safety reasoning should move into a checked/shadow provenance layer rather than ordinary call setup.

## Status

This is a progress PR. The top-level `lowering_memory_safe` theorem is intentionally still cheated and marked as such in `lowering/proofs/loweringMemSafetyProofsScript.sml`. The current statement is intermediate; the intended next step is to replace `reachable_by_execution` with a real checked/shadow execution safety model.

## Validation

- `git diff --check main..HEAD`
- artifact/sensitive-content scans over the PR diff (only false positive was the `LOG` opcode constructor)
- `(cd venom/defs && Holmake --qof -j1 venomExecSemanticsTheory.uo)`
- `(cd venom/proofs && Holmake --qof -j1 venomMemProofsTheory.uo)`
- `(cd venom/analysis/base_ptr/proofs && Holmake --qof -j1 bpPtrsBoundedCounterexampleTheory.uo bridgeCounterexampleTheory.uo)`
- `(cd lowering/defs && Holmake --qof -j1 loweringAllocaSafeAccessCounterexampleTheory.uo)`
- `(cd lowering/proofs && Holmake --qof -j1 loweringMemSafetyProofsTheory.uo)`
- `(cd lowering && Holmake --qof -j1 loweringMemSafetyPropsTheory.uo)`
