### PR TITLE
Fix executable compiler fixtures on current HOL

### DIFF
--- a/lowering/defs/evalCompilerBytecodeScript.sml
+++ b/lowering/defs/evalCompilerBytecodeScript.sml
@@ -10,9 +10,12 @@ Theory evalCompilerBytecode
 Ancestors evalCompiler compileVyper concretizeMemLocDefs alist byte integer_word option
 Libs evalCompilerBytecodeLib finite_mapLib computeLib wordsLib
 
-val () = the_compset := add_finite_map_compset(!the_compset)
-val () = the_compset := computeLib.add_thms [fmap_to_alist_FEMPTY] (!the_compset)
-val () = the_compset := computeLib.add_thms [i2w_pos] (!the_compset)
+fun holbuild_extra_deps (_ : string list) = ()
+val () = holbuild_extra_deps ["bytecode"]
+
+val () = computeLib.upd_compset add_finite_map_compset
+val () = computeLib.upd_compset (computeLib.add_thms [fmap_to_alist_FEMPTY])
+val () = computeLib.upd_compset (computeLib.add_thms [i2w_pos])
 
 val () = Globals.max_print_depth := 20
 

--- a/lowering/defs/evalCompilerScript.sml
+++ b/lowering/defs/evalCompilerScript.sml
@@ -10,9 +10,9 @@ Theory evalCompiler
 Ancestors compileVyper concretizeMemLocDefs alist byte integer_word option
 Libs finite_mapLib computeLib wordsLib
 
-val () = the_compset := add_finite_map_compset(!the_compset)
-val () = the_compset := computeLib.add_thms [fmap_to_alist_FEMPTY] (!the_compset)
-val () = the_compset := computeLib.add_thms [i2w_pos] (!the_compset)
+val () = computeLib.upd_compset add_finite_map_compset
+val () = computeLib.upd_compset (computeLib.add_thms [fmap_to_alist_FEMPTY])
+val () = computeLib.upd_compset (computeLib.add_thms [i2w_pos])
 
 val () = Globals.max_print_depth := 20
 


### PR DESCRIPTION
_co-authored by gpt-5.6-sol_

## Summary

- migrate executable compiler fixtures to the current HOL compset context API
- declare bytecode fixtures as holbuild inputs so byte-for-byte checks run in the hermetic build stage
