### PR TITLE
Fix memory copy elision proof timeout

### DIFF
--- a/venom/passes/memory_copy_elision/proofs/memoryCopyElisionProofsScript.sml
+++ b/venom/passes/memory_copy_elision/proofs/memoryCopyElisionProofsScript.sml
@@ -1447,8 +1447,59 @@ Proof
 QED
 
 (* Output ptrs after bp_handle_inst depend only on bp_get_ptrs, not on the
-   concrete fmap representation.  Keep bp_get_ptrs abstract; only simplify the
-   output FUPDATE. *)
+   concrete fmap representation.  Keep bp_get_ptrs abstract; split only the
+   operand shapes that the pointer opcodes inspect. *)
+Triviality bp_handle_inst_add_snd_output_ext[local]:
+  !bp1 bp2 inst out.
+    (!v. bp_get_ptrs bp1 v = bp_get_ptrs bp2 v) /\
+    inst_output inst = SOME out /\
+    inst.inst_opcode = ADD ==>
+    bp_get_ptrs (SND (bp_handle_inst bp1 inst)) out =
+    bp_get_ptrs (SND (bp_handle_inst bp2 inst)) out
+Proof
+  rpt strip_tac >>
+  simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same] >>
+  Cases_on `inst.inst_operands` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `t` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `t'` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `h` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `h'` >> gvs[bp_get_ptrs_update_same] >>
+  rpt (IF_CASES_TAC >> gvs[bp_get_ptrs_update_same])
+QED
+
+Triviality bp_handle_inst_sub_snd_output_ext[local]:
+  !bp1 bp2 inst out.
+    (!v. bp_get_ptrs bp1 v = bp_get_ptrs bp2 v) /\
+    inst_output inst = SOME out /\
+    inst.inst_opcode = SUB ==>
+    bp_get_ptrs (SND (bp_handle_inst bp1 inst)) out =
+    bp_get_ptrs (SND (bp_handle_inst bp2 inst)) out
+Proof
+  rpt strip_tac >>
+  simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same] >>
+  Cases_on `inst.inst_operands` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `t` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `t'` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `h` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `h'` >> gvs[bp_get_ptrs_update_same] >>
+  rpt (IF_CASES_TAC >> gvs[bp_get_ptrs_update_same])
+QED
+
+Triviality bp_handle_inst_assign_snd_output_ext[local]:
+  !bp1 bp2 inst out.
+    (!v. bp_get_ptrs bp1 v = bp_get_ptrs bp2 v) /\
+    inst_output inst = SOME out /\
+    inst.inst_opcode = ASSIGN ==>
+    bp_get_ptrs (SND (bp_handle_inst bp1 inst)) out =
+    bp_get_ptrs (SND (bp_handle_inst bp2 inst)) out
+Proof
+  rpt strip_tac >>
+  simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same] >>
+  Cases_on `inst.inst_operands` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `t` >> gvs[bp_get_ptrs_update_same] >>
+  Cases_on `h` >> gvs[bp_get_ptrs_update_same]
+QED
+
 Triviality bp_handle_inst_snd_output_ext[local]:
   !bp1 bp2 inst out.
     (!v. bp_get_ptrs bp1 v = bp_get_ptrs bp2 v) /\
@@ -1463,13 +1514,10 @@ Proof
     (irule MAP_CONG >> simp[]) >>
   gvs[is_ptr_opcode_def]
   >- simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same]
-  >- (simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same] >>
-      rpt (CASE_TAC >> gvs[bp_get_ptrs_update_same]))
-  >- (simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same] >>
-      rpt (CASE_TAC >> gvs[bp_get_ptrs_update_same]))
-  >- (simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same])
-  >- (simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same] >>
-      rpt (CASE_TAC >> gvs[bp_get_ptrs_update_same]))
+  >- (irule bp_handle_inst_add_snd_output_ext >> simp[])
+  >- (irule bp_handle_inst_sub_snd_output_ext >> simp[])
+  >- simp[bp_handle_inst_def, LET_THM, bp_get_ptrs_update_same]
+  >- (irule bp_handle_inst_assign_snd_output_ext >> simp[])
 QED
 
 (* FST of bp_handle_inst depends only on bp_get_ptrs *)


### PR DESCRIPTION
_co-authored by OpenAI GPT-5.5_

## Summary

- Fixes a post-merge fresh-build tactic timeout in `memoryCopyElisionProofsTheory`.
- Replaces a broad `rpt CASE_TAC` proof suffix with small opcode-specific helper lemmas for ADD, SUB, and ASSIGN pointer-output extensionality.
- Keeps the proof focused on the operand shapes inspected by `bp_handle_inst`.

## Validation

- `memoryCopyElisionProofsTheory` target build passed with `--tactic-timeout 2.5`.
- Fresh forced scratch build passed with `--force --tactic-timeout 2.5` in `8299.984s`.
- Hygiene checks passed: whitespace, no added `NO_TAC`, no proof-instrumentation bypasses, and no staged sensitive artifacts.
