### PR TITLE
Complete the Vyper AST syntax API

### DIFF
--- a/syntax/vyperASTSyntax.sig
+++ b/syntax/vyperASTSyntax.sig
@@ -1,234 +1,613 @@
 signature vyperASTSyntax = sig
   include Abbrev
 
-  val Fixed_tm        : term
-  val Dynamic_tm      : term
-  val UintT_tm        : term
-  val IntT_tm         : term
-  val BoolT_tm        : term
-  val DecimalT_tm     : term
-  val StringT_tm      : term
-  val BytesT_tm       : term
-  val AddressT_tm     : term
-  val BaseT_tm        : term
-  val TupleT_tm       : term
-  val ArrayT_tm       : term
-  val StructT_tm      : term
-  val FlagT_tm        : term
-  val NoneT_tm        : term
-  val Signed_tm       : term
-  val Unsigned_tm     : term
-  val BoolL_tm        : term
-  val StringL_tm      : term
-  val BytesL_tm       : term
-  val IntL_tm         : term
-  val DecimalL_tm     : term
-  val Add_tm          : term
-  val Sub_tm          : term
-  val Mul_tm          : term
-  val Div_tm          : term
-  val UnsafeAdd_tm    : term
-  val UnsafeSub_tm    : term
-  val UnsafeMul_tm    : term
-  val UnsafeDiv_tm    : term
-  val Mod_tm          : term
-  val ExpMod_tm       : term
-  val Exp_tm          : term
-  val And_tm          : term
-  val Or_tm           : term
-  val XOr_tm          : term
-  val ShL_tm          : term
-  val ShR_tm          : term
-  val In_tm           : term
-  val NotIn_tm        : term
-  val Eq_tm           : term
-  val NotEq_tm        : term
-  val Lt_tm           : term
-  val LtE_tm          : term
-  val Gt_tm           : term
-  val GtE_tm          : term
-  val Sender_tm       : term
-  val SelfAddr_tm     : term
-  val TimeStamp_tm    : term
-  val BlockNumber_tm  : term
-  val BlobBaseFee_tm  : term
-  val GasPrice_tm     : term
-  val PrevHash_tm     : term
-  val Address_tm      : term
-  val Balance_tm      : term
-  val Wei_tm          : term
-  val Kwei_tm         : term
-  val Mwei_tm         : term
-  val Gwei_tm         : term
-  val Szabo_tm        : term
-  val Finney_tm       : term
-  val Ether_tm        : term
-  val KEther_tm       : term
-  val MEther_tm       : term
-  val GEther_tm       : term
-  val TEther_tm       : term
-  val Len_tm          : term
-  val Not_tm          : term
-  val Neg_tm          : term
-  val Keccak256_tm    : term
-  val Concat_tm       : term
-  val Slice_tm        : term
-  val AsWeiValue_tm   : term
-  val MakeArray_tm    : term
-  val AddMod_tm       : term
-  val MulMod_tm       : term
-  val Floor_tm        : term
-  val Bop_tm          : term
-  val Env_tm          : term
-  val Acc_tm          : term
-  val BlockHash_tm    : term
-  val BlobHash_tm     : term
-  val ECRecover_tm    : term
-  val ECAdd_tm        : term
-  val ECMul_tm        : term
-  val IntCall_tm      : term
-  val Send_tm         : term
-  val Empty_tm        : term
-  val MaxValue_tm     : term
-  val MinValue_tm     : term
-  val Epsilon_tm      : term
-  val Convert_tm      : term
-  val Extract32_tm    : term
-  val AbiDecode_tm    : term
-  val AbiEncode_tm    : term
-  val MethodId_tm     : term
-  val Name_tm         : term
+  val bound_ty : hol_type
+  val base_type_ty : hol_type
+  val type_ty : hol_type
+  val int_bound_ty : hol_type
+  val literal_ty : hol_type
+  val binop_ty : hol_type
+  val env_item_ty : hol_type
+  val account_item_ty : hol_type
+  val denomination_ty : hol_type
+  val builtin_ty : hol_type
+  val ext_call_sig_ty : hol_type
+  val raw_call_flags_ty : hol_type
+  val create_kind_ty : hol_type
+  val type_builtin_ty : hol_type
+  val expr_ty : hol_type
+  val stmt_ty : hol_type
+  val assignment_target_ty : hol_type
+  val base_assignment_target_ty : hol_type
+  val iterator_ty : hol_type
+  val call_target_ty : hol_type
+  val assert_reason_ty : hol_type
+  val raise_reason_ty : hol_type
+  val function_visibility_ty : hol_type
+  val function_mutability_ty : hol_type
+  val variable_visibility_ty : hol_type
+  val variable_mutability_ty : hol_type
+  val argument_ty : hol_type
+  val interface_func_ty : hol_type
+  val value_type_ty : hol_type
+  val toplevel_ty : hol_type
+
+  val Fixed_tm : term
+  val mk_Fixed_tm : term -> term
+  val dest_Fixed_tm : term -> term
+  val is_Fixed : term -> bool
+  val Dynamic_tm : term
+  val mk_Dynamic_tm : term -> term
+  val dest_Dynamic_tm : term -> term
+  val is_Dynamic : term -> bool
+
+  val UintT_tm : term
+  val mk_UintT_tm : term -> term
+  val dest_UintT_tm : term -> term
+  val is_UintT : term -> bool
+  val IntT_tm : term
+  val mk_IntT_tm : term -> term
+  val dest_IntT_tm : term -> term
+  val is_IntT : term -> bool
+  val BoolT_tm : term
+  val is_BoolT : term -> bool
+  val DecimalT_tm : term
+  val is_DecimalT : term -> bool
+  val StringT_tm : term
+  val mk_StringT_tm : term -> term
+  val dest_StringT_tm : term -> term
+  val is_StringT : term -> bool
+  val BytesT_tm : term
+  val mk_BytesT_tm : term -> term
+  val dest_BytesT_tm : term -> term
+  val is_BytesT : term -> bool
+  val AddressT_tm : term
+  val is_AddressT : term -> bool
+
+  val BaseT_tm : term
+  val mk_BaseT_tm : term -> term
+  val dest_BaseT_tm : term -> term
+  val is_BaseT : term -> bool
+  val TupleT_tm : term
+  val mk_TupleT_tm : term -> term
+  val dest_TupleT_tm : term -> term
+  val is_TupleT : term -> bool
+  val mk_TupleT : term list -> term
+  val dest_TupleT : term -> term list
+  val ArrayT_tm : term
+  val mk_ArrayT_tm : term * term -> term
+  val dest_ArrayT_tm : term -> term * term
+  val is_ArrayT : term -> bool
+  val StructT_tm : term
+  val mk_StructT_tm : term -> term
+  val dest_StructT_tm : term -> term
+  val is_StructT : term -> bool
+  val FlagT_tm : term
+  val mk_FlagT_tm : term -> term
+  val dest_FlagT_tm : term -> term
+  val is_FlagT : term -> bool
+  val NoneT_tm : term
+  val is_NoneT : term -> bool
+
+  val BoolL_tm : term
+  val mk_BoolL_tm : term -> term
+  val dest_BoolL_tm : term -> term
+  val is_BoolL : term -> bool
+  val StringL_tm : term
+  val mk_StringL_tm : term -> term
+  val dest_StringL_tm : term -> term
+  val is_StringL : term -> bool
+  val mk_StringL : string -> term
+  val dest_StringL : term -> string
+  val BytesL_tm : term
+  val mk_BytesL_tm : term -> term
+  val dest_BytesL_tm : term -> term
+  val is_BytesL : term -> bool
+  val IntL_tm : term
+  val mk_IntL_tm : term -> term
+  val dest_IntL_tm : term -> term
+  val is_IntL : term -> bool
+  val DecimalL_tm : term
+  val mk_DecimalL_tm : term -> term
+  val dest_DecimalL_tm : term -> term
+  val is_DecimalL : term -> bool
+
+  val Empty_tm : term
+  val is_Empty : term -> bool
+  val MaxValue_tm : term
+  val is_MaxValue : term -> bool
+  val MinValue_tm : term
+  val is_MinValue : term -> bool
+  val Epsilon_tm : term
+  val is_Epsilon : term -> bool
+  val Convert_tm : term
+  val is_Convert : term -> bool
+  val Extract32_tm : term
+  val is_Extract32 : term -> bool
+
+  val Name_tm : term
+  val mk_Name_tm : term * term -> term
+  val dest_Name_tm : term -> term * term
+  val is_Name : term -> bool
+  val mk_Name : term * string -> term
+  val dest_Name : term -> term * string
+
   val TopLevelName_tm : term
-  val IfExp_tm        : term
-  val Literal_tm      : term
-  val StructLit_tm    : term
-  val Subscript_tm    : term
-  val Attribute_tm    : term
-  val Builtin_tm      : term
-  val TypeBuiltin_tm  : term
-  val Pop_tm          : term
-  val AstCall_tm      : term
-  val NameTarget_tm   : term
+  val mk_TopLevelName_tm : term * term -> term
+  val dest_TopLevelName_tm : term -> term * term
+  val is_TopLevelName : term -> bool
+
+  val FlagMember_tm : term
+  val mk_FlagMember_tm : term * term * term -> term
+  val dest_FlagMember_tm : term -> term * term * term
+  val is_FlagMember : term -> bool
+  val mk_FlagMember : term * term * string -> term
+  val dest_FlagMember : term -> term * term * string
+
+  val IfExp_tm : term
+  val mk_IfExp_tm : term * term * term * term -> term
+  val dest_IfExp_tm : term -> term * term * term * term
+  val is_IfExp : term -> bool
+
+  val Literal_tm : term
+  val mk_Literal_tm : term * term -> term
+  val dest_Literal_tm : term -> term * term
+  val is_Literal : term -> bool
+
+  val StructLit_tm : term
+  val mk_StructLit_tm : term * term * term -> term
+  val dest_StructLit_tm : term -> term * term * term
+  val is_StructLit : term -> bool
+  val mk_StructLit : term * term * (string * term) list -> term
+  val dest_StructLit : term -> term * term * (string * term) list
+
+  val Subscript_tm : term
+  val mk_Subscript_tm : term * term * term -> term
+  val dest_Subscript_tm : term -> term * term * term
+  val is_Subscript : term -> bool
+
+  val Attribute_tm : term
+  val mk_Attribute_tm : term * term * term -> term
+  val dest_Attribute_tm : term -> term * term * term
+  val is_Attribute : term -> bool
+  val mk_Attribute : term * term * string -> term
+  val dest_Attribute : term -> term * term * string
+
+  val Builtin_tm : term
+  val mk_Builtin_tm : term * term * term -> term
+  val dest_Builtin_tm : term -> term * term * term
+  val is_Builtin : term -> bool
+  val mk_Builtin : term * term * term list -> term
+  val dest_Builtin : term -> term * term * term list
+
+  val TypeBuiltin_tm : term
+  val mk_TypeBuiltin_tm : term * term * term * term -> term
+  val dest_TypeBuiltin_tm : term -> term * term * term * term
+  val is_TypeBuiltin : term -> bool
+  val mk_TypeBuiltin : term * term * term * term list -> term
+  val dest_TypeBuiltin : term -> term * term * term * term list
+
+  val Pop_tm : term
+  val mk_Pop_tm : term * term -> term
+  val dest_Pop_tm : term -> term * term
+  val is_Pop : term -> bool
+
+  val Call_tm : term
+  val mk_Call_tm : term * term * term * term -> term
+  val dest_Call_tm : term -> term * term * term * term
+  val is_Call : term -> bool
+  val mk_Call : term * term * term list * term option -> term
+  val dest_Call : term -> term * term * term list * term option
+
+  val NameTarget_tm : term
+  val mk_NameTarget_tm : term -> term
+  val dest_NameTarget_tm : term -> term
+  val is_NameTarget : term -> bool
+  val mk_NameTarget : string -> term
+  val dest_NameTarget : term -> string
+
   val TopLevelNameTarget_tm : term
