### PR TITLE
Rename dftTheory to venomDftTheory

### DIFF
--- a/venom/passes/dft/venomDftScript.sml
+++ b/venom/passes/dft/venomDftScript.sml
@@ -1,5 +1,5 @@
 (* DFT pass — public API *)
-Theory dft
+Theory venomDft
 Ancestors
   dftDefs dftCorrectness
 

--- a/venom/passes/venomPassesHolScript.sml
+++ b/venom/passes/venomPassesHolScript.sml
@@ -43,7 +43,7 @@ Ancestors
   (* interprocedural *)
   functionInliner
   (* dead function traversal *)
-  dft
+  venomDft
   (* invoke copy forwarding *)
   internalReturnCopyFwdProofs
   readonlyInvokeCopyFwdProofs


### PR DESCRIPTION
In line with #69. In preparation for upcoming changes to holbuild where we need theory names to be unique including across the HOL package.