### PR TITLE
Translate immutable assignment targets as top-level names

### DIFF
--- a/frontend/jsonToVyperExprScript.sml
+++ b/frontend/jsonToVyperExprScript.sml
@@ -517,7 +517,10 @@ Definition make_name_def:
 End
 
 Definition make_name_target_def:
-  make_name_target ctx id = NameTarget id
+  make_name_target ctx id =
+    if MEM id (SND (SND ctx))
+    then TopLevelNameTarget (FST (SND ctx), id)
+    else NameTarget id
 End
 
 (* ===== Expression Translation ===== *)


### PR DESCRIPTION
Make bare target translation mirror expression name translation by consulting the current module's constants and immutables.  This lets initializer assignments resolve through TopLevelNameTarget while preserving NameTarget for local variables.

Fixes #418 