-  val SubscriptTarget_tm    : term
-  val AttributeTarget_tm    : term
-  val BaseTarget_tm   : term
-  val TupleTarget_tm  : term
-  val Array_tm        : term
-  val Range_tm        : term
-  val Pass_tm         : term
-  val Continue_tm     : term
-  val Break_tm        : term
-  val Expr_tm         : term
-  val For_tm          : term
-  val If_tm           : term
-  val Assert_tm       : term
-  val Log_tm          : term
-  val Raise_tm        : term
-  val Return_tm       : term
-  val Assign_tm       : term
-  val AugAssign_tm    : term
-  val Append_tm       : term
-  val AnnAssign_tm    : term
-  val External_tm     : term
-  val Internal_tm     : term
-  val Deploy_tm       : term
-  val Pure_tm         : term
-  val View_tm         : term
-  val Nonpayable_tm   : term
-  val Payable_tm      : term
-  val Public_tm       : term
-  val Private_tm      : term
-  val Constant_tm     : term
-  val Immutable_tm    : term
-  val Transient_tm    : term
-  val Storage_tm      : term
-  val Type_tm         : term
-  val HashMapT_tm     : term
+  val mk_TopLevelNameTarget_tm : term -> term
+  val dest_TopLevelNameTarget_tm : term -> term
+  val is_TopLevelNameTarget : term -> bool
+
+  val SubscriptTarget_tm : term
+  val mk_SubscriptTarget_tm : term * term -> term
+  val dest_SubscriptTarget_tm : term -> term * term
+  val is_SubscriptTarget : term -> bool
+
+  val AttributeTarget_tm : term
+  val mk_AttributeTarget_tm : term * term -> term
+  val dest_AttributeTarget_tm : term -> term * term
+  val is_AttributeTarget : term -> bool
+  val mk_AttributeTarget : term * string -> term
+  val dest_AttributeTarget : term -> term * string
+
+  val BaseTarget_tm : term
+  val mk_BaseTarget_tm : term -> term
+  val dest_BaseTarget_tm : term -> term
+  val is_BaseTarget : term -> bool
+
+  val TupleTarget_tm : term
+  val mk_TupleTarget_tm : term -> term
+  val dest_TupleTarget_tm : term -> term
+  val is_TupleTarget : term -> bool
+  val mk_TupleTarget : term list -> term
+  val dest_TupleTarget : term -> term list
+
+  val Array_tm : term
+  val mk_Array_tm : term -> term
+  val dest_Array_tm : term -> term
+  val is_Array : term -> bool
+
+  val Range_tm : term
+  val mk_Range_tm : term * term -> term
+  val dest_Range_tm : term -> term * term
+  val is_Range : term -> bool
+
+  val Pass_tm : term
+  val is_Pass : term -> bool
+  val Continue_tm : term
+  val is_Continue : term -> bool
+  val Break_tm : term
+  val is_Break : term -> bool
+
+  val Expr_tm : term
+  val mk_Expr_tm : term -> term
+  val dest_Expr_tm : term -> term
+  val is_Expr : term -> bool
+
+  val For_tm : term
+  val mk_For_tm : term * term * term * term * term -> term
+  val dest_For_tm : term -> term * term * term * term * term
+  val is_For : term -> bool
+  val mk_For : string * term * term * term * term list -> term
+  val dest_For : term -> string * term * term * term * term list
+
+  val If_tm : term
+  val mk_If_tm : term * term * term -> term
+  val dest_If_tm : term -> term * term * term
+  val is_If : term -> bool
+  val mk_If : term * term list * term list -> term
+  val dest_If : term -> term * term list * term list
+
+  val Assert_tm : term
+  val mk_Assert_tm : term * term -> term
+  val dest_Assert_tm : term -> term * term
+  val is_Assert : term -> bool
+
+  val Log_tm : term
+  val mk_Log_tm : term * term -> term
+  val dest_Log_tm : term -> term * term
+  val is_Log : term -> bool
+  val mk_Log : term * term list -> term
+  val dest_Log : term -> term * term list
+
+  val Raise_tm : term
+  val mk_Raise_tm : term -> term
+  val dest_Raise_tm : term -> term
+  val is_Raise : term -> bool
+
+  val Return_tm : term
+  val mk_Return_tm : term -> term
+  val dest_Return_tm : term -> term
+  val is_Return : term -> bool
+  val mk_Return : term option -> term
+  val dest_Return : term -> term option
+
+  val Assign_tm : term
+  val mk_Assign_tm : term * term -> term
+  val dest_Assign_tm : term -> term * term
+  val is_Assign : term -> bool
+
+  val AugAssign_tm : term
+  val mk_AugAssign_tm : term * term * term * term -> term
+  val dest_AugAssign_tm : term -> term * term * term * term
+  val is_AugAssign : term -> bool
+
+  val Append_tm : term
+  val mk_Append_tm : term * term -> term
+  val dest_Append_tm : term -> term * term
+  val is_Append : term -> bool
+
+  val AnnAssign_tm : term
+  val mk_AnnAssign_tm : term * term * term -> term
+  val dest_AnnAssign_tm : term -> term * term * term
+  val is_AnnAssign : term -> bool
+  val mk_AnnAssign : string * term * term -> term
+  val dest_AnnAssign : term -> string * term * term
+
+  val IntCall_tm : term
+  val mk_IntCall_tm : term -> term
+  val dest_IntCall_tm : term -> term
+  val is_IntCall : term -> bool
+
+  val ExtCall_tm : term
+  val mk_ExtCall_tm : term * term -> term
+  val dest_ExtCall_tm : term -> term * term
+  val is_ExtCall : term -> bool
+
+  val Send_tm : term
+  val is_Send : term -> bool
+  val mk_raw_call_flags : {max_outsize: term, is_delegate: term, is_static: term, revert_on_failure: term} -> term
+  val dest_raw_call_flags : term -> {max_outsize: term, is_delegate: term, is_static: term, revert_on_failure: term}
+  val is_raw_call_flags : term -> bool
+
+  val RawCallTarget_tm : term
+  val mk_RawCallTarget_tm : term -> term
+  val dest_RawCallTarget_tm : term -> term
+  val is_RawCallTarget : term -> bool
+  val RawLog_tm : term
+  val is_RawLog : term -> bool
+  val RawRevert_tm : term
+  val is_RawRevert : term -> bool
+  val SelfDestructTarget_tm : term
+  val is_SelfDestructTarget : term -> bool
+  val CreateTarget_tm : term
+  val mk_CreateTarget_tm : term * term -> term
+  val dest_CreateTarget_tm : term -> term * term
+  val is_CreateTarget : term -> bool
+
+  val AssertBare_tm : term
+  val is_AssertBare : term -> bool
+  val AssertUnreachable_tm : term
+  val is_AssertUnreachable : term -> bool
+  val AssertReason_tm : term
+  val mk_AssertReason_tm : term -> term
+  val dest_AssertReason_tm : term -> term
+  val is_AssertReason : term -> bool
+
+  val RaiseBare_tm : term
+  val is_RaiseBare : term -> bool
+  val RaiseUnreachable_tm : term
+  val is_RaiseUnreachable : term -> bool
+  val RaiseReason_tm : term
+  val mk_RaiseReason_tm : term -> term
+  val dest_RaiseReason_tm : term -> term
+  val is_RaiseReason : term -> bool
+
+  val Signed_tm : term
+  val mk_Signed_tm : term -> term
+  val dest_Signed_tm : term -> term
+  val is_Signed : term -> bool
+  val Unsigned_tm : term
+  val mk_Unsigned_tm : term -> term
+  val dest_Unsigned_tm : term -> term
+  val is_Unsigned : term -> bool
+
+  val Add_tm : term val is_Add : term -> bool
+  val Sub_tm : term val is_Sub : term -> bool
+  val Mul_tm : term val is_Mul : term -> bool
+  val Div_tm : term val is_Div : term -> bool
+  val UnsafeAdd_tm : term val is_UnsafeAdd : term -> bool
+  val UnsafeSub_tm : term val is_UnsafeSub : term -> bool
+  val UnsafeMul_tm : term val is_UnsafeMul : term -> bool
+  val UnsafeDiv_tm : term val is_UnsafeDiv : term -> bool
+  val ExpMod_tm : term val is_ExpMod : term -> bool
+  val Mod_tm : term val is_Mod : term -> bool
+  val Exp_tm : term val is_Exp : term -> bool
+  val And_tm : term val is_And : term -> bool
+  val Or_tm : term val is_Or : term -> bool
+  val XOr_tm : term val is_XOr : term -> bool
+  val ShL_tm : term val is_ShL : term -> bool
+  val ShR_tm : term val is_ShR : term -> bool
+  val In_tm : term val is_In : term -> bool
+  val NotIn_tm : term val is_NotIn : term -> bool
+  val Eq_tm : term val is_Eq : term -> bool
+  val NotEq_tm : term val is_NotEq : term -> bool
+  val Lt_tm : term val is_Lt : term -> bool
+  val LtE_tm : term val is_LtE : term -> bool
+  val Gt_tm : term val is_Gt : term -> bool
+  val GtE_tm : term val is_GtE : term -> bool
+  val Min_tm : term val is_Min : term -> bool
+  val Max_tm : term val is_Max : term -> bool
+
+  val Sender_tm : term val is_Sender : term -> bool
+  val SelfAddr_tm : term val is_SelfAddr : term -> bool
+  val ValueSent_tm : term val is_ValueSent : term -> bool
+  val TimeStamp_tm : term val is_TimeStamp : term -> bool
+  val BlockNumber_tm : term val is_BlockNumber : term -> bool
+  val BlobBaseFee_tm : term val is_BlobBaseFee : term -> bool
+  val GasPrice_tm : term val is_GasPrice : term -> bool
+  val PrevHash_tm : term val is_PrevHash : term -> bool
+  val ChainId_tm : term val is_ChainId : term -> bool
+  val Coinbase_tm : term val is_Coinbase : term -> bool
+  val GasLimit_tm : term val is_GasLimit : term -> bool
+  val BaseFee_tm : term val is_BaseFee : term -> bool
+  val PrevRandao_tm : term val is_PrevRandao : term -> bool
+  val TxOrigin_tm : term val is_TxOrigin : term -> bool
+  val MsgGas_tm : term val is_MsgGas : term -> bool
+
+  val Address_tm : term val is_Address : term -> bool
+  val Balance_tm : term val is_Balance : term -> bool
+  val Codehash_tm : term val is_Codehash : term -> bool
+  val Codesize_tm : term val is_Codesize : term -> bool
+  val IsContract_tm : term val is_IsContract : term -> bool
+  val Code_tm : term val is_Code : term -> bool
+
+  val Wei_tm : term val is_Wei : term -> bool
+  val Kwei_tm : term val is_Kwei : term -> bool
+  val Mwei_tm : term val is_Mwei : term -> bool
+  val Gwei_tm : term val is_Gwei : term -> bool
+  val Szabo_tm : term val is_Szabo : term -> bool
+  val Finney_tm : term val is_Finney : term -> bool
+  val Ether_tm : term val is_Ether : term -> bool
+  val KEther_tm : term val is_KEther : term -> bool
+  val MEther_tm : term val is_MEther : term -> bool
+  val GEther_tm : term val is_GEther : term -> bool
+  val TEther_tm : term val is_TEther : term -> bool
+
+  val Len_tm : term val is_Len : term -> bool
+  val Not_tm : term val is_Not : term -> bool
+  val Neg_tm : term val is_Neg : term -> bool
+  val Abs_tm : term val is_Abs : term -> bool
+  val Keccak256_tm : term val is_Keccak256 : term -> bool
+  val Sha256_tm : term val is_Sha256 : term -> bool
+  val AsWeiValue_tm : term
+  val mk_AsWeiValue_tm : term -> term
+  val dest_AsWeiValue_tm : term -> term
+  val is_AsWeiValue : term -> bool
+  val Concat_tm : term
+  val mk_Concat_tm : term -> term
+  val dest_Concat_tm : term -> term
+  val is_Concat : term -> bool
+  val Slice_tm : term
+  val mk_Slice_tm : term -> term
+  val dest_Slice_tm : term -> term
+  val is_Slice : term -> bool
+  val Uint2Str_tm : term
+  val mk_Uint2Str_tm : term -> term
+  val dest_Uint2Str_tm : term -> term
+  val is_Uint2Str : term -> bool
+  val MakeArray_tm : term
+  val mk_MakeArray_tm : term * term -> term
+  val dest_MakeArray_tm : term -> term * term
+  val is_MakeArray : term -> bool
+  val Ceil_tm : term val is_Ceil : term -> bool
+  val Floor_tm : term val is_Floor : term -> bool
+  val AddMod_tm : term val is_AddMod : term -> bool
+  val MulMod_tm : term val is_MulMod : term -> bool
+  val Bop_tm : term
+  val mk_Bop_tm : term -> term
+  val dest_Bop_tm : term -> term
+  val is_Bop : term -> bool
+  val BlockHash_tm : term val is_BlockHash : term -> bool
+  val BlobHash_tm : term val is_BlobHash : term -> bool
+  val Env_tm : term
+  val mk_Env_tm : term -> term
+  val dest_Env_tm : term -> term
+  val is_Env : term -> bool
+  val Acc_tm : term
+  val mk_Acc_tm : term -> term
+  val dest_Acc_tm : term -> term
+  val is_Acc : term -> bool
+  val MethodId_tm : term val is_MethodId : term -> bool
+  val ECRecover_tm : term val is_ECRecover : term -> bool
+  val ECAdd_tm : term val is_ECAdd : term -> bool
+  val ECMul_tm : term val is_ECMul : term -> bool
+  val PowMod256_tm : term val is_PowMod256 : term -> bool
+
+  val AbiDecode_tm : term
+  val mk_AbiDecode_tm : term -> term
+  val dest_AbiDecode_tm : term -> term
+  val is_AbiDecode : term -> bool
+  val AbiEncode_tm : term
+  val mk_AbiEncode_tm : term -> term
+  val dest_AbiEncode_tm : term -> term
+  val is_AbiEncode : term -> bool
+
+  val CreateMinimalProxy_tm : term val is_CreateMinimalProxy : term -> bool
+  val CreateCopyOf_tm : term val is_CreateCopyOf : term -> bool
+  val CreateFromBlueprint_tm : term
+  val mk_CreateFromBlueprint_tm : term * term -> term
+  val dest_CreateFromBlueprint_tm : term -> term * term
+  val is_CreateFromBlueprint : term -> bool
+  val RawCreate_tm : term val is_RawCreate : term -> bool
+
+  val External_tm : term val is_External : term -> bool
+  val Internal_tm : term val is_Internal : term -> bool
+  val Deploy_tm : term val is_Deploy : term -> bool
+  val Pure_tm : term val is_Pure : term -> bool
+  val View_tm : term val is_View : term -> bool
+  val Nonpayable_tm : term val is_Nonpayable : term -> bool
+  val Payable_tm : term val is_Payable : term -> bool
+  val Public_tm : term val is_Public : term -> bool
+  val Private_tm : term val is_Private : term -> bool
+  val Constant_tm : term
+  val mk_Constant_tm : term -> term
+  val dest_Constant_tm : term -> term
+  val is_Constant : term -> bool
+  val Immutable_tm : term val is_Immutable : term -> bool
+  val Transient_tm : term val is_Transient : term -> bool
+  val Storage_tm : term val is_Storage : term -> bool
+  val Type_tm : term
+  val mk_Type_tm : term -> term
+  val dest_Type_tm : term -> term
+  val is_Type : term -> bool
+  val HashMapT_tm : term
+  val mk_HashMapT_tm : term * term -> term
+  val dest_HashMapT_tm : term -> term * term
+  val is_HashMapT : term -> bool
+
   val FunctionDecl_tm : term
