### PR TITLE
Accept address-to-uint conversions in the type checker

### DIFF
--- a/semantics/vyperTypeSystemScript.sml
+++ b/semantics/vyperTypeSystemScript.sml
@@ -397,6 +397,7 @@ Definition valid_conversion_def:
   valid_conversion (BaseT (UintT _)) (BaseT (IntT _)) = T /\
   valid_conversion (BaseT (IntT _)) (BaseT (UintT _)) = T /\
   valid_conversion (BaseT (IntT _)) (BaseT (IntT _)) = T /\
+  valid_conversion (BaseT AddressT) (BaseT (UintT _)) = T /\
   valid_conversion (BaseT (UintT _)) (BaseT AddressT) = T /\
   valid_conversion (BaseT (IntT _)) (BaseT AddressT) = T /\
   valid_conversion (FlagT _) (BaseT (IntT _)) = T /\


### PR DESCRIPTION
Align valid_conversion with the pinned Vyper compiler by allowing address values to be converted to unsigned integers of any supported width. Address values use the BytesV representation, whose existing conversion semantics already perform the required target-width bounds check.

Fixes #446.