### PR TITLE
docs: update AGENTS.md HOL build workflow guidance

### DIFF
--- a/.github/workflows/holbuild.yml
+++ b/.github/workflows/holbuild.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}
         run: |
-          holbuild --holdir "$HOLDIR" -j"$(nproc)" build --skip-checkpoints --skip-goalfrag
+          holbuild --verbose --holdir "$HOLDIR" -j"$(nproc)" build --skip-checkpoints --skip-goalfrag
 
       - name: Verify no successful-build checkpoints remain
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Prefer using dedicated tools instead of bash operation:
 - **Read tool** for ALL file reading (not `cat`, `head`, `tail`, `less`)
 - **Grep tool** for searching file contents (not `grep`, `rg`, or `Search` with paths)
 - **Write/Edit tools** for file modifications (not `echo`, `sed`, `awk`)
-- **mcp tools** for hol operations - `hol_send`, `holmake` etc.
+- **`holbuild`** for HOL operations/builds.
 
 ## Completion Standard
 
@@ -35,7 +35,7 @@ If you need to temporarily cheat a proof for debugging:
 3. Add a comment explaining why it's cheated
 
 ```sml
-(* TEMPORARILY CHEATED - investigating batch/interactive discrepancy
+(* TEMPORARILY CHEATED - investigating proof/build issue
 Proof
   Induct_on `fuel` >- rw[...] >>
   ...original proof...
@@ -74,26 +74,15 @@ venom/passes/  # directory for each pass
 
 ## Building
 
+Use direct script edits plus `holbuild` for HOL proof development and build validation.
 
 **Build time:** Keep under 30s. If longer, refactor the proof.
 
-**Theory files:** `.sig` and `.uo` files are generated in the `.hol/` subdir, never in the source directory. Don't try to load theories (`load "fooTheory"`) that haven't been built yet - run `Holmake` first.
+**Theory files:** `.sig` and `.uo` files are generated in the `.hol/` subdir, never in the source directory. Don't try to load theories (`load "fooTheory"`) that haven't been built yet - run `holbuild` first.
 
-## Interactive HOL Sessions
+**No interactive mode:** Do not use interactive proof-state workflows, including `g()`, `e()`, or `p()`.
 
-Use the hol4 MCP tools for proof development.
-
-**Workflow: hol_state_at + Edit**
-1. `hol_file_init` - parse file, list theorems with line numbers and cheat status
-2. `hol_state_at(line, col)` - navigate to position, auto-replay tactics, show goals
-3. Edit file directly with Edit tool to add/modify tactics
-4. `hol_state_at` again to verify the change worked
-
-**CRITICAL**: The user requests not to use `g()`, `e()`, `p()` - the tool manages proof state
-
-**Key points:**
-- `hol_state_at` handles file changes, checkpoints, and tactic replay automatically
-- Use `hol_send` only for queries (DB.match, type_of) not proof navigation
+**Never use `--skip-goalfrag`:** It is not allowed.
 
 ### File Conventions (repo-specific)
 
@@ -223,13 +212,11 @@ If these are missing, ask the user to provide access.
 
 ## Proof Strategy
 
-**When proofs get complex:** Step back, look for helper lemmas, consider refactoring definitions. Use `hol_state_at` at different positions to debug. Cheats are temporary scaffolding only.
+**When proofs get complex:** Step back, look for helper lemmas, consider refactoring definitions, and validate incrementally with `holbuild`. Cheats are temporary scaffolding only.
 
 **Signs you're on wrong track:** Many nested TRY blocks, dozens of subgoals, slow tactics, unpredictable variable names (`h''` etc.) → stop and reconsider.
 
 ## HOL4
-
-There is NEVER "disagreement" between batch and interactive mode, they use the same machinery. ANY DIFFERENCE BETWEEN THEM IS A RESULT OF STALE SESSION STATE, USE `hol_restart()`!
 
 ### sg vs by vs suffices_by
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Use direct script edits plus `holbuild` for HOL proof development and build vali
 **Workflow: Edit / holbuild / loop**
 1. Edit the `.sml` file directly
 2. Run `holbuild` — on proof failure it prints the goal state (via goalfrag)
-3. Read the goal state, edit tactics, re-run `holbuild` until it passes
+3. Read the goal state, edit proof, re-run `holbuild` until it passes
 
 **Build time:** Keep under 30s. If longer, refactor the proof.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,14 @@ venom/passes/  # directory for each pass
 
 Use direct script edits plus `holbuild` for HOL proof development and build validation.
 
+**Workflow: Edit / holbuild / loop**
+1. Edit the `.sml` file directly
+2. Run `holbuild` — on proof failure it prints the goal state (via goalfrag)
+3. Read the goal state, edit tactics, re-run `holbuild` until it passes
+
 **Build time:** Keep under 30s. If longer, refactor the proof.
 
-**Theory files:** `.sig` and `.uo` files are generated in the `.hol/` subdir, never in the source directory. Don't try to load theories (`load "fooTheory"`) that haven't been built yet - run `holbuild` first.
+**Theory files:** `.sig` and `.uo` files are generated in the `.holbuild/` subdir, never in the source directory. Don't try to load theories (`load "fooTheory"`) that haven't been built yet - run `holbuild` first.
 
 **No interactive mode:** Do not use interactive proof-state workflows, including `g()`, `e()`, or `p()`.
 


### PR DESCRIPTION
Update AGENTS.md to reflect current HOL4 development workflow:

- Replace MCP tool references (hol_state_at, hol_file_init, hol_send) with holbuild
- Remove interactive session section; state no interactive mode / no g(), e(), p()
- Add prohibition on --skip-goalfrag
- Remove stale batch/interactive discrepancy note
- Minor comment fix in cheat template