+  val mk_FunctionDecl_tm : term * term * term * term * term * term * term * term * term -> term
+  val dest_FunctionDecl_tm : term -> term * term * term * term * term * term * term * term * term
+  val is_FunctionDecl : term -> bool
   val VariableDecl_tm : term
-  val HashMapDecl_tm  : term
-  val StructDecl_tm   : term
-  val EventDecl_tm    : term
-  val FlagDecl_tm     : term
+  val mk_VariableDecl_tm : term * term * term * term * term -> term
+  val dest_VariableDecl_tm : term -> term * term * term * term * term
+  val is_VariableDecl : term -> bool
+  val HashMapDecl_tm : term
+  val mk_HashMapDecl_tm : term * term * term * term * term * term -> term
+  val dest_HashMapDecl_tm : term -> term * term * term * term * term * term
+  val is_HashMapDecl : term -> bool
+  val StructDecl_tm : term
+  val mk_StructDecl_tm : term * term -> term
+  val dest_StructDecl_tm : term -> term * term
+  val is_StructDecl : term -> bool
+  val EventDecl_tm : term
+  val mk_EventDecl_tm : term * term -> term
+  val dest_EventDecl_tm : term -> term * term
+  val is_EventDecl : term -> bool
+  val FlagDecl_tm : term
+  val mk_FlagDecl_tm : term * term -> term
+  val dest_FlagDecl_tm : term -> term * term
+  val is_FlagDecl : term -> bool
+  val InterfaceDecl_tm : term
+  val mk_InterfaceDecl_tm : term * term -> term
+  val dest_InterfaceDecl_tm : term -> term * term
+  val is_InterfaceDecl : term -> bool
 
-  val type_ty       : hol_type
-  val stmt_ty       : hol_type
-  val expr_ty       : hol_type
-  val toplevel_ty   : hol_type
+  datatype expr_view =
+      VName of term * string
+    | VTopLevelName of term * term
+    | VFlagMember of term * term * string
+    | VIfExp of term * term * term * term
+    | VLiteral of term * term
+    | VStructLit of term * term * (string * term) list
+    | VSubscript of term * term * term
+    | VAttribute of term * term * string
+    | VBuiltin of term * term * term list
+    | VTypeBuiltin of term * term * term * term list
+    | VPop of term * term
+    | VCall of term * term * term list * term option
+  val view_expr : term -> expr_view
 
-  val identifier_ty : hol_type
-  val argument_ty   : hol_type
+  datatype stmt_view =
+      VPass
+    | VContinue
+    | VBreak
+    | VExpr of term
+    | VFor of string * term * term * term * term list
+    | VIf of term * term list * term list
+    | VAssert of term * term
+    | VLog of term * term list
+    | VRaise of term
+    | VReturn of term option
+    | VAssign of term * term
+    | VAugAssign of term * term * term * term
+    | VAppend of term * term
+    | VAnnAssign of string * term * term
+  val view_stmt : term -> stmt_view
 
-  val bool_tm      : term
-  val address_tm   : term
-  val decimal_tm   : term
-  val mk_Fixed     : term -> term
-  val mk_Dynamic   : term -> term
-  val mk_Signed    : term -> term
-  val mk_Unsigned  : term -> term
-  val mk_uint      : term -> term
-  val mk_int       : term -> term
-  val mk_bytes     : term -> term
-  val mk_FunctionDecl : term -> term -> term -> term -> term -> term -> term -> term -> term -> term
-  val mk_VariableDecl : term * term * term * term * term -> term
-  val mk_HashMapDecl  : term * term * term * term * term * term -> term
-  val mk_String    : term -> term
-  val mk_Bytes     : term -> term
-  val mk_BytesM    : term -> term
-  val mk_Expr      : term -> term
-  val mk_For       : term -> term -> term -> term -> term -> term
-  val mk_Name      : string -> term
-  val mk_StructLit : term * term * term list -> term
-  val mk_IfExp     : term * term * term * term -> term
-  val mk_IntCall   : term -> term
-  val mk_Empty     : term * term -> term
-  val mk_MaxValue  : term * term -> term
-  val mk_MinValue  : term * term -> term
-  val mk_Convert   : term * term * term -> term
-  val mk_Extract32 : term * term * term * term -> term
-  val mk_AbiDecode : term * term * term -> term
-  val mk_AbiEncode : term * term * term -> term
-  val mk_MethodId  : term * term -> term
-  val mk_Call      : term -> term -> term list -> term -> term
-  val mk_Assert    : term * term -> term
-  val mk_Log       : term * term -> term
-  val mk_Subscript : term -> term -> term -> term
-  val mk_If        : term -> term -> term -> term
-  val mk_li        : term * term -> term
-  val mk_ld        : term * term -> term
-  val mk_lb        : term * term -> term
-  val mk_ls        : term * string -> term
-  val mk_empty_lstr : term -> term
-  val mk_Return    : term option -> term
-  val mk_AnnAssign : term * term * term -> term
-  val mk_AugAssign : term * term * term * term -> term
-  val mk_Hex_dyn   : term * string -> term
-  val mk_Hex       : term * string -> term
-  val mk_Builtin   : term -> term -> term -> term
-  val mk_Concat    : term -> term
-  val mk_Slice     : term -> term
-  val mk_Not       : term * term -> term
-  val mk_Neg       : term * term -> term
-  val mk_Keccak256 : term * term -> term
-  val mk_AsWeiValue : term * term * term -> term
-  val mk_Floor     : term * term -> term
-  val mk_ECRecover : term * term * term * term * term -> term
-  val mk_ECAdd     : term * term * term -> term
-  val mk_ECMul     : term * term * term -> term
-  val mk_Bop       : term -> term
-  val mk_Len       : term * term -> term
-  val mk_MakeArray : term * term * term * term list -> term
-  val mk_Tuple     : term * term list -> term
-  val mk_SArray    : term * term * term list -> term
-  val mk_msg_sender    : term -> term
-  val mk_self_addr     : term -> term
-  val mk_time_stamp    : term -> term
-  val mk_block_number  : term -> term
-  val mk_blob_base_fee : term -> term
-  val mk_gas_price     : term -> term
-  val mk_prev_hash     : term -> term
-  val mk_BlockHash : term * term -> term
-  val mk_BlobHash  : term * term -> term
+  datatype call_target_view =
+      VIntCall of term
+    | VExtCall of term * term
+    | VSend
+    | VRawCallTarget of term
+    | VRawLog
+    | VRawRevert
+    | VSelfDestructTarget
+    | VCreateTarget of term * term
+  val view_call_target : term -> call_target_view
 
+  datatype toplevel_view =
+      VFunctionDecl of term * term * term * term * term * term * term * term * term
+    | VVariableDecl of term * term * term * term * term
+    | VHashMapDecl of term * term * term * term * term * term
+    | VStructDecl of term * term
+    | VEventDecl of term * term
+    | VFlagDecl of term * term
+    | VInterfaceDecl of term * term
+  val view_toplevel : term -> toplevel_view
 end

--- a/syntax/vyperASTSyntax.sig
+++ b/syntax/vyperASTSyntax.sig
@@ -558,6 +558,35 @@ signature vyperASTSyntax = sig
   val dest_InterfaceDecl_tm : term -> term * term
   val is_InterfaceDecl : term -> bool
 
+  datatype base_assignment_target_view =
+      VBNameTarget of string
+    | VBTopLevelNameTarget of term
+    | VBSubscriptTarget of term * term
+    | VBAttributeTarget of term * string
+  val view_base_assignment_target : term -> base_assignment_target_view
+
+  datatype assignment_target_view =
+      VATBase of term
+    | VATTuple of term list
+  val view_assignment_target : term -> assignment_target_view
+
+  datatype iterator_view =
+      VIArray of term
+    | VIRange of term * term
+  val view_iterator : term -> iterator_view
+
+  datatype assert_reason_view =
+      VAssertBareReason
+    | VAssertUnreachableReason
+    | VAssertReasonExpr of term
+  val view_assert_reason : term -> assert_reason_view
+
+  datatype raise_reason_view =
+      VRaiseBareReason
+    | VRaiseUnreachableReason
+    | VRaiseReasonExpr of term
+  val view_raise_reason : term -> raise_reason_view
+
   datatype expr_view =
       VName of term * string
     | VTopLevelName of term * term

--- a/syntax/vyperASTSyntax.sml
+++ b/syntax/vyperASTSyntax.sml
@@ -1,280 +1,578 @@
 structure vyperASTSyntax :> vyperASTSyntax = struct
 
-  open HolKernel vyperASTTheory byteStringCacheLib
-  open boolSyntax stringSyntax pairSyntax optionSyntax listSyntax numSyntax
+open HolKernel vyperASTTheory boolSyntax stringSyntax pairSyntax optionSyntax listSyntax
 
-  fun astk s = prim_mk_const{Thy="vyperAST",Name=s}
-  fun asty s = mk_thy_type{Thy="vyperAST",Tyop=s,Args=[]}
+val ERR = Feedback.mk_HOL_ERR "vyperASTSyntax"
 
-  val Fixed_tm        = astk"Fixed"
-  val Dynamic_tm      = astk"Dynamic"
-  val UintT_tm        = astk"UintT"
-  val IntT_tm         = astk"IntT"
-  val BoolT_tm        = astk"BoolT"
-  val DecimalT_tm     = astk"DecimalT"
-  val StringT_tm      = astk"StringT"
-  val BytesT_tm       = astk"BytesT"
-  val AddressT_tm     = astk"AddressT"
-  val BaseT_tm        = astk"BaseT"
-  val TupleT_tm       = astk"TupleT"
-  val ArrayT_tm       = astk"ArrayT"
-  val StructT_tm      = astk"StructT"
-  val FlagT_tm        = astk"FlagT"
-  val NoneT_tm        = astk"NoneT"
-  val Signed_tm       = astk"Signed"
-  val Unsigned_tm     = astk"Unsigned"
-  val BoolL_tm        = astk"BoolL"
-  val StringL_tm      = astk"StringL"
-  val BytesL_tm       = astk"BytesL"
-  val IntL_tm         = astk"IntL"
-  val DecimalL_tm     = astk"DecimalL"
-  val Add_tm          = astk"Add"
-  val Sub_tm          = astk"Sub"
-  val Mul_tm          = astk"Mul"
-  val Div_tm          = astk"Div"
-  val UnsafeAdd_tm    = astk"UnsafeAdd"
-  val UnsafeSub_tm    = astk"UnsafeSub"
-  val UnsafeMul_tm    = astk"UnsafeMul"
-  val UnsafeDiv_tm    = astk"UnsafeDiv"
-  val ExpMod_tm       = astk"ExpMod"
-  val Mod_tm          = astk"Mod"
-  val Exp_tm          = astk"Exp"
-  val And_tm          = astk"And"
-  val Or_tm           = astk"Or"
-  val XOr_tm          = astk"XOr"
-  val ShL_tm          = astk"ShL"
-  val ShR_tm          = astk"ShR"
-  val In_tm           = astk"In"
-  val NotIn_tm        = astk"NotIn"
-  val Eq_tm           = astk"Eq"
-  val NotEq_tm        = astk"NotEq"
-  val Lt_tm           = astk"Lt"
-  val LtE_tm          = astk"LtE"
-  val Gt_tm           = astk"Gt"
-  val GtE_tm          = astk"GtE"
-  val Sender_tm       = astk"Sender"
-  val SelfAddr_tm     = astk"SelfAddr"
-  val TimeStamp_tm    = astk"TimeStamp"
-  val BlockNumber_tm  = astk"BlockNumber"
-  val BlobBaseFee_tm  = astk"BlobBaseFee"
-  val GasPrice_tm     = astk"GasPrice"
-  val PrevHash_tm     = astk"PrevHash"
-  val Address_tm      = astk"Address"
-  val Balance_tm      = astk"Balance"
-  val Wei_tm          = astk"Wei"
-  val Kwei_tm         = astk"Kwei"
-  val Mwei_tm         = astk"Mwei"
-  val Gwei_tm         = astk"Gwei"
-  val Szabo_tm        = astk"Szabo"
-  val Finney_tm       = astk"Finney"
-  val Ether_tm        = astk"Ether"
-  val KEther_tm       = astk"KEther"
-  val MEther_tm       = astk"MEther"
-  val GEther_tm       = astk"GEther"
-  val TEther_tm       = astk"TEther"
-  val Len_tm          = astk"Len"
-  val Not_tm          = astk"Not"
-  val Neg_tm          = astk"Neg"
-  val Keccak256_tm    = astk"Keccak256"
-  val AsWeiValue_tm   = astk"AsWeiValue"
-  val Concat_tm       = astk"Concat"
-  val Slice_tm        = astk"Slice"
-  val MakeArray_tm    = astk"MakeArray"
-  val Floor_tm        = astk"Floor"
-  val Bop_tm          = astk"Bop"
-  val AddMod_tm       = astk"AddMod"
-  val MulMod_tm       = astk"MulMod"
-  val Env_tm          = astk"Env"
-  val BlockHash_tm    = astk"BlockHash"
-  val BlobHash_tm     = astk"BlobHash"
-  val Acc_tm          = astk"Acc"
-  val ECRecover_tm    = astk"ECRecover"
-  val ECAdd_tm        = astk"ECAdd"
-  val ECMul_tm        = astk"ECMul"
-  val IntCall_tm      = astk"IntCall"
-  val Send_tm         = astk"Send"
-  val Empty_tm        = astk"Empty"
-  val MaxValue_tm     = astk"MaxValue"
-  val MinValue_tm     = astk"MinValue"
-  val Epsilon_tm      = astk"Epsilon"
-  val Convert_tm      = astk"Convert"
-  val Extract32_tm    = astk"Extract32"
-  val AbiDecode_tm    = astk"AbiDecode"
-  val AbiEncode_tm    = astk"AbiEncode"
-  fun mk_AbiDecode_flag b = mk_comb(AbiDecode_tm, mk_bool b)
-  fun mk_AbiEncode_flag b = mk_comb(AbiEncode_tm, mk_bool b)
-  val MethodId_tm     = astk"MethodId"
-  val Name_tm            = astk"Name"
-  val TopLevelName_tm    = astk"TopLevelName"
-  val IfExp_tm        = astk"IfExp"
-  val Literal_tm      = astk"Literal"
-  val StructLit_tm    = astk"StructLit"
-  val Subscript_tm    = astk"Subscript"
-  val Attribute_tm    = astk"Attribute"
-  val Builtin_tm      = astk"Builtin"
-  val TypeBuiltin_tm  = astk"TypeBuiltin"
-  val Pop_tm          = astk"Pop"
-  val AstCall_tm      = astk"Call"
-  val NameTarget_tm              = astk"NameTarget"
-  val TopLevelNameTarget_tm      = astk"TopLevelNameTarget"
-  val SubscriptTarget_tm    = astk"SubscriptTarget"
-  val AttributeTarget_tm    = astk"AttributeTarget"
-  val BaseTarget_tm   = astk"BaseTarget"
-  val TupleTarget_tm  = astk"TupleTarget"
-  val Array_tm        = astk"Array"
-  val Range_tm        = astk"Range"
-  val Pass_tm         = astk"Pass"
-  val Continue_tm     = astk"Continue"
-  val Break_tm        = astk"Break"
-  val Expr_tm         = astk"Expr"
-  val For_tm          = astk"For"
-  val If_tm           = astk"If"
-  val Assert_tm       = astk"Assert"
-  val Log_tm          = astk"Log"
-  val Raise_tm        = astk"Raise"
-  val Return_tm       = astk"Return"
-  val Assign_tm       = astk"Assign"
-  val AugAssign_tm    = astk"AugAssign"
-  val Append_tm       = astk"Append"
-  val AnnAssign_tm    = astk"AnnAssign"
-  val External_tm     = astk"External"
-  val Internal_tm     = astk"Internal"
-  val Deploy_tm       = astk"Deploy"
-  val Pure_tm         = astk"Pure"
-  val View_tm         = astk"View"
-  val Nonpayable_tm   = astk"Nonpayable"
-  val Payable_tm      = astk"Payable"
-  val Public_tm       = astk"Public"
-  val Private_tm      = astk"Private"
-  val Constant_tm     = astk"Constant"
-  val Immutable_tm    = astk"Immutable"
-  val Transient_tm    = astk"Transient"
-  val Storage_tm      = astk"Storage"
-  val Type_tm         = astk"Type"
-  val HashMapT_tm     = astk"HashMapT"
-  val FunctionDecl_tm = astk"FunctionDecl"
-  val VariableDecl_tm = astk"VariableDecl"
-  val HashMapDecl_tm  = astk"HashMapDecl"
-  val StructDecl_tm   = astk"StructDecl"
-  val EventDecl_tm    = astk"EventDecl"
-  val FlagDecl_tm     = astk"FlagDecl"
+fun astk s = prim_mk_const {Thy = "vyperAST", Name = s}
+fun asty s = mk_thy_type {Thy = "vyperAST", Tyop = s, Args = []}
 
-  val type_ty = asty"type"
-  val stmt_ty = asty"stmt"
-  val expr_ty = asty"expr"
-  val toplevel_ty = asty"toplevel"
+val bound_ty = asty "bound"
+val base_type_ty = asty "base_type"
+val type_ty = asty "type"
+val int_bound_ty = asty "int_bound"
+val literal_ty = asty "literal"
+val binop_ty = asty "binop"
+val env_item_ty = asty "env_item"
+val account_item_ty = asty "account_item"
+val denomination_ty = asty "denomination"
+val builtin_ty = asty "builtin"
+val ext_call_sig_ty = mk_prod (string_ty, mk_prod (mk_list_type type_ty, type_ty))
+val raw_call_flags_ty = asty "raw_call_flags"
+val create_kind_ty = asty "create_kind"
+val type_builtin_ty = asty "type_builtin"
+val expr_ty = asty "expr"
+val stmt_ty = asty "stmt"
+val assignment_target_ty = asty "assignment_target"
+val base_assignment_target_ty = asty "base_assignment_target"
+val iterator_ty = asty "iterator"
+val call_target_ty = asty "call_target"
+val assert_reason_ty = asty "assert_reason"
+val raise_reason_ty = asty "raise_reason"
+val function_visibility_ty = asty "function_visibility"
+val function_mutability_ty = asty "function_mutability"
+val variable_visibility_ty = asty "variable_visibility"
+val variable_mutability_ty = asty "variable_mutability"
+val argument_ty = mk_prod (string_ty, type_ty)
+val interface_func_ty = mk_prod (string_ty, mk_prod (mk_list_type argument_ty, mk_prod (type_ty, function_mutability_ty)))
+val value_type_ty = asty "value_type"
+val toplevel_ty = asty "toplevel"
 
-  val identifier_ty = string_ty
-  val argument_ty = mk_prod(identifier_ty, type_ty)
-  val bool_tm = mk_comb(BaseT_tm, BoolT_tm)
-  val address_tm = mk_comb(BaseT_tm, AddressT_tm)
-  val decimal_tm = mk_comb(BaseT_tm, DecimalT_tm)
-  fun mk_Fixed n = mk_comb(Fixed_tm, n)
-  fun mk_Dynamic n = mk_comb(Dynamic_tm, n)
-  fun mk_Signed n = mk_comb(Signed_tm, n)
-  fun mk_Unsigned n = mk_comb(Unsigned_tm, n)
-  fun mk_uint n = mk_comb(BaseT_tm, mk_comb(UintT_tm, n))
-  fun mk_int n = mk_comb(BaseT_tm, mk_comb(IntT_tm, n))
-  fun mk_bytes n = mk_comb(BaseT_tm, mk_comb(BytesT_tm, mk_Fixed n))
-  fun mk_FunctionDecl v m nr rr n a d t b = list_mk_comb(FunctionDecl_tm, [v,m,nr,rr,n,a,d,t,b])
-  fun mk_VariableDecl (v,m,n,t,s) = list_mk_comb(VariableDecl_tm, [v,m,n,t,s])
-  fun mk_HashMapDecl (v,bt,n,t,vt,s) = list_mk_comb(HashMapDecl_tm, [v,bt,n,t,vt,s])
-  fun mk_String n = mk_comb(BaseT_tm, mk_comb(StringT_tm, n))
-  fun mk_Bytes n = mk_comb(BaseT_tm, mk_comb(BytesT_tm, mk_Dynamic n))
-  fun mk_BytesM n = mk_comb(BaseT_tm, mk_comb(BytesT_tm, mk_Fixed n))
-  fun mk_Expr e = mk_comb(Expr_tm, e)
-  fun mk_For s t i n b = list_mk_comb(For_tm, [s,t,i,n,b])
-  fun mk_Name s = mk_comb(Name_tm, fromMLstring s)
-  fun mk_StructLit (ty,s,ls) = list_mk_comb(StructLit_tm, [
-    ty, s, mk_list(ls, mk_prod(string_ty, expr_ty))])
-  fun mk_IfExp (ty,e1,e2,e3) = list_mk_comb(IfExp_tm, [ty,e1,e2,e3])
-  fun mk_IntCall nsid = mk_comb(IntCall_tm, nsid)
-  fun mk_Empty (ty,t) = list_mk_comb(TypeBuiltin_tm, [
-    ty, Empty_tm, t, mk_list([], expr_ty)])
-  fun mk_MaxValue (ty,t) = list_mk_comb(TypeBuiltin_tm, [
-    ty, MaxValue_tm, t, mk_list([], expr_ty)])
-  fun mk_MinValue (ty,t) = list_mk_comb(TypeBuiltin_tm, [
-    ty, MinValue_tm, t, mk_list([], expr_ty)])
-  fun mk_Convert (ty,t,v) = list_mk_comb(TypeBuiltin_tm, [
-    ty, Convert_tm, t, mk_list([v], expr_ty)])
-  fun mk_Extract32 (ty,t,bytes,idx) = list_mk_comb(TypeBuiltin_tm, [
-    ty, Extract32_tm, t, mk_list([bytes,idx], expr_ty)])
-  fun mk_AbiDecode (ty,t,bytes) = list_mk_comb(TypeBuiltin_tm, [
-    ty, mk_AbiDecode_flag true, t, mk_list([bytes], expr_ty)])
-  fun mk_AbiEncode (ty,t,v) = list_mk_comb(TypeBuiltin_tm, [
-    ty, mk_AbiEncode_flag true, t, mk_list([v], expr_ty)])
-  fun mk_Call ty ct args drv = list_mk_comb(AstCall_tm, [ty, ct, mk_list (args, expr_ty), drv])
-  fun mk_Assert (e,s) = list_mk_comb(Assert_tm, [e, s])
-  fun mk_Log (id,es) = list_mk_comb(Log_tm, [id, es])
-  fun mk_Subscript ty e1 e2 = list_mk_comb(Subscript_tm, [ty, e1, e2])
-  fun mk_If e s1 s2 = list_mk_comb(If_tm, [e,s1,s2])
-  fun mk_li (ty,i) = list_mk_comb(Literal_tm, [ty, mk_comb(IntL_tm, i)])
-  fun mk_ld (ty,i) = list_mk_comb(Literal_tm, [ty, mk_comb(DecimalL_tm, i)])
-  fun mk_lb (ty,b) = list_mk_comb(Literal_tm, [ty, mk_comb(BoolL_tm, b)])
-  fun mk_ls (ty,s) = list_mk_comb(Literal_tm,
-    [ty, mk_comb(StringL_tm, fromMLstring s)])
-  fun mk_empty_lstr ty = mk_ls(ty, "")
-  fun mk_Return tmo = mk_comb(Return_tm, lift_option (mk_option expr_ty) I tmo)
-  fun mk_AnnAssign (s,t,e) = list_mk_comb(AnnAssign_tm, [s, t, e])
-  fun mk_AugAssign (ty, t, b, e) = list_mk_comb(AugAssign_tm, [ty, t, b, e])
-  fun mk_Hex_dyn (ty, s) = let
-    val s = if String.isPrefix "0x" s then String.extract(s,2,NONE) else s
-  in
-    list_mk_comb(Literal_tm,
-      [ty, mk_comb(BytesL_tm, cached_bytes_from_hex s)])
+fun syntax0 name =
+  let val tm = astk name in
+    (tm, fn x => aconv x tm)
   end
-  fun mk_Hex (ty, s) = let
-    val s = if String.isPrefix "0x" s then String.extract(s,2,NONE) else s
+
+fun dest_n name c n tm =
+  let
+    val (h, args) = strip_comb tm
   in
-    list_mk_comb(Literal_tm,
-      [ty, mk_comb(BytesL_tm, cached_bytes_from_hex s)])
+    if aconv h c andalso length args = n then args
+    else raise ERR ("dest_" ^ name) "unexpected term shape"
   end
-  fun mk_Builtin ty b es = list_mk_comb(Builtin_tm, [ty, b, es])
-  fun mk_Concat n = mk_comb(Concat_tm, n)
-  fun mk_Slice n = mk_comb(Slice_tm, n)
-  fun mk_Not (ty,t) = mk_Builtin ty Not_tm (mk_list([t], expr_ty))
-  fun mk_Neg (ty,t) = mk_Builtin ty Neg_tm (mk_list([t], expr_ty))
-  fun mk_Keccak256 (ty,t) = mk_Builtin ty Keccak256_tm (mk_list([t], expr_ty))
-  fun mk_AsWeiValue (ty,d,t) = mk_Builtin ty (mk_comb(AsWeiValue_tm, d)) (mk_list([t], expr_ty))
-  fun mk_Floor (ty,e) = mk_Builtin ty Floor_tm (mk_list([e], expr_ty))
-  fun mk_ECRecover (ty,h,v,r,s) = mk_Builtin ty ECRecover_tm (mk_list([h,v,r,s], expr_ty))
-  fun mk_ECAdd (ty,p1,p2) = mk_Builtin ty ECAdd_tm (mk_list([p1,p2], expr_ty))
-  fun mk_ECMul (ty,p,n) = mk_Builtin ty ECMul_tm (mk_list([p,n], expr_ty))
-  fun mk_MethodId (ty,e) = mk_Builtin ty MethodId_tm (mk_list([e], expr_ty))
-  fun mk_Bop b = mk_comb(Bop_tm, b)
-  fun mk_Len (ty,e) = mk_Builtin ty Len_tm (mk_list([e], expr_ty))
-  fun mk_MakeArray (ty,to,b,ls) =
-    mk_Builtin ty (list_mk_comb(MakeArray_tm, [to,b]))
-      (mk_list (ls, expr_ty))
-  fun mk_Tuple (ty,ls) = let
-    val n = numSyntax.term_of_int $ List.length ls
-    val b = mk_comb(Fixed_tm, n)
+
+fun mk_n c args = list_mk_comb (c, args)
+
+fun syntax5 name =
+  let val c = astk name in
+    ( c
+    , fn (a,b,c1,d,e) => mk_n c [a,b,c1,d,e]
+    , fn tm =>
+        (case dest_n name c 5 tm of
+           [a,b,c1,d,e] => (a,b,c1,d,e)
+         | _ => raise ERR ("dest_" ^ name) "internal arity error")
+    , can (dest_n name c 5)
+    )
+  end
+
+fun syntax6 name =
+  let val c = astk name in
+    ( c
+    , fn (a,b,c1,d,e,f) => mk_n c [a,b,c1,d,e,f]
+    , fn tm =>
+        (case dest_n name c 6 tm of
+           [a,b,c1,d,e,f] => (a,b,c1,d,e,f)
+         | _ => raise ERR ("dest_" ^ name) "internal arity error")
+    , can (dest_n name c 6)
+    )
+  end
+
+fun syntax7 name =
+  let val c = astk name in
+    ( c
+    , fn (a,b,c1,d,e,f,g) => mk_n c [a,b,c1,d,e,f,g]
+    , fn tm =>
+        (case dest_n name c 7 tm of
+           [a,b,c1,d,e,f,g] => (a,b,c1,d,e,f,g)
+         | _ => raise ERR ("dest_" ^ name) "internal arity error")
+    , can (dest_n name c 7)
+    )
+  end
+
+fun syntax9 name =
+  let val c = astk name in
+    ( c
+    , fn (a,b,c1,d,e,f,g,h,i) => mk_n c [a,b,c1,d,e,f,g,h,i]
+    , fn tm =>
+        (case dest_n name c 9 tm of
+           [a,b,c1,d,e,f,g,h,i] => (a,b,c1,d,e,f,g,h,i)
+         | _ => raise ERR ("dest_" ^ name) "internal arity error")
+    , can (dest_n name c 9)
+    )
+  end
+
+fun dest_string tm = fromHOLstring tm
+fun mk_string s = fromMLstring s
+
+fun dest_term_list ty tm =
+  let val (xs, elem_ty) = dest_list tm in
+    if elem_ty = ty then xs else raise ERR "dest_term_list" "wrong element type"
+  end
+
+fun mk_term_list ty xs = mk_list (xs, ty)
+
+fun dest_term_option ty tm =
+  if is_none tm then (ignore (dest_none tm); NONE)
+  else if is_some tm then SOME (dest_some tm)
+  else raise ERR "dest_term_option" "not an option term"
+
+fun mk_term_option ty NONE = mk_none ty
+  | mk_term_option _ (SOME tm) = mk_some tm
+
+val (Fixed_tm, mk_Fixed_tm, dest_Fixed_tm, is_Fixed) = syntax_fns1 "vyperAST" "Fixed"
+val (Dynamic_tm, mk_Dynamic_tm, dest_Dynamic_tm, is_Dynamic) = syntax_fns1 "vyperAST" "Dynamic"
+
+val (UintT_tm, mk_UintT_tm, dest_UintT_tm, is_UintT) = syntax_fns1 "vyperAST" "UintT"
+val (IntT_tm, mk_IntT_tm, dest_IntT_tm, is_IntT) = syntax_fns1 "vyperAST" "IntT"
+val (BoolT_tm, is_BoolT) = syntax0 "BoolT"
+val (DecimalT_tm, is_DecimalT) = syntax0 "DecimalT"
+val (StringT_tm, mk_StringT_tm, dest_StringT_tm, is_StringT) = syntax_fns1 "vyperAST" "StringT"
+val (BytesT_tm, mk_BytesT_tm, dest_BytesT_tm, is_BytesT) = syntax_fns1 "vyperAST" "BytesT"
+val (AddressT_tm, is_AddressT) = syntax0 "AddressT"
+
+val (BaseT_tm, mk_BaseT_tm, dest_BaseT_tm, is_BaseT) = syntax_fns1 "vyperAST" "BaseT"
+val (TupleT_tm, mk_TupleT_tm, dest_TupleT_tm, is_TupleT) = syntax_fns1 "vyperAST" "TupleT"
+fun mk_TupleT tys = mk_TupleT_tm (mk_term_list type_ty tys)
+fun dest_TupleT tm = dest_term_list type_ty (dest_TupleT_tm tm)
+val (ArrayT_tm, mk_ArrayT_tm, dest_ArrayT_tm, is_ArrayT) = syntax_fns2 "vyperAST" "ArrayT"
+val (StructT_tm, mk_StructT_tm, dest_StructT_tm, is_StructT) = syntax_fns1 "vyperAST" "StructT"
+val (FlagT_tm, mk_FlagT_tm, dest_FlagT_tm, is_FlagT) = syntax_fns1 "vyperAST" "FlagT"
+val (NoneT_tm, is_NoneT) = syntax0 "NoneT"
+
+val (BoolL_tm, mk_BoolL_tm, dest_BoolL_tm, is_BoolL) = syntax_fns1 "vyperAST" "BoolL"
+val (StringL_tm, mk_StringL_tm, dest_StringL_tm, is_StringL) = syntax_fns1 "vyperAST" "StringL"
+fun mk_StringL s = mk_StringL_tm (mk_string s)
+fun dest_StringL tm = dest_string (dest_StringL_tm tm)
+val (BytesL_tm, mk_BytesL_tm, dest_BytesL_tm, is_BytesL) = syntax_fns1 "vyperAST" "BytesL"
+val (IntL_tm, mk_IntL_tm, dest_IntL_tm, is_IntL) = syntax_fns1 "vyperAST" "IntL"
+val (DecimalL_tm, mk_DecimalL_tm, dest_DecimalL_tm, is_DecimalL) = syntax_fns1 "vyperAST" "DecimalL"
+
+val (Signed_tm, mk_Signed_tm, dest_Signed_tm, is_Signed) = syntax_fns1 "vyperAST" "Signed"
+val (Unsigned_tm, mk_Unsigned_tm, dest_Unsigned_tm, is_Unsigned) = syntax_fns1 "vyperAST" "Unsigned"
+
+val (Add_tm, is_Add) = syntax0 "Add"
+val (Sub_tm, is_Sub) = syntax0 "Sub"
+val (Mul_tm, is_Mul) = syntax0 "Mul"
+val (Div_tm, is_Div) = syntax0 "Div"
+val (UnsafeAdd_tm, is_UnsafeAdd) = syntax0 "UnsafeAdd"
+val (UnsafeSub_tm, is_UnsafeSub) = syntax0 "UnsafeSub"
+val (UnsafeMul_tm, is_UnsafeMul) = syntax0 "UnsafeMul"
+val (UnsafeDiv_tm, is_UnsafeDiv) = syntax0 "UnsafeDiv"
+val (ExpMod_tm, is_ExpMod) = syntax0 "ExpMod"
+val (Mod_tm, is_Mod) = syntax0 "Mod"
+val (Exp_tm, is_Exp) = syntax0 "Exp"
+val (And_tm, is_And) = syntax0 "And"
+val (Or_tm, is_Or) = syntax0 "Or"
+val (XOr_tm, is_XOr) = syntax0 "XOr"
+val (ShL_tm, is_ShL) = syntax0 "ShL"
+val (ShR_tm, is_ShR) = syntax0 "ShR"
+val (In_tm, is_In) = syntax0 "In"
+val (NotIn_tm, is_NotIn) = syntax0 "NotIn"
+val (Eq_tm, is_Eq) = syntax0 "Eq"
+val (NotEq_tm, is_NotEq) = syntax0 "NotEq"
+val (Lt_tm, is_Lt) = syntax0 "Lt"
+val (LtE_tm, is_LtE) = syntax0 "LtE"
+val (Gt_tm, is_Gt) = syntax0 "Gt"
+val (GtE_tm, is_GtE) = syntax0 "GtE"
+val (Min_tm, is_Min) = syntax0 "Min"
+val (Max_tm, is_Max) = syntax0 "Max"
+
+val (Sender_tm, is_Sender) = syntax0 "Sender"
+val (SelfAddr_tm, is_SelfAddr) = syntax0 "SelfAddr"
+val (ValueSent_tm, is_ValueSent) = syntax0 "ValueSent"
+val (TimeStamp_tm, is_TimeStamp) = syntax0 "TimeStamp"
+val (BlockNumber_tm, is_BlockNumber) = syntax0 "BlockNumber"
+val (BlobBaseFee_tm, is_BlobBaseFee) = syntax0 "BlobBaseFee"
+val (GasPrice_tm, is_GasPrice) = syntax0 "GasPrice"
+val (PrevHash_tm, is_PrevHash) = syntax0 "PrevHash"
+val (ChainId_tm, is_ChainId) = syntax0 "ChainId"
+val (Coinbase_tm, is_Coinbase) = syntax0 "Coinbase"
+val (GasLimit_tm, is_GasLimit) = syntax0 "GasLimit"
+val (BaseFee_tm, is_BaseFee) = syntax0 "BaseFee"
+val (PrevRandao_tm, is_PrevRandao) = syntax0 "PrevRandao"
+val (TxOrigin_tm, is_TxOrigin) = syntax0 "TxOrigin"
+val (MsgGas_tm, is_MsgGas) = syntax0 "MsgGas"
+
+val (Address_tm, is_Address) = syntax0 "Address"
+val (Balance_tm, is_Balance) = syntax0 "Balance"
+val (Codehash_tm, is_Codehash) = syntax0 "Codehash"
+val (Codesize_tm, is_Codesize) = syntax0 "Codesize"
+val (IsContract_tm, is_IsContract) = syntax0 "IsContract"
+val (Code_tm, is_Code) = syntax0 "Code"
+
+val (Wei_tm, is_Wei) = syntax0 "Wei"
+val (Kwei_tm, is_Kwei) = syntax0 "Kwei"
+val (Mwei_tm, is_Mwei) = syntax0 "Mwei"
+val (Gwei_tm, is_Gwei) = syntax0 "Gwei"
+val (Szabo_tm, is_Szabo) = syntax0 "Szabo"
+val (Finney_tm, is_Finney) = syntax0 "Finney"
+val (Ether_tm, is_Ether) = syntax0 "Ether"
+val (KEther_tm, is_KEther) = syntax0 "KEther"
+val (MEther_tm, is_MEther) = syntax0 "MEther"
+val (GEther_tm, is_GEther) = syntax0 "GEther"
+val (TEther_tm, is_TEther) = syntax0 "TEther"
+
+val (Len_tm, is_Len) = syntax0 "Len"
+val (Not_tm, is_Not) = syntax0 "Not"
+val (Neg_tm, is_Neg) = syntax0 "Neg"
+val (Abs_tm, is_Abs) = syntax0 "Abs"
+val (Keccak256_tm, is_Keccak256) = syntax0 "Keccak256"
+val (Sha256_tm, is_Sha256) = syntax0 "Sha256"
+val (AsWeiValue_tm, mk_AsWeiValue_tm, dest_AsWeiValue_tm, is_AsWeiValue) = syntax_fns1 "vyperAST" "AsWeiValue"
+val (Concat_tm, mk_Concat_tm, dest_Concat_tm, is_Concat) = syntax_fns1 "vyperAST" "Concat"
+val (Slice_tm, mk_Slice_tm, dest_Slice_tm, is_Slice) = syntax_fns1 "vyperAST" "Slice"
+val (Uint2Str_tm, mk_Uint2Str_tm, dest_Uint2Str_tm, is_Uint2Str) = syntax_fns1 "vyperAST" "Uint2Str"
+val (MakeArray_tm, mk_MakeArray_tm, dest_MakeArray_tm, is_MakeArray) = syntax_fns2 "vyperAST" "MakeArray"
+val (Ceil_tm, is_Ceil) = syntax0 "Ceil"
+val (Floor_tm, is_Floor) = syntax0 "Floor"
+val (AddMod_tm, is_AddMod) = syntax0 "AddMod"
+val (MulMod_tm, is_MulMod) = syntax0 "MulMod"
+val (Bop_tm, mk_Bop_tm, dest_Bop_tm, is_Bop) = syntax_fns1 "vyperAST" "Bop"
+val (BlockHash_tm, is_BlockHash) = syntax0 "BlockHash"
+val (BlobHash_tm, is_BlobHash) = syntax0 "BlobHash"
+val (Env_tm, mk_Env_tm, dest_Env_tm, is_Env) = syntax_fns1 "vyperAST" "Env"
+val (Acc_tm, mk_Acc_tm, dest_Acc_tm, is_Acc) = syntax_fns1 "vyperAST" "Acc"
+val (MethodId_tm, is_MethodId) = syntax0 "MethodId"
+val (ECRecover_tm, is_ECRecover) = syntax0 "ECRecover"
+val (ECAdd_tm, is_ECAdd) = syntax0 "ECAdd"
+val (ECMul_tm, is_ECMul) = syntax0 "ECMul"
+val (PowMod256_tm, is_PowMod256) = syntax0 "PowMod256"
+
+val (CreateMinimalProxy_tm, is_CreateMinimalProxy) = syntax0 "CreateMinimalProxy"
+val (CreateCopyOf_tm, is_CreateCopyOf) = syntax0 "CreateCopyOf"
+val (CreateFromBlueprint_tm, mk_CreateFromBlueprint_tm, dest_CreateFromBlueprint_tm, is_CreateFromBlueprint) = syntax_fns2 "vyperAST" "CreateFromBlueprint"
+val (RawCreate_tm, is_RawCreate) = syntax0 "RawCreate"
+
+val (Empty_tm, is_Empty) = syntax0 "Empty"
+val (MaxValue_tm, is_MaxValue) = syntax0 "MaxValue"
+val (MinValue_tm, is_MinValue) = syntax0 "MinValue"
+val (Epsilon_tm, is_Epsilon) = syntax0 "Epsilon"
+val (Convert_tm, is_Convert) = syntax0 "Convert"
+val (Extract32_tm, is_Extract32) = syntax0 "Extract32"
+val (AbiDecode_tm, mk_AbiDecode_tm, dest_AbiDecode_tm, is_AbiDecode) = syntax_fns1 "vyperAST" "AbiDecode"
+val (AbiEncode_tm, mk_AbiEncode_tm, dest_AbiEncode_tm, is_AbiEncode) = syntax_fns1 "vyperAST" "AbiEncode"
+
+fun dest_string_pair_expr tm =
+  let val (s, e) = dest_pair tm in (dest_string s, e) end
+
+fun mk_string_pair_expr (s, e) = mk_pair (mk_string s, e)
+
+val (Name_tm, mk_Name_tm, dest_Name_tm, is_Name) =
+  syntax_fns2 "vyperAST" "Name"
+fun mk_Name (ty, id) = mk_Name_tm (ty, mk_string id)
+fun dest_Name tm = let val (ty, id) = dest_Name_tm tm in (ty, dest_string id) end
+
+val (TopLevelName_tm, mk_TopLevelName_tm, dest_TopLevelName_tm,
+     is_TopLevelName) = syntax_fns2 "vyperAST" "TopLevelName"
+
+val (FlagMember_tm, mk_FlagMember_tm, dest_FlagMember_tm, is_FlagMember) =
+  syntax_fns3 "vyperAST" "FlagMember"
+fun mk_FlagMember (ty, nsid, id) = mk_FlagMember_tm (ty, nsid, mk_string id)
+fun dest_FlagMember tm =
+  let val (ty, nsid, id) = dest_FlagMember_tm tm in (ty, nsid, dest_string id) end
+
+val (IfExp_tm, mk_IfExp_tm, dest_IfExp_tm, is_IfExp) =
+  syntax_fns4 "vyperAST" "IfExp"
+
+val (Literal_tm, mk_Literal_tm, dest_Literal_tm, is_Literal) =
+  syntax_fns2 "vyperAST" "Literal"
+
+val (StructLit_tm, mk_StructLit_tm, dest_StructLit_tm, is_StructLit) =
+  syntax_fns3 "vyperAST" "StructLit"
+fun mk_StructLit (ty, nsid, fields) =
+  mk_StructLit_tm (ty, nsid, mk_term_list (mk_prod (string_ty, expr_ty))
+    (map mk_string_pair_expr fields))
+fun dest_StructLit tm =
+  let
+    val (ty, nsid, fields_tm) = dest_StructLit_tm tm
   in
-    mk_MakeArray (ty, mk_none type_ty, b, ls)
+    (ty, nsid, map dest_string_pair_expr
+      (dest_term_list (mk_prod (string_ty, expr_ty)) fields_tm))
   end
-  fun mk_SArray (ty,t,ls) = let
-    val n = numSyntax.term_of_int $ List.length ls
-    val b = mk_comb(Fixed_tm, n)
+
+val (Subscript_tm, mk_Subscript_tm, dest_Subscript_tm, is_Subscript) =
+  syntax_fns3 "vyperAST" "Subscript"
+
+val (Attribute_tm, mk_Attribute_tm, dest_Attribute_tm, is_Attribute) =
+  syntax_fns3 "vyperAST" "Attribute"
+fun mk_Attribute (ty, e, id) = mk_Attribute_tm (ty, e, mk_string id)
+fun dest_Attribute tm =
+  let val (ty, e, id) = dest_Attribute_tm tm in (ty, e, dest_string id) end
+
+val (Builtin_tm, mk_Builtin_tm, dest_Builtin_tm, is_Builtin) =
+  syntax_fns3 "vyperAST" "Builtin"
+fun mk_Builtin (ty, b, es) = mk_Builtin_tm (ty, b, mk_term_list expr_ty es)
+fun dest_Builtin tm =
+  let val (ty, b, es) = dest_Builtin_tm tm in (ty, b, dest_term_list expr_ty es) end
+
+val (TypeBuiltin_tm, mk_TypeBuiltin_tm, dest_TypeBuiltin_tm, is_TypeBuiltin) =
+  syntax_fns4 "vyperAST" "TypeBuiltin"
+fun mk_TypeBuiltin (ty, tb, target_ty, es) =
+  mk_TypeBuiltin_tm (ty, tb, target_ty, mk_term_list expr_ty es)
+fun dest_TypeBuiltin tm =
+  let val (ty, tb, target_ty, es) = dest_TypeBuiltin_tm tm in
+    (ty, tb, target_ty, dest_term_list expr_ty es)
+  end
+
+val (Pop_tm, mk_Pop_tm, dest_Pop_tm, is_Pop) = syntax_fns2 "vyperAST" "Pop"
+
+val (Call_tm, mk_Call_tm, dest_Call_tm, is_Call) = syntax_fns4 "vyperAST" "Call"
+fun mk_Call (ty, ct, es, drv) =
+  mk_Call_tm (ty, ct, mk_term_list expr_ty es, mk_term_option expr_ty drv)
+fun dest_Call tm =
+  let val (ty, ct, es, drv) = dest_Call_tm tm in
+    (ty, ct, dest_term_list expr_ty es, dest_term_option expr_ty drv)
+  end
+
+val (NameTarget_tm, mk_NameTarget_tm, dest_NameTarget_tm, is_NameTarget) =
+  syntax_fns1 "vyperAST" "NameTarget"
+fun mk_NameTarget id = mk_NameTarget_tm (mk_string id)
+fun dest_NameTarget tm = dest_string (dest_NameTarget_tm tm)
+
+val (TopLevelNameTarget_tm, mk_TopLevelNameTarget_tm,
+     dest_TopLevelNameTarget_tm, is_TopLevelNameTarget) =
+  syntax_fns1 "vyperAST" "TopLevelNameTarget"
+
+val (SubscriptTarget_tm, mk_SubscriptTarget_tm, dest_SubscriptTarget_tm,
+     is_SubscriptTarget) = syntax_fns2 "vyperAST" "SubscriptTarget"
+
+val (AttributeTarget_tm, mk_AttributeTarget_tm, dest_AttributeTarget_tm,
+     is_AttributeTarget) = syntax_fns2 "vyperAST" "AttributeTarget"
+fun mk_AttributeTarget (bt, id) = mk_AttributeTarget_tm (bt, mk_string id)
+fun dest_AttributeTarget tm =
+  let val (bt, id) = dest_AttributeTarget_tm tm in (bt, dest_string id) end
+
+val (BaseTarget_tm, mk_BaseTarget_tm, dest_BaseTarget_tm, is_BaseTarget) =
+  syntax_fns1 "vyperAST" "BaseTarget"
+
+val (TupleTarget_tm, mk_TupleTarget_tm, dest_TupleTarget_tm, is_TupleTarget) =
+  syntax_fns1 "vyperAST" "TupleTarget"
+fun mk_TupleTarget targets = mk_TupleTarget_tm (mk_term_list assignment_target_ty targets)
+fun dest_TupleTarget tm = dest_term_list assignment_target_ty (dest_TupleTarget_tm tm)
+
+val (Array_tm, mk_Array_tm, dest_Array_tm, is_Array) = syntax_fns1 "vyperAST" "Array"
+val (Range_tm, mk_Range_tm, dest_Range_tm, is_Range) = syntax_fns2 "vyperAST" "Range"
+
+val (Pass_tm, is_Pass) = syntax0 "Pass"
+val (Continue_tm, is_Continue) = syntax0 "Continue"
+val (Break_tm, is_Break) = syntax0 "Break"
+
+val (Expr_tm, mk_Expr_tm, dest_Expr_tm, is_Expr) = syntax_fns1 "vyperAST" "Expr"
+val (For_tm, mk_For_tm, dest_For_tm, is_For) = syntax5 "For"
+fun mk_For (id, ty, it, bound, body) =
+  mk_For_tm (mk_string id, ty, it, bound, mk_term_list stmt_ty body)
+fun dest_For tm =
+  let val (id, ty, it, bound, body) = dest_For_tm tm in
+    (dest_string id, ty, it, bound, dest_term_list stmt_ty body)
+  end
+
+val (If_tm, mk_If_tm, dest_If_tm, is_If) = syntax_fns3 "vyperAST" "If"
+fun mk_If (cond, th, el) = mk_If_tm (cond, mk_term_list stmt_ty th, mk_term_list stmt_ty el)
+fun dest_If tm =
+  let val (cond, th, el) = dest_If_tm tm in
+    (cond, dest_term_list stmt_ty th, dest_term_list stmt_ty el)
+  end
+
+val (Assert_tm, mk_Assert_tm, dest_Assert_tm, is_Assert) =
+  syntax_fns2 "vyperAST" "Assert"
+
+val (Log_tm, mk_Log_tm, dest_Log_tm, is_Log) = syntax_fns2 "vyperAST" "Log"
+fun mk_Log (id, es) = mk_Log_tm (id, mk_term_list expr_ty es)
+fun dest_Log tm =
+  let val (id, es) = dest_Log_tm tm in (id, dest_term_list expr_ty es) end
+
+val (Raise_tm, mk_Raise_tm, dest_Raise_tm, is_Raise) =
+  syntax_fns1 "vyperAST" "Raise"
+
+val (Return_tm, mk_Return_tm, dest_Return_tm, is_Return) =
+  syntax_fns1 "vyperAST" "Return"
+fun mk_Return opt = mk_Return_tm (mk_term_option expr_ty opt)
+fun dest_Return tm = dest_term_option expr_ty (dest_Return_tm tm)
+
+val (Assign_tm, mk_Assign_tm, dest_Assign_tm, is_Assign) =
+  syntax_fns2 "vyperAST" "Assign"
+val (AugAssign_tm, mk_AugAssign_tm, dest_AugAssign_tm, is_AugAssign) =
+  syntax_fns4 "vyperAST" "AugAssign"
+val (Append_tm, mk_Append_tm, dest_Append_tm, is_Append) =
+  syntax_fns2 "vyperAST" "Append"
+val (AnnAssign_tm, mk_AnnAssign_tm, dest_AnnAssign_tm, is_AnnAssign) =
+  syntax_fns3 "vyperAST" "AnnAssign"
+fun mk_AnnAssign (id, ty, e) = mk_AnnAssign_tm (mk_string id, ty, e)
+fun dest_AnnAssign tm =
+  let val (id, ty, e) = dest_AnnAssign_tm tm in (dest_string id, ty, e) end
+
+val (IntCall_tm, mk_IntCall_tm, dest_IntCall_tm, is_IntCall) =
+  syntax_fns1 "vyperAST" "IntCall"
+val (ExtCall_tm, mk_ExtCall_tm, dest_ExtCall_tm, is_ExtCall) =
+  syntax_fns2 "vyperAST" "ExtCall"
+val (Send_tm, is_Send) = syntax0 "Send"
+val (RawCallTarget_tm, mk_RawCallTarget_tm, dest_RawCallTarget_tm,
+     is_RawCallTarget) = syntax_fns1 "vyperAST" "RawCallTarget"
+val (RawLog_tm, is_RawLog) = syntax0 "RawLog"
+val (RawRevert_tm, is_RawRevert) = syntax0 "RawRevert"
+val (SelfDestructTarget_tm, is_SelfDestructTarget) = syntax0 "SelfDestructTarget"
+val (CreateTarget_tm, mk_CreateTarget_tm, dest_CreateTarget_tm, is_CreateTarget) =
+  syntax_fns2 "vyperAST" "CreateTarget"
+
+val (AssertBare_tm, is_AssertBare) = syntax0 "AssertBare"
+val (AssertUnreachable_tm, is_AssertUnreachable) = syntax0 "AssertUnreachable"
+val (AssertReason_tm, mk_AssertReason_tm, dest_AssertReason_tm, is_AssertReason) =
+  syntax_fns1 "vyperAST" "AssertReason"
+val (RaiseBare_tm, is_RaiseBare) = syntax0 "RaiseBare"
+val (RaiseUnreachable_tm, is_RaiseUnreachable) = syntax0 "RaiseUnreachable"
+val (RaiseReason_tm, mk_RaiseReason_tm, dest_RaiseReason_tm, is_RaiseReason) =
+  syntax_fns1 "vyperAST" "RaiseReason"
+
+fun mk_raw_call_flags {max_outsize, is_delegate, is_static, revert_on_failure} =
+  TypeBase.mk_record
+    (raw_call_flags_ty,
+     [("rcf_max_outsize", max_outsize),
+      ("rcf_is_delegate", is_delegate),
+      ("rcf_is_static", is_static),
+      ("rcf_revert_on_failure", revert_on_failure)])
+
+fun dest_raw_call_flags tm =
+  let
+    val (ty, fields) = TypeBase.dest_record tm
+    fun field name =
+      case List.find (fn (n, _) => n = name) fields of
+        SOME (_, v) => v
+      | NONE => raise ERR "dest_raw_call_flags" ("missing field " ^ name)
   in
-    mk_MakeArray (ty, mk_some t, b, ls)
+    if ty = raw_call_flags_ty then
+      {max_outsize = field "rcf_max_outsize",
+       is_delegate = field "rcf_is_delegate",
+       is_static = field "rcf_is_static",
+       revert_on_failure = field "rcf_revert_on_failure"}
+    else raise ERR "dest_raw_call_flags" "wrong record type"
   end
-  fun mk_msg_sender ty = mk_Builtin ty
-    (mk_comb(Env_tm, Sender_tm)) (mk_list([], expr_ty))
-  fun mk_self_addr ty = mk_Builtin ty
-    (mk_comb(Env_tm, SelfAddr_tm)) (mk_list([], expr_ty))
-  fun mk_time_stamp ty = mk_Builtin ty
-    (mk_comb(Env_tm, TimeStamp_tm)) (mk_list([], expr_ty))
-  fun mk_block_number ty = mk_Builtin ty
-    (mk_comb(Env_tm, BlockNumber_tm)) (mk_list([], expr_ty))
-  fun mk_blob_base_fee ty = mk_Builtin ty
-    (mk_comb(Env_tm, BlobBaseFee_tm)) (mk_list([], expr_ty))
-  fun mk_gas_price ty = mk_Builtin ty
-    (mk_comb(Env_tm, GasPrice_tm)) (mk_list([], expr_ty))
-  fun mk_prev_hash ty = mk_Builtin ty
-    (mk_comb(Env_tm, PrevHash_tm)) (mk_list([], expr_ty))
-  fun mk_BlockHash (ty,e) = mk_Builtin ty
-    BlockHash_tm (mk_list([e], expr_ty))
-  fun mk_BlobHash (ty,e) = mk_Builtin ty
-    BlobHash_tm (mk_list([e], expr_ty))
+
+val is_raw_call_flags = can dest_raw_call_flags
+
+val (External_tm, is_External) = syntax0 "External"
+val (Internal_tm, is_Internal) = syntax0 "Internal"
+val (Deploy_tm, is_Deploy) = syntax0 "Deploy"
+val (Pure_tm, is_Pure) = syntax0 "Pure"
+val (View_tm, is_View) = syntax0 "View"
+val (Nonpayable_tm, is_Nonpayable) = syntax0 "Nonpayable"
+val (Payable_tm, is_Payable) = syntax0 "Payable"
+val (Public_tm, is_Public) = syntax0 "Public"
+val (Private_tm, is_Private) = syntax0 "Private"
+val (Constant_tm, mk_Constant_tm, dest_Constant_tm, is_Constant) = syntax_fns1 "vyperAST" "Constant"
+val (Immutable_tm, is_Immutable) = syntax0 "Immutable"
+val (Transient_tm, is_Transient) = syntax0 "Transient"
+val (Storage_tm, is_Storage) = syntax0 "Storage"
+val (Type_tm, mk_Type_tm, dest_Type_tm, is_Type) = syntax_fns1 "vyperAST" "Type"
+val (HashMapT_tm, mk_HashMapT_tm, dest_HashMapT_tm, is_HashMapT) = syntax_fns2 "vyperAST" "HashMapT"
+
+val (FunctionDecl_tm, mk_FunctionDecl_tm, dest_FunctionDecl_tm, is_FunctionDecl) = syntax9 "FunctionDecl"
+val (VariableDecl_tm, mk_VariableDecl_tm, dest_VariableDecl_tm, is_VariableDecl) = syntax5 "VariableDecl"
+val (HashMapDecl_tm, mk_HashMapDecl_tm, dest_HashMapDecl_tm, is_HashMapDecl) = syntax6 "HashMapDecl"
+val (StructDecl_tm, mk_StructDecl_tm, dest_StructDecl_tm, is_StructDecl) = syntax_fns2 "vyperAST" "StructDecl"
+val (EventDecl_tm, mk_EventDecl_tm, dest_EventDecl_tm, is_EventDecl) = syntax_fns2 "vyperAST" "EventDecl"
+val (FlagDecl_tm, mk_FlagDecl_tm, dest_FlagDecl_tm, is_FlagDecl) = syntax_fns2 "vyperAST" "FlagDecl"
+val (InterfaceDecl_tm, mk_InterfaceDecl_tm, dest_InterfaceDecl_tm, is_InterfaceDecl) = syntax_fns2 "vyperAST" "InterfaceDecl"
+
+datatype expr_view =
+    VName of term * string
+  | VTopLevelName of term * term
+  | VFlagMember of term * term * string
+  | VIfExp of term * term * term * term
+  | VLiteral of term * term
+  | VStructLit of term * term * (string * term) list
+  | VSubscript of term * term * term
+  | VAttribute of term * term * string
+  | VBuiltin of term * term * term list
+  | VTypeBuiltin of term * term * term * term list
+  | VPop of term * term
+  | VCall of term * term * term list * term option
+
+fun view_expr tm =
+  if is_Name tm then VName (dest_Name tm)
+  else if is_TopLevelName tm then VTopLevelName (dest_TopLevelName_tm tm)
+  else if is_FlagMember tm then VFlagMember (dest_FlagMember tm)
+  else if is_IfExp tm then VIfExp (dest_IfExp_tm tm)
+  else if is_Literal tm then VLiteral (dest_Literal_tm tm)
+  else if is_StructLit tm then VStructLit (dest_StructLit tm)
+  else if is_Subscript tm then VSubscript (dest_Subscript_tm tm)
+  else if is_Attribute tm then VAttribute (dest_Attribute tm)
+  else if is_Builtin tm then VBuiltin (dest_Builtin tm)
+  else if is_TypeBuiltin tm then VTypeBuiltin (dest_TypeBuiltin tm)
+  else if is_Pop tm then VPop (dest_Pop_tm tm)
+  else if is_Call tm then VCall (dest_Call tm)
+  else raise ERR "view_expr" "not a vyperAST expr constructor"
+
+datatype stmt_view =
+    VPass
+  | VContinue
+  | VBreak
+  | VExpr of term
+  | VFor of string * term * term * term * term list
+  | VIf of term * term list * term list
+  | VAssert of term * term
+  | VLog of term * term list
+  | VRaise of term
+  | VReturn of term option
+  | VAssign of term * term
+  | VAugAssign of term * term * term * term
+  | VAppend of term * term
+  | VAnnAssign of string * term * term
+
+fun view_stmt tm =
+  if is_Pass tm then VPass
+  else if is_Continue tm then VContinue
+  else if is_Break tm then VBreak
+  else if is_Expr tm then VExpr (dest_Expr_tm tm)
+  else if is_For tm then VFor (dest_For tm)
+  else if is_If tm then VIf (dest_If tm)
+  else if is_Assert tm then VAssert (dest_Assert_tm tm)
+  else if is_Log tm then VLog (dest_Log tm)
+  else if is_Raise tm then VRaise (dest_Raise_tm tm)
+  else if is_Return tm then VReturn (dest_Return tm)
+  else if is_Assign tm then VAssign (dest_Assign_tm tm)
+  else if is_AugAssign tm then VAugAssign (dest_AugAssign_tm tm)
+  else if is_Append tm then VAppend (dest_Append_tm tm)
+  else if is_AnnAssign tm then VAnnAssign (dest_AnnAssign tm)
+  else raise ERR "view_stmt" "not a vyperAST stmt constructor"
+
+datatype call_target_view =
+    VIntCall of term
+  | VExtCall of term * term
+  | VSend
+  | VRawCallTarget of term
+  | VRawLog
+  | VRawRevert
+  | VSelfDestructTarget
+  | VCreateTarget of term * term
+
+fun view_call_target tm =
+  if is_IntCall tm then VIntCall (dest_IntCall_tm tm)
+  else if is_ExtCall tm then VExtCall (dest_ExtCall_tm tm)
+  else if is_Send tm then VSend
+  else if is_RawCallTarget tm then VRawCallTarget (dest_RawCallTarget_tm tm)
+  else if is_RawLog tm then VRawLog
+  else if is_RawRevert tm then VRawRevert
+  else if is_SelfDestructTarget tm then VSelfDestructTarget
+  else if is_CreateTarget tm then VCreateTarget (dest_CreateTarget_tm tm)
+  else raise ERR "view_call_target" "not a vyperAST call_target constructor"
+
+datatype toplevel_view =
+    VFunctionDecl of term * term * term * term * term * term * term * term * term
+  | VVariableDecl of term * term * term * term * term
+  | VHashMapDecl of term * term * term * term * term * term
+  | VStructDecl of term * term
+  | VEventDecl of term * term
+  | VFlagDecl of term * term
+  | VInterfaceDecl of term * term
+
+fun view_toplevel tm =
+  if is_FunctionDecl tm then VFunctionDecl (dest_FunctionDecl_tm tm)
+  else if is_VariableDecl tm then VVariableDecl (dest_VariableDecl_tm tm)
+  else if is_HashMapDecl tm then VHashMapDecl (dest_HashMapDecl_tm tm)
+  else if is_StructDecl tm then VStructDecl (dest_StructDecl_tm tm)
+  else if is_EventDecl tm then VEventDecl (dest_EventDecl_tm tm)
+  else if is_FlagDecl tm then VFlagDecl (dest_FlagDecl_tm tm)
+  else if is_InterfaceDecl tm then VInterfaceDecl (dest_InterfaceDecl_tm tm)
+  else raise ERR "view_toplevel" "not a vyperAST toplevel constructor"
 
 end

--- a/syntax/vyperASTSyntax.sml
+++ b/syntax/vyperASTSyntax.sml
@@ -473,6 +473,66 @@ val (EventDecl_tm, mk_EventDecl_tm, dest_EventDecl_tm, is_EventDecl) = syntax_fn
 val (FlagDecl_tm, mk_FlagDecl_tm, dest_FlagDecl_tm, is_FlagDecl) = syntax_fns2 "vyperAST" "FlagDecl"
 val (InterfaceDecl_tm, mk_InterfaceDecl_tm, dest_InterfaceDecl_tm, is_InterfaceDecl) = syntax_fns2 "vyperAST" "InterfaceDecl"
 
+datatype base_assignment_target_view =
+    VBNameTarget of string
+  | VBTopLevelNameTarget of term
+  | VBSubscriptTarget of term * term
+  | VBAttributeTarget of term * string
+
+fun view_base_assignment_target tm =
+  if is_NameTarget tm then VBNameTarget (dest_NameTarget tm)
+  else if is_TopLevelNameTarget tm then
+    VBTopLevelNameTarget (dest_TopLevelNameTarget_tm tm)
+  else if is_SubscriptTarget tm then
+    VBSubscriptTarget (dest_SubscriptTarget_tm tm)
+  else if is_AttributeTarget tm then
+    VBAttributeTarget (dest_AttributeTarget tm)
+  else raise ERR "view_base_assignment_target"
+    "not a vyperAST base_assignment_target constructor"
+
+datatype assignment_target_view =
+    VATBase of term
+  | VATTuple of term list
+
+fun view_assignment_target tm =
+  if is_BaseTarget tm then VATBase (dest_BaseTarget_tm tm)
+  else if is_TupleTarget tm then VATTuple (dest_TupleTarget tm)
+  else raise ERR "view_assignment_target"
+    "not a vyperAST assignment_target constructor"
+
+datatype iterator_view =
+    VIArray of term
+  | VIRange of term * term
+
+fun view_iterator tm =
+  if is_Array tm then VIArray (dest_Array_tm tm)
+  else if is_Range tm then VIRange (dest_Range_tm tm)
+  else raise ERR "view_iterator" "not a vyperAST iterator constructor"
+
+datatype assert_reason_view =
+    VAssertBareReason
+  | VAssertUnreachableReason
+  | VAssertReasonExpr of term
+
+fun view_assert_reason tm =
+  if is_AssertBare tm then VAssertBareReason
+  else if is_AssertUnreachable tm then VAssertUnreachableReason
+  else if is_AssertReason tm then VAssertReasonExpr (dest_AssertReason_tm tm)
+  else raise ERR "view_assert_reason"
+    "not a vyperAST assert_reason constructor"
+
+datatype raise_reason_view =
+    VRaiseBareReason
+  | VRaiseUnreachableReason
+  | VRaiseReasonExpr of term
+
+fun view_raise_reason tm =
+  if is_RaiseBare tm then VRaiseBareReason
+  else if is_RaiseUnreachable tm then VRaiseUnreachableReason
+  else if is_RaiseReason tm then VRaiseReasonExpr (dest_RaiseReason_tm tm)
+  else raise ERR "view_raise_reason"
+    "not a vyperAST raise_reason constructor"
+
 datatype expr_view =
     VName of term * string
   | VTopLevelName of term * term

--- a/syntax/vyperASTSyntaxTestScript.sml
+++ b/syntax/vyperASTSyntaxTestScript.sml
@@ -113,6 +113,34 @@ val _ = List.app (fn tm => ignore (vyperASTSyntax.view_expr tm)) expr_samples;
 val base_target = vyperASTSyntax.mk_BaseTarget_tm
   (vyperASTSyntax.mk_NameTarget "x");
 val tuple_target = vyperASTSyntax.mk_TupleTarget [base_target];
+val base_target_samples =
+  [ vyperASTSyntax.mk_NameTarget "x"
+  , vyperASTSyntax.mk_TopLevelNameTarget_tm nsid
+  , vyperASTSyntax.mk_SubscriptTarget_tm
+      (vyperASTSyntax.mk_NameTarget "xs", lit_tm)
+  , vyperASTSyntax.mk_AttributeTarget
+      (vyperASTSyntax.mk_NameTarget "s", "field")
+  ];
+val _ = List.app
+  (fn tm => ignore (vyperASTSyntax.view_base_assignment_target tm))
+  base_target_samples;
+val _ = List.app
+  (fn tm => ignore (vyperASTSyntax.view_assignment_target tm))
+  [base_target, tuple_target];
+val _ = List.app
+  (fn tm => ignore (vyperASTSyntax.view_iterator tm))
+  [vyperASTSyntax.mk_Array_tm name_tm,
+   vyperASTSyntax.mk_Range_tm (lit_tm, name_tm)];
+val _ = List.app
+  (fn tm => ignore (vyperASTSyntax.view_assert_reason tm))
+  [vyperASTSyntax.AssertBare_tm,
+   vyperASTSyntax.AssertUnreachable_tm,
+   vyperASTSyntax.mk_AssertReason_tm name_tm];
+val _ = List.app
+  (fn tm => ignore (vyperASTSyntax.view_raise_reason tm))
+  [vyperASTSyntax.RaiseBare_tm,
+   vyperASTSyntax.RaiseUnreachable_tm,
+   vyperASTSyntax.mk_RaiseReason_tm name_tm];
 val stmt_samples =
   [ vyperASTSyntax.Continue_tm
   , vyperASTSyntax.Break_tm

--- a/syntax/vyperASTSyntaxTestScript.sml
+++ b/syntax/vyperASTSyntaxTestScript.sml
@@ -1,0 +1,204 @@
+Theory vyperASTSyntaxTest
+Ancestors
+  vyperAST
+Libs
+  vyperASTSyntax
+
+fun same_term a b = Term.aconv a b;
+
+val u256 =
+  vyperASTSyntax.mk_BaseT_tm
+    (vyperASTSyntax.mk_UintT_tm (numSyntax.term_of_int 256));
+val name_tm = vyperASTSyntax.mk_Name (u256, "x");
+val _ =
+  case vyperASTSyntax.dest_Name name_tm of
+  | (ty, "x") => if same_term ty u256 then () else raise Fail "dest_Name ty"
+  | _ => raise Fail "dest_Name";
+
+val lit_tm =
+  vyperASTSyntax.mk_Literal_tm
+    (u256, vyperASTSyntax.mk_IntL_tm
+      (intSyntax.term_of_int (Arbint.fromInt 1)));
+val call_tm = vyperASTSyntax.mk_Call
+  (u256, vyperASTSyntax.Send_tm, [name_tm, lit_tm], SOME name_tm);
+val _ =
+  case vyperASTSyntax.dest_Call call_tm of
+  | (ty, target, [arg1, arg2], SOME drv) =>
+      if same_term ty u256 andalso
+         same_term target vyperASTSyntax.Send_tm andalso
+         same_term arg1 name_tm andalso
+         same_term arg2 lit_tm andalso
+         same_term drv name_tm
+      then ()
+      else raise Fail "dest_Call components"
+  | _ => raise Fail "dest_Call";
+
+val for_tm = vyperASTSyntax.mk_For
+  ("i", u256, vyperASTSyntax.mk_Range_tm (lit_tm, name_tm),
+   numSyntax.term_of_int 10, [vyperASTSyntax.Pass_tm]);
+val _ =
+  case vyperASTSyntax.dest_For for_tm of
+  | ("i", ty, iter, bound, [body]) =>
+      if same_term ty u256 andalso
+         vyperASTSyntax.is_Range iter andalso
+         same_term bound (numSyntax.term_of_int 10) andalso
+         same_term body vyperASTSyntax.Pass_tm
+      then ()
+      else raise Fail "dest_For components"
+  | _ => raise Fail "dest_For";
+
+val _ =
+  case vyperASTSyntax.view_expr name_tm of
+  | vyperASTSyntax.VName (ty, "x") =>
+      if same_term ty u256 then () else raise Fail "view_expr ty"
+  | _ => raise Fail "view_expr";
+
+val _ = if not (vyperASTSyntax.is_Name lit_tm) then ()
+        else raise Fail "is_Name negative";
+
+val body_tm = listSyntax.mk_list ([vyperASTSyntax.Pass_tm], vyperASTSyntax.stmt_ty);
+val empty_args_tm = listSyntax.mk_list ([], vyperASTSyntax.argument_ty);
+val empty_defaults_tm = listSyntax.mk_list ([], vyperASTSyntax.expr_ty);
+val fn_tm = vyperASTSyntax.mk_FunctionDecl_tm
+  (vyperASTSyntax.External_tm,
+   vyperASTSyntax.Nonpayable_tm,
+   boolSyntax.F,
+   boolSyntax.F,
+   stringSyntax.fromMLstring "f",
+   empty_args_tm,
+   empty_defaults_tm,
+   u256,
+   body_tm);
+val _ =
+  case vyperASTSyntax.view_toplevel fn_tm of
+  | vyperASTSyntax.VFunctionDecl (vis, mut, nonre, rawret, name, args, defaults, ret, body) =>
+      if same_term vis vyperASTSyntax.External_tm andalso
+         same_term mut vyperASTSyntax.Nonpayable_tm andalso
+         same_term nonre boolSyntax.F andalso
+         same_term rawret boolSyntax.F andalso
+         stringSyntax.fromHOLstring name = "f" andalso
+         same_term args empty_args_tm andalso
+         same_term defaults empty_defaults_tm andalso
+         same_term ret u256 andalso
+         same_term body body_tm
+      then ()
+      else raise Fail "view_toplevel FunctionDecl components"
+  | _ => raise Fail "view_toplevel FunctionDecl";
+
+(* Exhaust every recursive AST view constructor. The individual raw constructor
+   and destructor functions are generated from the same checked constants; these
+   tests guard the hand-written list/option/string adapters and view dispatch. *)
+val nsid = pairSyntax.mk_pair
+  (optionSyntax.mk_none numSyntax.num, stringSyntax.fromMLstring "member");
+val fields = listSyntax.mk_list
+  ([pairSyntax.mk_pair (stringSyntax.fromMLstring "field", name_tm)],
+   pairSyntax.mk_prod (stringSyntax.string_ty, vyperASTSyntax.expr_ty));
+val expr_samples =
+  [ vyperASTSyntax.mk_TopLevelName_tm (u256, nsid)
+  , vyperASTSyntax.mk_FlagMember (u256, nsid, "member")
+  , vyperASTSyntax.mk_IfExp_tm (u256, name_tm, name_tm, name_tm)
+  , vyperASTSyntax.mk_StructLit (u256, nsid, [("field", name_tm)])
+  , vyperASTSyntax.mk_Subscript_tm (u256, name_tm, lit_tm)
+  , vyperASTSyntax.mk_Attribute (u256, name_tm, "field")
+  , vyperASTSyntax.mk_Builtin (u256,
+      vyperASTSyntax.mk_Bop_tm vyperASTSyntax.Add_tm,
+      [name_tm, lit_tm])
+  , vyperASTSyntax.mk_TypeBuiltin
+      (u256, vyperASTSyntax.Convert_tm, u256, [name_tm])
+  , vyperASTSyntax.mk_Pop_tm
+      (u256, vyperASTSyntax.mk_NameTarget "xs")
+  ];
+val _ = List.app (fn tm => ignore (vyperASTSyntax.view_expr tm)) expr_samples;
+
+val base_target = vyperASTSyntax.mk_BaseTarget_tm
+  (vyperASTSyntax.mk_NameTarget "x");
+val tuple_target = vyperASTSyntax.mk_TupleTarget [base_target];
+val stmt_samples =
+  [ vyperASTSyntax.Continue_tm
+  , vyperASTSyntax.Break_tm
+  , vyperASTSyntax.mk_Expr_tm name_tm
+  , vyperASTSyntax.mk_If (name_tm, [vyperASTSyntax.Pass_tm], [])
+  , vyperASTSyntax.mk_Assert_tm
+      (name_tm, vyperASTSyntax.AssertBare_tm)
+  , vyperASTSyntax.mk_Log (nsid, [name_tm])
+  , vyperASTSyntax.mk_Raise_tm vyperASTSyntax.RaiseBare_tm
+  , vyperASTSyntax.mk_Return (SOME name_tm)
+  , vyperASTSyntax.mk_Assign_tm (tuple_target, name_tm)
+  , vyperASTSyntax.mk_AugAssign_tm
+      (u256, vyperASTSyntax.mk_NameTarget "x",
+       vyperASTSyntax.Add_tm, name_tm)
+  , vyperASTSyntax.mk_Append_tm
+      (vyperASTSyntax.mk_NameTarget "xs", name_tm)
+  , vyperASTSyntax.mk_AnnAssign ("x", u256, name_tm)
+  ];
+val _ = List.app (fn tm => ignore (vyperASTSyntax.view_stmt tm)) stmt_samples;
+
+val flags = vyperASTSyntax.mk_raw_call_flags
+  { max_outsize = numSyntax.term_of_int 32
+  , is_delegate = boolSyntax.F
+  , is_static = boolSyntax.T
+  , revert_on_failure = boolSyntax.T
+  };
+val call_target_samples =
+  [ vyperASTSyntax.mk_IntCall_tm nsid
+  , vyperASTSyntax.mk_ExtCall_tm
+      (boolSyntax.T,
+       pairSyntax.mk_pair
+         (stringSyntax.fromMLstring "f",
+          pairSyntax.mk_pair
+            (listSyntax.mk_list ([u256], vyperASTSyntax.type_ty), u256)))
+  , vyperASTSyntax.Send_tm
+  , vyperASTSyntax.mk_RawCallTarget_tm flags
+  , vyperASTSyntax.RawLog_tm
+  , vyperASTSyntax.RawRevert_tm
+  , vyperASTSyntax.SelfDestructTarget_tm
+  , vyperASTSyntax.mk_CreateTarget_tm
+      (vyperASTSyntax.CreateMinimalProxy_tm, boolSyntax.T)
+  ];
+val _ = List.app
+  (fn tm => ignore (vyperASTSyntax.view_call_target tm))
+  call_target_samples;
+val _ =
+  if vyperASTSyntax.is_raw_call_flags flags then
+    let val decoded = vyperASTSyntax.dest_raw_call_flags flags in
+      if same_term (#max_outsize decoded) (numSyntax.term_of_int 32) andalso
+         same_term (#is_delegate decoded) boolSyntax.F andalso
+         same_term (#is_static decoded) boolSyntax.T andalso
+         same_term (#revert_on_failure decoded) boolSyntax.T
+      then () else raise Fail "raw_call_flags fields"
+    end
+  else raise Fail "raw_call_flags recognizer";
+
+val no_slot = optionSyntax.mk_none numSyntax.num;
+val empty_fields = listSyntax.mk_list ([], vyperASTSyntax.argument_ty);
+val empty_event_fields = listSyntax.mk_list
+  ([], pairSyntax.mk_prod (vyperASTSyntax.argument_ty, bool));
+val empty_members = listSyntax.mk_list ([], stringSyntax.string_ty);
+val empty_interfaces = listSyntax.mk_list
+  ([], vyperASTSyntax.interface_func_ty);
+val toplevel_samples =
+  [ vyperASTSyntax.mk_VariableDecl_tm
+      (vyperASTSyntax.Private_tm,
+       vyperASTSyntax.Storage_tm,
+       stringSyntax.fromMLstring "x", u256, no_slot)
+  , vyperASTSyntax.mk_HashMapDecl_tm
+      (vyperASTSyntax.Private_tm, boolSyntax.F,
+       stringSyntax.fromMLstring "m", u256,
+       vyperASTSyntax.mk_Type_tm u256, no_slot)
+  , vyperASTSyntax.mk_StructDecl_tm
+      (stringSyntax.fromMLstring "S", empty_fields)
+  , vyperASTSyntax.mk_EventDecl_tm
+      (stringSyntax.fromMLstring "E", empty_event_fields)
+  , vyperASTSyntax.mk_FlagDecl_tm
+      (stringSyntax.fromMLstring "F", empty_members)
+  , vyperASTSyntax.mk_InterfaceDecl_tm
+      (stringSyntax.fromMLstring "I", empty_interfaces)
+  ];
+val _ = List.app
+  (fn tm => ignore (vyperASTSyntax.view_toplevel tm))
+  toplevel_samples;
+
+val _ =
+  (ignore (vyperASTSyntax.dest_Name lit_tm);
+   raise Fail "dest_Name accepted Literal")
+  handle HOL_ERR _ => ();


### PR DESCRIPTION
## Summary

Replace the partial `vyperASTSyntax` helper with a systematic syntax API for the
complete current `vyperAST` datatype family, and add an exhaustive recursive-view
smoke theory.

This is an initial draft for API and compatibility review. The constructor,
destructor, recognizer, typed-adapter, and view implementation is complete and is
already used by a downstream term-native translator over compiler-produced AST
terms. The main remaining question is how much of the historical convenience API
to preserve alongside the new systematic interface.

## Proposed API

The library now provides:

- HOL type handles for all AST component datatypes;
- constructor terms for every current constructor;
- systematic raw `mk_*_tm`, `dest_*_tm`, and `is_*` functions;
- typed ML adapters for constructors containing HOL lists, options, strings, and
  named fields;
- exhaustive `view_expr`, `view_stmt`, `view_call_target`, and `view_toplevel`
  datatypes/functions;
- field-name-based `raw_call_flags` construction and destruction through
  `TypeBase`;
- fail-closed `HOL_ERR` diagnostics for unexpected term shapes.

The intended naming convention is:

- `Ctor_tm`: HOL constructor term;
- `mk_Ctor_tm` / `dest_Ctor_tm` / `is_Ctor`: raw term syntax;
- `mk_Ctor` / `dest_Ctor`: typed ML convenience adapter where useful;
- `view_*`: exhaustive dispatch over recursive AST categories.

## Tests

`vyperASTSyntaxTestTheory` covers:

- every recursive expression constructor;
- every statement constructor;
- every call-target constructor;
- every top-level declaration constructor;
- list, option, and string adapters;
- `raw_call_flags` record round trips;
- rejection of a mismatched destructor.

Validated locally with:

```text
holbuild vyperASTSyntaxTestTheory
```

A full `holbuild vyperHolTheory` progressed through the syntax, frontend, Vyper
semantics, and numerous downstream targets, but stopped at the pre-existing
2.5-second tactic timeout in `dfAnalyzeProofsTheory` at
`df_fold_forward_invariant`; no syntax-library compatibility failure was
reported.

## Legacy compatibility

The old signature exports 226 names; the proposed signature exports 597. The new
library is functionally much more complete, but 63 historical exports are not
present with exactly the same name and SML argument shape.

Straightforward compatibility aliases include:

```text
AstCall_tm
identifier_ty
bool_tm / address_tm / decimal_tm
mk_Fixed / mk_Dynamic
mk_Signed / mk_Unsigned
mk_uint / mk_int
fixed/dynamic bytes and string type helpers
```

Common literal and builtin conveniences can also remain wrappers where their
current behavior is still valid.

Other names require an explicit migration decision rather than simple aliases:

- old and new `mk_Call`, `mk_Subscript`, `mk_Builtin`, and declaration helpers
  use incompatible curried versus tuple argument styles;
- historical `mk_Name` omits the type annotation required by the current AST;
- historical ABI helpers silently select boolean flags;
- hex/byte conveniences add `byteStringCacheLib` and include duplicate forms;
- some helpers reflect older constructor shapes.

Standard ML cannot overload these functions by argument shape. In-tree source
appears only to load `vyperASTSyntax` and does not call the historical convenience
functions, but external consumers may exist.

## Draft follow-up work

Before marking the PR ready:

- [ ] agree on the canonical argument style for conflicting convenience names;
- [ ] restore unambiguous compatibility aliases;
- [ ] retain, rename, or deliberately deprecate each useful historical helper;
- [ ] avoid preserving helpers that construct terms missing required current AST
      fields;
- [ ] run full CI and address any external/in-tree compatibility findings;
- [ ] add brief API documentation if maintainers want it outside the signature.

## Downstream migration

After this lands in an upstream revision, the downstream translator will switch
from its temporary `vyperASTSyntaxToUpstream` structure to this canonical
`vyperASTSyntax` and delete the local copy and duplicated smoke theory.
