### PR TITLE
Fix HOL proof tactic timeouts

### DIFF
--- a/lowering/arithmeticPropsScript.sml
+++ b/lowering/arithmeticPropsScript.sml
@@ -407,7 +407,8 @@ Theorem unsigned_in_range_not_gt_hi[local]:
 Proof
   rw[type_bounds_def, in_type_range_def, math_val_def, LET_THM] >>
   `2 ** type_bits ty ≤ 2 ** 256` by simp[bitTheory.TWOEXP_MONO2] >>
-  `2 ** type_bits ty − 1 < dimword (:256)` by simp[wordsTheory.dimword_def] >>
+  `2 ** type_bits ty − 1 < dimword (:256)` by
+    simp[wordsTheory.dimword_def, venomMemPropsTheory.dimindex_256] >>
   simp[wordsTheory.w2n_n2w]
 QED
 
@@ -871,8 +872,9 @@ Resume compile_clamp_ok[signed]:
         integer_wordTheory.WORD_LTi, integer_wordTheory.WORD_GTi] >>
     `type_bits ty − 1 ≤ 255` by simp[] >>
     `2 ** (type_bits ty − 1) ≤ 2 ** 255` by simp[bitTheory.TWOEXP_MONO2] >>
-    simp[integer_wordTheory.w2i_i2w_neg, integer_wordTheory.w2i_i2w_pos,
-         wordsTheory.INT_MIN_def, integer_wordTheory.INT_MAX_def] >>
+    simp[integer_wordTheory.w2i_i2w_neg] >>
+    simp[integer_wordTheory.w2i_i2w_pos] >>
+    simp[wordsTheory.INT_MIN_def, integer_wordTheory.INT_MAX_def] >>
     intLib.COOPER_TAC) >>
   `bool_to_word (bool_to_word (v < lo) = 0w) &&
    bool_to_word (bool_to_word (v > hi) = 0w) ≠ 0w` by gvs[] >>

--- a/lowering/builtinPropsScript.sml
+++ b/lowering/builtinPropsScript.sml
@@ -132,10 +132,12 @@ Theorem step_SHA3[local]:
       step_inst_base (mk_inst id SHA3 [op1; op2] [out]) ss =
         OK (update_var out hash ss)
 Proof
-  rw[step_inst_base_def, mk_inst_def] >>
+  rpt gen_tac >> strip_tac >>
   qexists `word_of_bytes T 0w
     (Keccak_256_w64
       (TAKE (w2n v2) (DROP (w2n v1) ss.vs_memory ++ REPLICATE (w2n v2) 0w)))` >>
+  PURE_REWRITE_TAC[mk_inst_def] >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
   simp[]
 QED
 

--- a/lowering/emitHelperPropsScript.sml
+++ b/lowering/emitHelperPropsScript.sml
@@ -154,7 +154,9 @@ Theorem step_GT:
     step_inst_base (mk_inst id GT [op1; op2] [out]) ss =
       OK (update_var out (bool_to_word (w2n v1 > w2n v2)) ss)
 Proof
-  rw[step_inst_base_def] >> irule exec_pure2_ok >> rw[]
+  rw[] >> ASM_REWRITE_TAC[step_inst_base_def, mk_inst_opcode,
+                           opcode_case_def] >>
+  irule exec_pure2_ok >> rw[]
 QED
 
 Theorem step_LT:

--- a/lowering/exprLoweringPropsScript.sml
+++ b/lowering/exprLoweringPropsScript.sml
@@ -410,10 +410,12 @@ Theorem iszero_bool_correct:
     step_inst_base (mk_inst inst_id ISZERO [op] [out_var]) ss =
       OK (update_var out_var (val_to_w256 (BoolV (¬b))) ss)
 Proof
-  Cases_on `b`
-  >> simp[step_inst_base_def, exec_pure1_def, eval_operand_def,
-          val_to_w256_def, update_var_def, venomInstTheory.mk_inst_def,
-          venomExecSemanticsTheory.bool_to_word_def, comp_return_def, comp_bind_def, comp_ignore_bind_def]
+  Cases_on `b` >> rpt strip_tac >>
+  PURE_REWRITE_TAC[venomInstTheory.mk_inst_def] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> simp[] >>
+  simp[exec_pure1_def, eval_operand_def, val_to_w256_def,
+       update_var_def, venomExecSemanticsTheory.bool_to_word_def,
+       comp_return_def, comp_bind_def, comp_ignore_bind_def]
 QED
 
 (* ASSERT instruction: non-zero → OK (no-op), zero → Abort *)

--- a/lowering/moduleLoweringPropsScript.sml
+++ b/lowering/moduleLoweringPropsScript.sml
@@ -416,8 +416,14 @@ Resume compile_entry_checks_correct[nonpayable_abort]:
   (* abort assumption *)
   >- first_assum ACCEPT_TAC
   (* inst_extends st cs' from payable emit chain *)
-  >- metis_tac[inst_extends_emit_op, inst_extends_emit_void,
-               inst_extends_trans]
+  >- (qmatch_asmsub_rename_tac
+        `emit_op CALLVALUE [] st = (cv, pay_st1)` >>
+      qmatch_asmsub_rename_tac
+        `emit_op ISZERO [cv] pay_st1 = (no_value, pay_st2)` >>
+      imp_res_tac inst_extends_emit_op >>
+      imp_res_tac inst_extends_emit_void >>
+      irule inst_extends_trans >> qexists_tac `pay_st1` >> simp[] >>
+      irule inst_extends_trans >> qexists_tac `pay_st2` >> simp[])
   (* inst_extends cs' st' from CDS conditional *)
   >> (qpat_x_assum `emit_op CALLVALUE _ _ = _` kall_tac >>
       qpat_x_assum `emit_op ISZERO [cv] _ = _` kall_tac >>

--- a/lowering/proofs/valueEncodingProofsScript.sml
+++ b/lowering/proofs/valueEncodingProofsScript.sml
@@ -139,9 +139,10 @@ Proof
   rpt strip_tac >>
   `k MOD dimword(:256) = k` by
     (irule arithmeticTheory.LESS_MOD >>
-     simp[wordsTheory.dimword_def] >>
+     PURE_REWRITE_TAC[wordsTheory.dimword_def, dimindex_256] >>
      irule arithmeticTheory.LESS_LESS_EQ_TRANS >>
-     qexists_tac `2 ** n` >> simp[]) >>
+     qexists_tac `2 ** n` >> conj_tac >- FIRST_ASSUM ACCEPT_TAC >>
+     irule bitTheory.TWOEXP_MONO2 >> FIRST_ASSUM ACCEPT_TAC) >>
   simp[]
 QED
 

--- a/semantics/prop/vyperAssignTargetScript.sml
+++ b/semantics/prop/vyperAssignTargetScript.sml
@@ -295,12 +295,26 @@ Proof
         assign_operation_CASE_rator, bound_CASE_rator,
         AllCaseEqs(), PULL_EXISTS] >>
    rpt strip_tac >>
-   gvs[pairTheory.ELIM_UNCURRY, bind_def, return_def, raise_def,
-       ignore_bind_def, lift_option_def, lift_option_type_def, lift_sum_def,
-       check_def, assert_def,
-       option_CASE_rator, prod_CASE_rator, sum_CASE_rator,
-       type_value_CASE_rator, assign_operation_CASE_rator, bound_CASE_rator,
-       AllCaseEqs(), PULL_EXISTS] >>
+   gvs[pairTheory.ELIM_UNCURRY] >>
+   gvs[bind_def, ignore_bind_def] >>
+   gvs[return_def, raise_def] >>
+   gvs[lift_option_def, lift_option_type_def, lift_sum_def] >>
+   gvs[check_def, assert_def] >>
+   gvs[option_CASE_rator, prod_CASE_rator, sum_CASE_rator] >>
+   gvs[type_value_CASE_rator, assign_operation_CASE_rator,
+       bound_CASE_rator] >>
+   gvs[AllCaseEqs()] >>
+   gvs[PULL_EXISTS] >>
+   gvs[return_def, raise_def] >>
+   gvs[bind_def, ignore_bind_def] >>
+   gvs[lift_option_def, lift_option_type_def, lift_sum_def] >>
+   gvs[option_CASE_rator, prod_CASE_rator, sum_CASE_rator] >>
+   gvs[type_value_CASE_rator, assign_operation_CASE_rator,
+       bound_CASE_rator] >>
+   gvs[check_def, assert_def] >>
+   gvs[AllCaseEqs()] >>
+   gvs[PULL_EXISTS] >>
+   gvs[return_def, raise_def] >>
    MAP_EVERY (fn th => TRY (imp_res_tac th >> gvs[]))
      [assign_result_state, set_global_immutables,
       resolve_array_element_state,

--- a/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
+++ b/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
@@ -1481,8 +1481,10 @@ Proof
   RULE_ASSUM_TAC (REWRITE_RULE [check_def, type_check_def, assert_def, return_def]) >>
   gvs[] >>
   (* Resolve case expressions on dest_AddressV/dest_NumV *)
-  rpt (BasicProvers.FULL_CASE_TAC >>
-       gvs[return_def, raise_def]) >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[return_def, raise_def] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[return_def, raise_def] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[return_def, raise_def] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[return_def, raise_def] >>
   imp_res_tac transfer_value_immutables >> gvs[] >>
   first_x_assum drule >>
   metis_tac[preserves_immutables_dom_trans, preserves_immutables_dom_eq]
@@ -3037,11 +3039,13 @@ Proof
      `FST (SND (SND (SND (SND fn_tup))))`,
      `SND (SND (SND (SND (SND fn_tup))))`]
     mp_tac intcall_mutual_tail_body_provider_from_generated_ih \\
-  simp[get_scopes_def, return_def] \\
+  simp[get_scopes_def] \\
+  PURE_REWRITE_TAC[return_def] \\
   (impl_tac >-
-     (qpat_assum `∀s0 x0 t0 s1 ts0 t1 s2 tup0 t2 mut0 stup0 nr0 stup20 args0 sstup0 dflts0 sstup20 ret0 ss0 s3 x1 t3 s4 vs0 t4 needed_dflts0 cxd0 s5 prev0 t5 s6 dflt_vs0 t6 all_tenv s7 env t7 s8 rtv t8 is_view s9 lk t9 s10 cx0 t10. _ ⇒ ∀st0 res0 st1. eval_stmts cx0 ss0 st0 = (res0,st1) ⇒ preserves_immutables_dom cx0 st0 st1`
+     (qpat_x_assum `∀s0 x0 t0 s1 ts0 t1 s2 tup0 t2 mut0 stup0 nr0 stup20 args0 sstup0 dflts0 sstup20 ret0 ss0 s3 x1 t3 s4 vs0 t4 needed_dflts0 cxd0 s5 prev0 t5 s6 dflt_vs0 t6 all_tenv s7 env t7 s8 rtv t8 is_view s9 lk t9 s10 cx0 t10. _ ⇒ ∀st0 res0 st1. eval_stmts cx0 ss0 st0 = (res0,st1) ⇒ preserves_immutables_dom cx0 st0 st1`
         mp_tac \\
-      simp[get_scopes_def, return_def])) \\
+      PURE_REWRITE_TAC[get_scopes_def, return_def] \\
+      simp[])) \\
   simp[]
 QED
 
@@ -3140,7 +3144,8 @@ Proof
   \\ simp[bind_def]
   \\ BasicProvers.TOP_CASE_TAC
   \\ reverse BasicProvers.TOP_CASE_TAC
-  >- (rpt strip_tac \\ gvs[] \\
+  >- (rpt strip_tac \\
+      rpt (qpat_x_assum `_ = st` SUBST_ALL_TAC) \\
       irule intcall_default_frame_to_caller_imm_dom \\
       qexists_tac `fn` \\
       qexists_tac `r'⁴'` \\
@@ -3148,8 +3153,8 @@ Proof
       simp[] \\
       qspecl_then
         [`cx`, `src_id_opt`, `fn`, `es`,
-         `r`, `r`, `r`, `r`, `r`,
-         `()`, `r`, `x'`, `r`, `x''`, `r`, `()`, `r`, `x'⁴'`, `r'⁴'`,
+         `st`, `st`, `st`, `st`, `st`,
+         `()`, `st`, `x'`, `st`, `x''`, `st`, `()`, `st`, `x'⁴'`, `r'⁴'`,
          `DROP (LENGTH (FST (SND (SND (SND x'')))) -
                 (LENGTH (FST (SND (SND x''))) - LENGTH es))
                (FST (SND (SND (SND x''))))`,
@@ -3157,7 +3162,9 @@ Proof
          `INR y`, `r'⁵'`]
         mp_tac intcall_mutual_default_frame_imm_dom_from_generated_ih \\
       (impl_tac >-
-         (conj_tac >- (qpat_assum `∀s0 t0 s1 ts0 t1 s2 tup0 t2 s3 t3 s4 vs0 t4 s5 prev0 t5 s6 t6. _ ⇒ ∀st0 res0 st1. eval_exprs (cx with stk updated_by CONS (src_id_opt,fn)) _ st0 = (res0,st1) ⇒ preserves_immutables_dom (cx with stk updated_by CONS (src_id_opt,fn)) st0 st1` mp_tac \\ simp[]) \\
+         (conj_tac >- (qpat_x_assum `∀s0 x0 t0 s1 ts0 t1 s2 tup0 t2 mut0 stup0 nr0 stup20 args0 sstup0 dflts0 sstup20 ret0 body0 s3 x1 t3 s4 vs0 t4 es0 cxd0 s5 prev0 t5 s6 x2 t6. _ ⇒ ∀st0 res0 st1. eval_exprs cxd0 es0 st0 = (res0,st1) ⇒ preserves_immutables_dom cxd0 st0 st1` mp_tac \\ simp[]) \\
+          TRY (qpat_x_assum `∀s0 x0 t0 s1 ts0 t1 s2 tup0 t2 mut0 stup0 nr0 stup20 args0 sstup0 dflts0 sstup20 ret0 body0 s3 x1 t3 s4 vs0 t4 es0 cxd0 s5 prev0 t5 s6 x2 t6. _` kall_tac) \\
+          TRY (qpat_x_assum `∀s0 x0 t0 s1 ts0 t1 s2 tup0 t2 mut0 stup0 nr0 stup20 args0 sstup0 dflts0 sstup20 ret0 ss0 s3 x1 t3 s4 vs0 t4 needed_dflts0 cxd0 s5 prev0 t5 s6 dflt_vs0 t6 all_tenv s7 env t7 s8 rtv t8 is_view s9 lk t9 s10 cx0 t10. _` kall_tac) \\
           rpt conj_tac \\ simp[get_scopes_def, set_scopes_def, return_def,
                                 type_check_def, assert_def, ignore_bind_def] \\
           TRY decide_tac)) \\
@@ -3434,7 +3441,15 @@ Resume immutables_dom_mutual[ExtCall]:
   >- (
     last_x_assum(qspec_then`ARB`kall_tac)
     \\ gvs[CaseEq"bool", return_def, COND_RATOR, bind_def]
-    \\ gvs[CaseEq"sum", CaseEq"prod"]
+    \\ gvs[CaseEq"sum"]
+    \\ gvs[CaseEq"prod"]
+    \\ Cases_on `v` \\ gvs[]
+    \\ TRY BasicProvers.FULL_CASE_TAC \\ gvs[]
+    \\ TRY BasicProvers.FULL_CASE_TAC \\ gvs[]
+    \\ TRY BasicProvers.TOP_CASE_TAC \\ gvs[]
+    \\ TRY BasicProvers.TOP_CASE_TAC \\ gvs[]
+    \\ TRY BasicProvers.TOP_CASE_TAC \\ gvs[]
+    \\ TRY BasicProvers.TOP_CASE_TAC \\ gvs[]
     \\ imp_res_tac type_check_same_state
     \\ imp_res_tac lift_option_same_state
     \\ imp_res_tac lift_option_type_same_state

--- a/semantics/prop/vyperEvalPreservesScopesScript.sml
+++ b/semantics/prop/vyperEvalPreservesScopesScript.sml
@@ -720,27 +720,27 @@ Proof
   (* [] *) >- gvs[evaluate_def, return_def, preserves_scopes_dom_def]
   (* v::vs *) >- (drule case_eval_for_cons_dom >> metis_tac[])
   (* === Expression cases - use eval_expr_preserves_scopes_dom === *)
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
   (* chain interaction builtins *)
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_expr_preserves_scopes_dom >> gvs[])
-  >- (drule eval_exprs_preserves_scopes_dom >> gvs[])
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_expr_preserves_scopes_dom
+  >- drule_all_then ACCEPT_TAC eval_exprs_preserves_scopes_dom
   >- (drule eval_exprs_preserves_scopes_dom >> gvs[])
 QED
 

--- a/semantics/prop/vyperHashMapPreservationScript.sml
+++ b/semantics/prop/vyperHashMapPreservationScript.sml
@@ -275,7 +275,12 @@ Proof
           vyperStateTheory.get_address_immutables_def,
           vyperStateTheory.lift_option_def, vyperStateTheory.lift_option_type_def,
           vyperStateTheory.return_def, vyperStateTheory.raise_def, set_storage_immutables]
-  \\ rpt CASE_TAC \\ gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
+  \\ TRY CASE_TAC \\ gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
+  \\ TRY CASE_TAC \\ gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
+  \\ TRY CASE_TAC \\ gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
+  \\ TRY CASE_TAC \\ gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
+  \\ TRY CASE_TAC \\ gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
+  \\ TRY CASE_TAC \\ gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
 QED
 
 (* Helper: read_storage_slot FST preserved by set_storage under disjointness *)

--- a/semantics/prop/vyperImmutablesPreservationScript.sml
+++ b/semantics/prop/vyperImmutablesPreservationScript.sml
@@ -42,11 +42,16 @@ Proof
    qpat_x_assum `_ = (res, st')` mp_tac >>
    simp[get_immutables_def, get_address_immutables_def, bind_def,
         lift_option_def, lift_option_type_def, return_def, raise_def] >>
-   rpt CASE_TAC >> gvs[return_def, raise_def]) >>
+   CASE_TAC >> gvs[return_def, raise_def] >>
+   CASE_TAC >> gvs[return_def, raise_def]) >>
   PairCases_on `x'` >> gvs[] >>
   Cases_on `x'0` >> gvs[bind_def, return_def, raise_def] >>
   qpat_x_assum `_ = (res, st')` mp_tac >>
-  rpt (CASE_TAC >> gvs[return_def, raise_def, bind_def]) >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def] >>
+  CASE_TAC >> gvs[return_def, raise_def] >>
   rpt strip_tac >> gvs[] >>
   imp_res_tac read_storage_slot_immutables
 QED

--- a/semantics/prop/vyperPureExprScript.sml
+++ b/semantics/prop/vyperPureExprScript.sml
@@ -175,8 +175,13 @@ Theorem case_Builtin[local]:
        pure_expr (Builtin ty bt es) ⇒ st = st')
 Proof
   rpt strip_tac >>
-  gvs[evaluate_def, bind_def, AllCaseEqs(), pure_expr_def, ignore_bind_def,
-      check_def, type_check_def, assert_def, return_def, raise_def, get_accounts_def, lift_sum_def] >>
+  gvs[evaluate_def] >>
+  gvs[pure_expr_def] >>
+  gvs[bind_def, ignore_bind_def] >>
+  gvs[check_def, type_check_def, assert_def] >>
+  gvs[return_def, raise_def] >>
+  gvs[get_accounts_def, lift_sum_def] >>
+  gvs[AllCaseEqs()] >>
   Cases_on `bt = Len` >> gvs[bind_def, AllCaseEqs(), return_def, raise_def]
   (* Len case: eval_expr (HD es) + toplevel_array_length *)
   (* Len case *)

--- a/semantics/prop/vyperScopePreservationScript.sml
+++ b/semantics/prop/vyperScopePreservationScript.sml
@@ -151,7 +151,11 @@ Proof
   PairCases_on `x'` >> gvs[] >>
   Cases_on `x'0` >> gvs[bind_def, return_def, raise_def] >>
   qpat_x_assum `_ = (res, st')` mp_tac >>
-  rpt (CASE_TAC >> gvs[return_def, raise_def, bind_def]) >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
   rpt strip_tac >> gvs[] >>
   drule read_storage_slot_scopes >> simp[]
 QED

--- a/semantics/prop/vyperStatePreservationScript.sml
+++ b/semantics/prop/vyperStatePreservationScript.sml
@@ -97,11 +97,16 @@ Proof
   (qpat_x_assum `_ = (res, st')` mp_tac >>
    simp[get_immutables_def, get_address_immutables_def, bind_def,
         lift_option_def, lift_option_type_def, return_def, raise_def] >>
-   rpt CASE_TAC >> gvs[return_def, raise_def]) >>
+   CASE_TAC >> gvs[return_def, raise_def] >>
+   CASE_TAC >> gvs[return_def, raise_def]) >>
   PairCases_on `x'` >> gvs[] >>
   Cases_on `x'0` >> gvs[bind_def, return_def, raise_def] >>
   qpat_x_assum `_ = (res, st')` mp_tac >>
-  rpt (CASE_TAC >> gvs[return_def, raise_def, bind_def]) >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def, bind_def] >>
+  CASE_TAC >> gvs[return_def, raise_def] >>
+  CASE_TAC >> gvs[return_def, raise_def] >>
   rpt strip_tac >> gvs[] >>
   drule read_storage_slot_state >> simp[]
 QED

--- a/semantics/prop/vyperStorageWritePreservationScript.sml
+++ b/semantics/prop/vyperStorageWritePreservationScript.sml
@@ -355,8 +355,13 @@ Proof
        gvs[return_def, raise_def, bind_def, check_def, type_check_def,
            assert_def, AllCaseEqs()]) >>
   rpt strip_tac >> gvs[] >>
-  gvs[assert_def, bind_def, ignore_bind_def, return_def, raise_def,
-      AllCaseEqs()] >>
+  qpat_x_assum `_ = (INL elem_offset,s'')` mp_tac >>
+  simp[assert_def, bind_def, ignore_bind_def, return_def, raise_def,
+       AllCaseEqs()] >>
+  strip_tac >>
+  TRY (qpat_x_assum `elem_offset = _` SUBST_ALL_TAC) >>
+  TRY (qpat_x_assum `st = s''` SUBST_ALL_TAC) >>
+  TRY (qpat_x_assum `ty = _` SUBST_ALL_TAC) >>
   imp_res_tac evaluate_type_ArrayTV_inv >>
   rpt
     (FIRST

--- a/semantics/prop/vyperTypeABIScript.sml
+++ b/semantics/prop/vyperTypeABIScript.sml
@@ -1209,8 +1209,10 @@ Theorem vyper_to_abi_total:
 Proof
   ho_match_mp_tac vyper_to_abi_ind >>
   rpt conj_tac >> rpt gen_tac >>
-  simp[vyper_to_abi_def, evaluate_type_def, value_has_type_def,
-       AllCaseEqs(), PULL_EXISTS] >>
+  simp[vyper_to_abi_def] >>
+  simp[evaluate_type_def] >>
+  simp[value_has_type_def] >>
+  simp[AllCaseEqs(), PULL_EXISTS] >>
   rpt strip_tac >> gvs[value_has_type_def, AllCaseEqs(), PULL_EXISTS] >>
   TRY (Cases_on `v` >> gvs[value_has_type_def, vyper_to_abi_base_def] >> NO_TAC) >>
   TRY (drule evaluate_types_LIST_REL >> strip_tac >>
@@ -1232,7 +1234,8 @@ Proof
   TRY (first_x_assum drule_all >> strip_tac >> gvs[] >> NO_TAC) >>
   TRY (Cases_on `ALOOKUP sparse n` >> gvs[] >>
        drule_all sparse_values_have_type_ALOOKUP >> strip_tac >>
-       first_x_assum drule_all >> strip_tac >> gvs[] >> NO_TAC)
+       first_x_assum drule_all >> strip_tac >> gvs[] >> NO_TAC) >>
+  Cases_on `tvs` >> gvs[value_has_type_def]
 QED
 
 Theorem vyper_to_abi_bound_rel_strong[local]:

--- a/semantics/prop/vyperTypeBuiltinsScript.sml
+++ b/semantics/prop/vyperTypeBuiltinsScript.sml
@@ -1017,6 +1017,33 @@ Proof
 QED
 
 
+Theorem negated_flag_membership_INL[local]:
+  binop_negate (evaluate_binop u tv In (FlagV k) (FlagV k')) = INL v ==>
+  ?b. v = BoolV b
+Proof
+  simp[Once evaluate_binop_def, binop_negate_def] >> strip_tac >>
+  qexists_tac `int_and (&k) (&k') = 0` >> gvs[]
+QED
+
+Theorem negated_array_membership_INL[local]:
+  value_has_type (ArrayTV tv bd) v2 /\
+  binop_negate (evaluate_binop u result_tv In v1 v2) = INL v ==>
+  ?b. v = BoolV b
+Proof
+  Cases_on `v2` >> gvs[value_has_type_def] >>
+  simp[Once evaluate_binop_def, binop_negate_def] >>
+  metis_tac[]
+QED
+
+Theorem negated_equality_INL[local]:
+  binop_negate (evaluate_binop u tv Eq v1 v2) = INL v ==>
+  ?b. v = BoolV b
+Proof
+  Cases_on `v1` >> Cases_on `v2` >>
+  simp[Once evaluate_binop_def, binop_negate_def] >>
+  metis_tac[]
+QED
+
 Theorem well_typed_binop_success_type:
   well_typed_binop ty bop t1 t2 ∧
   evaluate_type tenv ty = SOME result_tv ∧
@@ -1029,11 +1056,14 @@ Proof
   rpt gen_tac >> strip_tac >>
   Cases_on `bop` >>
   gvs[well_typed_binop_def,
-      Excl "is_int_type_def", Excl "is_numeric_type_def", Excl "is_bool_type_def",
-      Excl "is_flag_type_def", Excl "is_comparable_type_def",
-      is_int_type_inv, is_numeric_type_inv, is_bool_type_inv,
-      is_flag_type_inv, is_comparable_type_inv,
-      evaluate_type_def, type_to_int_bound_def, AllCaseEqs()] >>
+      Excl "is_int_type_def", Excl "is_numeric_type_def",
+      Excl "is_bool_type_def", Excl "is_flag_type_def",
+      Excl "is_comparable_type_def"] >>
+  gvs[is_int_type_inv, is_numeric_type_inv] >>
+  gvs[is_bool_type_inv, is_flag_type_inv, is_comparable_type_inv] >>
+  gvs[evaluate_type_def] >>
+  gvs[type_to_int_bound_def] >>
+  gvs[AllCaseEqs()] >>
   (* Signed Add: route the successful bounded operation through its inversion lemma. *)
   TRY (
     qpat_x_assum `evaluate_binop (Signed n) (BaseTV (IntT n)) Add
@@ -1059,10 +1089,13 @@ Proof
     gvs[value_has_type_def, w2n_and_low_mask_lt] >> NO_TAC) >>
   (* All remaining: expand evaluate_binop but keep bounded/wrapped ops opaque.
      Use INL inversion lemmas to extract within_int_bound. *)
-  gvs[evaluate_binop_def, AllCaseEqs(), value_has_type_def,
-      Excl "bounded_int_op_def", Excl "bounded_decimal_op_def", Excl "wrapped_int_op_def",
-      Excl "within_int_bound_def",
-      LET_THM] >>
+  qpat_x_assum `evaluate_binop _ _ _ _ _ = INL v` mp_tac >>
+  PURE_ONCE_REWRITE_TAC[evaluate_binop_def] >>
+  PURE_REWRITE_TAC[vyperASTTheory.binop_case_def,
+                   vyperValueTheory.value_case_def] >>
+  simp_tac std_ss [LET_THM] >> strip_tac >>
+  gvs[AllCaseEqs()] >>
+  gvs[value_has_type_def, Excl "within_int_bound_def"] >>
   (* Re-abstract within_int_bound that got expanded by value_has_type_def *)
   TRY (simp[GSYM within_int_bound_def] >> NO_TAC) >>
   (* Bounded int ops: INL gives within_int_bound *)
@@ -1115,6 +1148,14 @@ Proof
   (* Max: choose the larger value *)
   TRY (
     irule within_int_bound_max >> simp[] >> NO_TAC) >>
+  (* Negated flag membership has a boolean result. *)
+  TRY (drule_all_then ACCEPT_TAC negated_flag_membership_INL >> NO_TAC) >>
+  TRY (drule_all_then ACCEPT_TAC negated_array_membership_INL >> NO_TAC) >>
+  TRY (drule_all_then ACCEPT_TAC negated_equality_INL >> NO_TAC) >>
+  (* Negated membership/equality: expose the inner boolean result. *)
+  TRY (
+    qpat_x_assum `binop_negate _ = INL v` mp_tac >>
+    simp[Once evaluate_binop_def, binop_negate_def] >> NO_TAC) >>
   (* Catch-all for simple remaining cases *)
   TRY (gvs[within_int_bound_def] >> NO_TAC) >>
   TRY (intLib.ARITH_TAC >> NO_TAC) >>

--- a/semantics/prop/vyperTypeContractGetterScript.sml
+++ b/semantics/prop/vyperTypeContractGetterScript.sml
@@ -1684,10 +1684,10 @@ Proof
        get_scopes_def, lookup_scopes_val_def, bind_def, lift_option_def,
        lift_option_type_def, return_def, raise_def] >>
   Cases_on `entry.value` >> simp[bind_def, return_def, raise_def] >>
-  Cases_on `vt` >> gvs[is_ArrayT_def, check_value_type_def,
-                        assignable_type_def, well_formed_type_def,
-                        evaluate_type_def, AllCaseEqs(), bind_def,
-                        return_def, raise_def, IS_SOME_EXISTS] >>
+  Cases_on `vt` >> gvs[is_ArrayT_def] >>
+  gvs[check_value_type_def, assignable_type_def, well_formed_type_def,
+      evaluate_type_def, AllCaseEqs(), bind_def, return_def, raise_def,
+      IS_SOME_EXISTS] >>
   rename [`evaluate_type (get_tenv cx) t = SOME elem_tv`,
           `type_slot_size (ArrayTV elem_tv bd)`] >>
   gvs[check_array_bounds_def, ignore_bind_def, lift_sum_def,

--- a/semantics/prop/vyperTypeConversionsScript.sml
+++ b/semantics/prop/vyperTypeConversionsScript.sml
@@ -16,6 +16,54 @@ Proof
   rw[bounded_decimal_op_def]
 QED
 
+Triviality uint_value_is_int[local]:
+  !m v. value_has_type (BaseTV (UintT m)) v ==> ?i. v = IntV i
+Proof
+  Cases_on `v` >> simp[value_has_type_def]
+QED
+
+Triviality sint_value_is_int[local]:
+  !m v. value_has_type (BaseTV (IntT m)) v ==> ?i. v = IntV i
+Proof
+  Cases_on `v` >> simp[value_has_type_def]
+QED
+
+Triviality bool_value_is_bool[local]:
+  !v. value_has_type (BaseTV BoolT) v ==> ?b. v = BoolV b
+Proof
+  Cases_on `v` >> simp[value_has_type_def]
+QED
+
+Triviality decimal_value_is_decimal[local]:
+  !v. value_has_type (BaseTV DecimalT) v ==> ?d. v = DecimalV d
+Proof
+  Cases_on `v` >> simp[value_has_type_def]
+QED
+
+Triviality bytes_value_is_bytes[local]:
+  !bd v. value_has_type (BaseTV (BytesT bd)) v ==> ?bs. v = BytesV bs
+Proof
+  Cases_on `bd` >> Cases_on `v` >> simp[value_has_type_def]
+QED
+
+Triviality address_value_is_bytes[local]:
+  !v. value_has_type (BaseTV AddressT) v ==> ?bs. v = BytesV bs
+Proof
+  Cases_on `v` >> simp[value_has_type_def]
+QED
+
+Triviality string_value_is_string[local]:
+  !n v. value_has_type (BaseTV (StringT n)) v ==> ?s. v = StringV s
+Proof
+  Cases_on `v` >> simp[value_has_type_def]
+QED
+
+Triviality flag_value_is_flag[local]:
+  !m v. value_has_type (FlagTV m) v ==> ?k. v = FlagV k
+Proof
+  Cases_on `v` >> simp[value_has_type_def]
+QED
+
 Theorem valid_conversion_no_type_error:
   valid_conversion from_ty to_ty /\
   evaluate_type (get_tenv cx) from_ty = SOME from_tv /\
@@ -27,12 +75,15 @@ Proof
   gvs[evaluate_type_builtin_def] >>
   Cases_on`from_ty` >> Cases_on`to_ty` >>
   gvs[valid_conversion_def, evaluate_type_def, AllCaseEqs()] >>
-  gvs[oneline value_has_type_def, evaluate_convert_def] >>
-  reverse(Cases_on`∃i. v = IntV i`)
-  >- (Cases_on`v` >> gvs[])
-  >> gvs[evaluate_convert_def]
-  >> Cases_on`v` >> gvs[]
-  >> gvs[evaluate_convert_def]
+  TRY (drule_all uint_value_is_int >> strip_tac >> gvs[]) >>
+  TRY (drule_all sint_value_is_int >> strip_tac >> gvs[]) >>
+  TRY (drule_all bool_value_is_bool >> strip_tac >> gvs[]) >>
+  TRY (drule_all decimal_value_is_decimal >> strip_tac >> gvs[]) >>
+  TRY (drule_all bytes_value_is_bytes >> strip_tac >> gvs[]) >>
+  TRY (drule_all address_value_is_bytes >> strip_tac >> gvs[]) >>
+  TRY (drule_all string_value_is_string >> strip_tac >> gvs[]) >>
+  TRY (drule_all flag_value_is_flag >> strip_tac >> gvs[]) >>
+  gvs[oneline value_has_type_def, evaluate_convert_def]
 QED
 
 Theorem evaluate_max_value_well_typed:

--- a/semantics/prop/vyperTypeEnvPreservationScript.sml
+++ b/semantics/prop/vyperTypeEnvPreservationScript.sml
@@ -227,8 +227,18 @@ Proof
   conj_tac >- ( rw[] >> res_tac >> gvs[]) >>
   conj_tac >- (
     rw[] >>
-    Cases_on`id = nm` >> gvs[lookup_scopes_def, FLOOKUP_UPDATE] >>
-    res_tac >> gvs[]) >>
+    Cases_on`id = nm` >>
+    ASM_SIMP_TAC std_ss [lookup_scopes_def, FLOOKUP_UPDATE] >>
+    FULL_SIMP_TAC std_ss [lookup_scopes_def, FLOOKUP_UPDATE, FLOOKUP_DEF,
+                          FDOM_FEMPTY, NOT_IN_EMPTY] >>
+    TRY (qpat_x_assum
+           `<|assignable := F; type := tyv; value := v|> = entry`
+           (SUBST_ALL_TAC o SYM) >> simp[]) >>
+    res_tac >>
+    TRY (qpat_x_assum `env.var_types ' id = ty`
+           (fn th => PURE_REWRITE_TAC [GSYM th]) >>
+         first_assum ACCEPT_TAC) >>
+    ASM_REWRITE_TAC[]) >>
   rw[] >> res_tac >> gvs[]
 QED
 

--- a/semantics/prop/vyperTypeEvalSoundnessScript.sml
+++ b/semantics/prop/vyperTypeEvalSoundnessScript.sml
@@ -2686,18 +2686,30 @@ Resume eval_all_type_sound_mutual[If]:
   simp_tac(srw_ss())[ignore_bind_def, bind_def] >>
   CASE_TAC >>
   reverse CASE_TAC >- (
-    strip_tac >> gvs[] >>
-    pop_assum mp_tac >>
+    strip_tac >> rpt BasicProvers.VAR_EQ_TAC >>
+    qpat_x_assum `push_scope st1 = (INR _,_)` mp_tac >>
     simp_tac(srw_ss())[push_scope_def,return_def]
   ) >>
   rename1 `eval_expr cx e st = (INL tv, st1)` >>
-  gvs[expr_result_typed_def, expr_runtime_typed_def, evaluate_type_def] >>
+  qpat_x_assum `well_typed_expr env e ==> _` mp_tac >>
+  (impl_tac >- first_assum ACCEPT_TAC) >>
+  pure_rewrite_tac[sumTheory.sum_case_def] >> BETA_TAC >> strip_tac >>
+  qpat_x_assum `expr_result_typed env e tv`
+    (strip_assume_tac o
+     REWRITE_RULE [expr_result_typed_def, expr_runtime_typed_def,
+                   evaluate_type_def]) >>
+  qpat_x_assum `evaluate_type env.type_defs (expr_type e) = SOME tv'` mp_tac >>
+  ASM_REWRITE_TAC[evaluate_type_def, vyperASTTheory.base_type_case_def] >> strip_tac >>
+  qpat_x_assum `SOME (BaseTV BoolT) = SOME tv'` mp_tac >>
+  disch_then (assume_tac o REWRITE_RULE [optionTheory.SOME_11]) >>
+  BasicProvers.VAR_EQ_TAC >>
   drule toplevel_value_typed_BoolTV >> strip_tac >>
   BasicProvers.VAR_EQ_TAC >>
   strip_tac >>
-  qpat_x_assum `IS_SOME (type_stmts env ret_ty ss)` mp_tac >>
-  qpat_x_assum `IS_SOME (type_stmts env ret_ty ss')` mp_tac >>
-  simp[optionTheory.IS_SOME_EXISTS] >> ntac 2 strip_tac >>
+  qpat_x_assum `IS_SOME (type_stmts env ret_ty ss)`
+    (strip_assume_tac o REWRITE_RULE [optionTheory.IS_SOME_EXISTS]) >>
+  qpat_x_assum `IS_SOME (type_stmts env ret_ty ss')`
+    (strip_assume_tac o REWRITE_RULE [optionTheory.IS_SOME_EXISTS]) >>
   irule scope_bracket_post >>
   conj_asm1_tac >- (
     irule env_consistent_env_maps_wf >> simp[] >>
@@ -2705,12 +2717,19 @@ Resume eval_all_type_sound_mutual[If]:
   ) >>
   qmatch_asmsub_abbrev_tac`finally body_fun pop_scope sf` >>
   qexistsl_tac[`body_fun`,`st1`] >>
-  simp[bind_def, ignore_bind_def] >>
+  PURE_REWRITE_TAC[bind_def, ignore_bind_def] >>
+  ASM_REWRITE_TAC[] >>
   first_x_assum (drule_then drule) >> strip_tac >>
   last_x_assum (drule_then drule) >> strip_tac >>
-  gvs[push_scope_def, return_def, finally_def] >>
+  qpat_x_assum `push_scope st1 = (INL x',sf)`
+    (strip_assume_tac o
+     SIMP_RULE (srw_ss()) [push_scope_def, return_def]) >>
+  rpt BasicProvers.VAR_EQ_TAC >>
+  pure_rewrite_tac[pairTheory.pair_case_def, sumTheory.sum_case_def] >>
+  BETA_TAC >> ASM_REWRITE_TAC[] >>
   qmatch_goalsub_abbrev_tac`body_fun st2` >>
-  Cases_on`body_fun st2` >> gvs[] >>
+  Cases_on`body_fun st2` >>
+  simp_tac std_ss [pairTheory.PAIR_EQ, sumTheory.sum_case_def] >>
   qmatch_assum_rename_tac`body_fun st2 = (rf,sf)` >>
   qho_match_abbrev_tac`P rf sf` >>
   irule switch_BoolV_post >>
@@ -2721,8 +2740,11 @@ Resume eval_all_type_sound_mutual[If]:
   `env_consistent env cx st2` by (simp[Abbr`st2`] >> irule push_scope_env_consistent >> simp[]) >>
   conj_tac >- (
     rpt gen_tac >> strip_tac >>
-    simp[Abbr`P`] >>
-    `state_well_typed st2` by gvs[Abbr`st2`, state_well_typed_def, scope_well_typed_def] >>
+    qunabbrev_tac`P` >> BETA_TAC >>
+    `state_well_typed st2` by (
+      irule push_scope_preserves_state_well_typed >>
+      qexists_tac `st1` >> qexists_tac `()` >>
+      simp[push_scope_def, return_def, Abbr`st2`]) >>
     first_x_assum drule_all >> strip_tac >>
     simp[] >>
     `st2 = st1 with scopes := FEMPTY::st1.scopes`
@@ -2748,7 +2770,7 @@ Resume eval_all_type_sound_mutual[If]:
         qpat_x_assum`env_consistent _ _ st1`mp_tac >>
         simp[env_consistent_def, env_scopes_consistent_def, IS_SOME_EXISTS]) >>
       conj_tac >- (
-        qexists_tac `x` >>
+        qexists_tac `x''` >>
         qexists_tac `ret_ty` >>
         qexists_tac `ss'` >> simp[] >>
         rpt strip_tac >> fs[] >>
@@ -2829,8 +2851,11 @@ Resume eval_all_type_sound_mutual[If]:
     irule env_extends_return_exception_typed >>
     qexists_tac `env_exn` >> simp[]) >>
   rpt gen_tac >> strip_tac >>
-  simp[Abbr`P`] >>
-  `state_well_typed st2` by gvs[Abbr`st2`, state_well_typed_def, scope_well_typed_def] >>
+  qunabbrev_tac`P` >> BETA_TAC >>
+  `state_well_typed st2` by (
+    irule push_scope_preserves_state_well_typed >>
+    qexists_tac `st1` >> qexists_tac `()` >>
+    simp[push_scope_def, return_def, Abbr`st2`]) >>
   first_x_assum drule_all >> strip_tac >>
   simp[] >>
   `st2 = st1 with scopes := FEMPTY::st1.scopes`
@@ -2856,7 +2881,7 @@ Resume eval_all_type_sound_mutual[If]:
       qpat_x_assum`env_consistent _ _ st1`mp_tac >>
       simp[env_consistent_def, env_scopes_consistent_def, IS_SOME_EXISTS]) >>
     conj_tac >- (
-      qexists_tac `x'` >>
+      qexists_tac `x` >>
       qexists_tac `ret_ty` >>
       qexists_tac `ss` >> simp[] >>
       rpt strip_tac >> fs[] >>
@@ -2871,7 +2896,7 @@ Resume eval_all_type_sound_mutual[If]:
       qpat_x_assum `!id entry. lookup_scopes id st1.scopes = SOME entry ==> _`
         (qspec_then `id` mp_tac) >> simp[] >> metis_tac[]) >>
     qexists_tac `st1` >> simp[] >>
-    qspecl_then [`cx`, `ss`, `FEMPTY`, `st1`, `INL x''`, `st1'`]
+    qspecl_then [`cx`, `ss`, `FEMPTY`, `st1`, `INL ()`, `st1'`]
       mp_tac (GEN_ALL eval_stmts_scope_bracket_gen_preserves_tv) >>
     simp[] >>
     disch_then irule >>
@@ -2879,7 +2904,7 @@ Resume eval_all_type_sound_mutual[If]:
     `stp = st1 with scopes updated_by CONS FEMPTY` by simp[Abbr`stp`] >>
     pop_assum SUBST1_TAC >>
     irule(CONJUNCT1(CONJUNCT2 eval_preserves_tv)) >>
-    qexists_tac `INL x''` >> qexists_tac `ss` >> simp[] >>
+    qexists_tac `INL ()` >> qexists_tac `ss` >> simp[] >>
     gvs[Abbr`stp`]) >>
   Cases_on `st1'.scopes` >> gvs[]
   >- (drule eval_stmts_preserves_scopes_len >> simp[]) >>

--- a/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
+++ b/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
@@ -1008,7 +1008,17 @@ Proof
            else return ())`,
        `lock_st with scopes := [env]`, `body_final_res`, `body_final_st`]
       mp_tac finally_preserves_state_predicate >>
-    simp[] >> metis_tac[]) >>
+    simp[] >> strip_tac >>
+    qpat_x_assum `_ ==> contract_storage_well_formed cx body_final_st` irule >>
+    rpt gen_tac >> strip_tac >>
+    qpat_x_assum
+      `!s r s'. contract_storage_well_formed cx s /\
+         do pop_function prev; _ od s = (r,s') ==>
+         contract_storage_well_formed cx s'`
+      (qspecl_then [`s`, `r`, `s'`] mp_tac) >>
+    ASM_REWRITE_TAC[] >> strip_tac >>
+    qpat_x_assum `_ ==> contract_storage_well_formed cx s'` irule >>
+    simp[]) >>
   Cases_on `body_final_res` >>
   gvs[] >>
   rename1 `safe_cast rtv rv` >>
@@ -1446,8 +1456,6 @@ Resume eval_all_storage_preservation_mutual[Targets_cons]:
     Cases_on `q` >> gvs[bind_def] >> rpt strip_tac >> gvs[]) >>
   rpt strip_tac >> gvs[]
 QED
-
-val _ = export_theory();
 
 Resume eval_all_storage_preservation_mutual[RaiseReason]:
   rpt gen_tac >> strip_tac >>
@@ -3166,8 +3174,11 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_ExtCall]:
               rewrite_tac[return_def, raise_def] >>
               Cases_on `NULL (lookup_account target_addr args_st.accounts).code` >>
               rewrite_tac[return_def, raise_def]
-              >- (strip_tac >> gvs[assert_def, bind_def, return_def, raise_def,
-                                    get_accounts_def, get_transient_storage_def] >>
+              >- (strip_tac >>
+                  qpat_x_assum `_ args_st = (res,st')` mp_tac >>
+                  simp[assert_def, bind_def, return_def, raise_def,
+                       get_accounts_def, get_transient_storage_def] >>
+                  strip_tac >> rpt BasicProvers.VAR_EQ_TAC >>
                   metis_tac[runtime_storage_consistent_storage]) >>
               simp_tac(srw_ss())[return_def, get_accounts_def, assert_def,
                                  get_transient_storage_def, raise_def, bind_def] >>

--- a/semantics/vyperSmallStepScript.sml
+++ b/semantics/vyperSmallStepScript.sml
@@ -1615,13 +1615,36 @@ Proof
      Pattern: unfold both sides, use IH for eval_exprs, match continuation bodies. *)
   (* Chain interaction builtins: all use same tactic.
      CPS evals exprs then calls apply_vals which matches big-step body. *)
-  \\ rpt (conj_tac >- (
+  \\ conj_tac >- (
     rw[eval_expr_cps_def, evaluate_def, ignore_bind_def, bind_def]
     \\ gvs[prod_CASE_rator, sum_CASE_rator, cont_def]
-    \\ CASE_TAC \\ gvs[]
-    \\ CASE_TAC \\ gvs[]
+    \\ CASE_TAC \\ gvs[] \\ CASE_TAC \\ gvs[]
     \\ rw[Once OWHILE_THM, nextk_def, stepk_def,
-          apply_exc_def, apply_vals_def, ignore_bind_def, bind_def]))
+          apply_exc_def, apply_vals_def, ignore_bind_def, bind_def])
+  \\ conj_tac >- (
+    rw[eval_expr_cps_def, evaluate_def, ignore_bind_def, bind_def]
+    \\ gvs[prod_CASE_rator, sum_CASE_rator, cont_def]
+    \\ CASE_TAC \\ gvs[] \\ CASE_TAC \\ gvs[]
+    \\ rw[Once OWHILE_THM, nextk_def, stepk_def,
+          apply_exc_def, apply_vals_def, ignore_bind_def, bind_def])
+  \\ conj_tac >- (
+    rw[eval_expr_cps_def, evaluate_def, ignore_bind_def, bind_def]
+    \\ gvs[prod_CASE_rator, sum_CASE_rator, cont_def]
+    \\ CASE_TAC \\ gvs[] \\ CASE_TAC \\ gvs[]
+    \\ rw[Once OWHILE_THM, nextk_def, stepk_def,
+          apply_exc_def, apply_vals_def, ignore_bind_def, bind_def])
+  \\ conj_tac >- (
+    rw[eval_expr_cps_def, evaluate_def, ignore_bind_def, bind_def]
+    \\ gvs[prod_CASE_rator, sum_CASE_rator, cont_def]
+    \\ CASE_TAC \\ gvs[] \\ CASE_TAC \\ gvs[]
+    \\ rw[Once OWHILE_THM, nextk_def, stepk_def,
+          apply_exc_def, apply_vals_def, ignore_bind_def, bind_def])
+  \\ conj_tac >- (
+    rw[eval_expr_cps_def, evaluate_def, ignore_bind_def, bind_def]
+    \\ gvs[prod_CASE_rator, sum_CASE_rator, cont_def]
+    \\ CASE_TAC \\ gvs[] \\ CASE_TAC \\ gvs[]
+    \\ rw[Once OWHILE_THM, nextk_def, stepk_def,
+          apply_exc_def, apply_vals_def, ignore_bind_def, bind_def])
   \\ conj_tac >- rw[eval_expr_cps_def, evaluate_def, return_def] (* eval_exprs [] *)
   (* eval_exprs (e::es) *)
   \\ rw[eval_expr_cps_def, evaluate_def, bind_def]

--- a/venom/analysis/base_ptr/proofs/basePtrProofsScript.sml
+++ b/venom/analysis/base_ptr/proofs/basePtrProofsScript.sml
@@ -14,7 +14,7 @@
 Theory basePtrProofs
 Ancestors
   basePtrDefs venomExecSemantics venomWf memLocDefs venomInstProofs
-  venomMemProps finite_map list pred_set venomInst
+  venomExecProofs venomMemProps finite_map list pred_set venomInst
 
 (* Transfer function only modifies the output variable's pointer set. *)
 Theorem bp_handle_inst_other_var_proof:
@@ -67,8 +67,7 @@ Theorem terminator_no_outputs[local]:
   ∀inst. inst_wf inst ∧ is_terminator inst.inst_opcode ⇒
     inst.inst_outputs = []
 Proof
-  rpt strip_tac >> Cases_on `inst.inst_opcode` >>
-  gvs[venomInstTheory.is_terminator_def, venomWfTheory.inst_wf_def]
+  ACCEPT_TAC venomExecProofsTheory.terminator_no_outputs
 QED
 
 (* FOLDL update_var preserves lookup for vars not in output list *)

--- a/venom/analysis/cfg/proofs/cfgCorrectnessProofScript.sml
+++ b/venom/analysis/cfg/proofs/cfgCorrectnessProofScript.sml
@@ -435,12 +435,16 @@ Theorem ce_preorder_order_false:
   INDEX_OF "b" (cfg_dfs_pre (cfg_analyze ce_fn3)) = SOME 2 /\
   ~(3 < 2)
 Proof
-  simp[ce_fn3_def] >> cfg_eval_tac >>
-  (* Need to show ~RTC ... "b" "a". Since succs "b" = [], only RTC refl.
-     "b" ≠ "a", so not reachable. *)
-  rpt strip_tac >>
-  qpat_x_assum `(λa b. _)^* "b" "a"` mp_tac >>
-  simp[Once relationTheory.RTC_CASES1]
+  simp[ce_fn3_def] >> rpt conj_tac
+  >- cfg_eval_tac
+  >- cfg_eval_tac
+  >- (cfg_eval_tac >>
+      (* Since succs "b" = [], RTC only permits the reflexive case. *)
+      rpt strip_tac >>
+      qpat_x_assum `(λa b. _)^* "b" "a"` mp_tac >>
+      simp[Once relationTheory.RTC_CASES1])
+  >- cfg_eval_tac
+  >- cfg_eval_tac
 QED
 
 (* ==========================================================================

--- a/venom/analysis/dataflow/proofs/dfAnalyzeProofsScript.sml
+++ b/venom/analysis/dataflow/proofs/dfAnalyzeProofsScript.sml
@@ -843,24 +843,33 @@ Theorem df_fold_forward_invariant:
     (!inst v. MEM inst instrs /\ P v ==> P (transfer inst v)) ==>
     P fv /\ !k v. FLOOKUP im k = SOME v ==> P v
 Proof
-  Induct >> rpt strip_tac >> fs[df_fold_forward_def, LET_THM]
-  (* Base: P fv = P acc *)
-  >- rw[]
-  (* Base: FLOOKUP (inst_map |+ ((lbl,idx),acc)) k = SOME v *)
-  >- (rw[] >> fs[finite_mapTheory.FLOOKUP_UPDATE] >>
+  Induct
+  >- (rpt gen_tac >> strip_tac >>
+      qpat_x_assum `df_fold_forward transfer lbl [] idx acc inst_map = (fv,im)`
+        mp_tac >>
+      simp[Once df_fold_forward_def] >> strip_tac >> gvs[] >>
+      rpt gen_tac >> strip_tac >>
+      fs[finite_mapTheory.FLOOKUP_UPDATE] >>
       Cases_on `(lbl,idx) = k` >> fs[] >> res_tac)
-  (* Inductive: both P fv and P v — apply IH to recursive fold call *)
-  >> (first_x_assum (qspecl_then [`transfer`, `lbl`, `idx+1`,
-        `transfer h acc`, `inst_map |+ ((lbl,idx),acc)`,
-        `fv`, `im`, `P`] mp_tac) >>
-      impl_tac >- (
-        rpt conj_tac
-        >- rw[]
-        >- (first_x_assum match_mp_tac >> rw[])
-        >- (rw[finite_mapTheory.FLOOKUP_UPDATE] >>
-            Cases_on `(lbl,idx) = k'` >> fs[] >> res_tac)
-        >- (rpt strip_tac >> first_x_assum match_mp_tac >> rw[])
-      ) >> metis_tac[])
+  >> rpt gen_tac >> strip_tac >>
+  qpat_x_assum
+    `df_fold_forward transfer lbl (h::instrs) idx acc inst_map = (fv,im)`
+    mp_tac >>
+  CONV_TAC (LAND_CONV (LHS_CONV
+    (ONCE_REWRITE_CONV [df_fold_forward_def]))) >>
+  simp[LET_THM] >> strip_tac >>
+  (* Inductive: apply the IH to the recursive fold call. *)
+  first_x_assum (qspecl_then [`transfer`, `lbl`, `idx+1`,
+    `transfer h acc`, `inst_map |+ ((lbl,idx),acc)`,
+    `fv`, `im`, `P`] mp_tac) >>
+  impl_tac >- (
+    rpt conj_tac
+    >- rw[]
+    >- (first_x_assum match_mp_tac >> rw[])
+    >- (rw[finite_mapTheory.FLOOKUP_UPDATE] >>
+        Cases_on `(lbl,idx) = k'` >> fs[] >> res_tac)
+    >- (rpt strip_tac >> first_x_assum match_mp_tac >> rw[])
+  ) >> metis_tac[]
 QED
 
 (* Generic invariant: forward fold from FEMPTY (df_fold_block Forward) *)
@@ -1554,8 +1563,12 @@ Proof
       Cases_on `k = (lbl,idx)` >> fs[finite_mapTheory.FLOOKUP_UPDATE] >>
       metis_tac[])
   (* step case *)
-  >> fs[dfAnalyzeDefsTheory.df_fold_backward_def, LET_THM] >>
-     pairarg_tac >> fs[] >> rw[]
+  >> qpat_x_assum
+       `df_fold_backward transfer lbl (h::instrs) idx acc inst_map = (fv,im)`
+       mp_tac >>
+     CONV_TAC (LAND_CONV (LHS_CONV
+       (ONCE_REWRITE_CONV [dfAnalyzeDefsTheory.df_fold_backward_def]))) >>
+     strip_tac >> fs[LET_THM] >> pairarg_tac >> fs[] >> rw[]
      (* P (transfer h acc') *)
      >- (qpat_x_assum `!transfer lbl idx acc inst_map fv im. _`
            (qspecl_then [`transfer`, `lbl`, `idx+1`, `acc`, `inst_map`,

--- a/venom/analysis/dominators/proofs/dominatorProofsScript.sml
+++ b/venom/analysis/dominators/proofs/dominatorProofsScript.sml
@@ -3987,7 +3987,8 @@ Proof
         metis_tac[preds_of_unreachable]) >>
       (* Show dom_joined fn st lbl = fn_labels fn *)
       `dom_joined fn st lbl = fn_labels fn` by (
-        simp[dom_joined_def, dfAnalyzeDefsTheory.df_joined_val_def, LET_THM] >>
+        simp_tac std_ss
+          [dom_joined_def, dfAnalyzeDefsTheory.df_joined_val_def, LET_THM] >>
         `MAP (\nbr. dom_edge_transfer () nbr lbl
                       (df_boundary (fn_labels fn) st nbr))
              (cfg_preds_of (cfg_analyze fn) lbl) =

--- a/venom/analysis/liveness/proofs/livenessProofsScript.sml
+++ b/venom/analysis/liveness/proofs/livenessProofsScript.sml
@@ -278,8 +278,31 @@ Proof
   >- (fs[df_fold_backward_def, LET_THM] >> rw[] >>
       Cases_on `k = (lbl,idx)` >> fs[FLOOKUP_UPDATE] >> metis_tac[])
   (* Step: h::instrs *)
-  >> fs[df_fold_backward_def, LET_THM] >>
-     pairarg_tac >> fs[] >> rw[]
+  >> qpat_x_assum
+       `df_fold_backward transfer lbl (h::instrs) idx acc inst_map = (fv,im)`
+       mp_tac >>
+     CONV_TAC (LAND_CONV (LHS_CONV
+       (ONCE_REWRITE_CONV [df_fold_backward_def]))) >>
+     strip_tac >> pop_assum mp_tac >>
+     PURE_ONCE_REWRITE_TAC [LET_THM] >> strip_tac >>
+     pairarg_tac >>
+     qpat_x_assum
+       `df_fold_backward transfer lbl instrs (idx + 1) acc inst_map =
+        (acc',inst_map')`
+       (fn fold_eq =>
+         qpat_x_assum
+           `_ (df_fold_backward transfer lbl instrs (idx + 1) acc inst_map) =
+            (fv,im)`
+           (fn result_eq =>
+             ASSUME_TAC fold_eq >>
+             STRIP_ASSUME_TAC (SIMP_RULE std_ss
+               [fold_eq, LET_THM, pairTheory.PAIR_EQ] result_eq))) >>
+     qpat_x_assum `transfer h acc' = fv`
+       (fn th => ONCE_REWRITE_TAC [GSYM th]) >>
+     qpat_x_assum
+       `inst_map' |+ ((lbl,idx),transfer h acc') = im`
+       (fn th => ONCE_REWRITE_TAC [GSYM th]) >>
+     conj_tac
      (* P (transfer h acc') *)
      >- (qpat_x_assum `!transfer lbl idx acc inst_map fv im P. _`
            (qspecl_then [`transfer`, `lbl`, `idx+1`, `acc`, `inst_map`,

--- a/venom/analysis/mem_ssa/proofs/memSSAProofsScript.sml
+++ b/venom/analysis/mem_ssa/proofs/memSSAProofsScript.sml
@@ -4184,7 +4184,10 @@ Proof
   pop_assum mp_tac >> pop_assum mp_tac >> pop_assum mp_tac >>
   pop_assum mp_tac >> pop_assum mp_tac >>
   simp[mem_ssa_reaching_in_block_def] >>
-  rpt CASE_TAC >> simp[] >>
+  CASE_TAC >> simp[] >>
+  CASE_TAC >> simp[] >>
+  CASE_TAC >> simp[] >>
+  CASE_TAC >> simp[] >>
   rpt strip_tac >> gvs[] >>
   (* Resolve phi contradiction cases *)
   TRY (fs[block_maps_correct_def] >> res_tac >> gvs[] >> NO_TAC) >>
@@ -6066,7 +6069,13 @@ Proof
   pairarg_tac >> gvs[] >>
   `MEM x visited1` by (Cases_on `result` >> gvs[] >> res_tac) >>
   Cases_on `result` >> gvs[] >>
-  metis_tac[]
+  rename1 `mem_ssa_collect_phi_clobbers walker visited1 ops =
+             (next_clobbers, visited')` >>
+  qpat_x_assum `!walker visited clobbers visited'. _`
+    (qspecl_then [`walker`, `visited1`, `next_clobbers`, `visited'`]
+       mp_tac) >>
+  ASM_REWRITE_TAC[] >>
+  strip_tac >> res_tac
 QED
 
 (* Visited monotonicity for walk_clobber *)
@@ -7058,22 +7067,16 @@ Proof
   Cases_on `mem_ssa_collect_phi_clobbers walker wr_vis ops` >>
   rename1 `_ = (cr_res, cr_vis)` >>
   simp[] >> disch_tac >>
-  (* Extract everything from the conjunction, then kill the original *)
-  `?rd0 pred0. MEM (rd0, pred0) ((op_rd,op_pred)::ops) /\
-    (!vis vis'. ~MEM def_id vis /\ walker vis rd0 = (NONE, vis') ==>
-       MEM def_id vis')` by (fs[] >> metis_tac[]) >>
-  `~MEM def_id visited` by fs[] >>
-  `!v rd r v'. walker v rd = (r,v') ==> !x. MEM x v ==> MEM x v'`
-    by fs[] >>
+  (* Split the conjunction before simplifying its individual facts. *)
+  qpat_x_assum `(case _ of NONE => _ | SOME _ => _) = _ /\ _`
+    strip_assume_tac >>
   `wr_res = NONE /\ cr_res = [] /\ cr_vis = visited'` by (
-    `(case wr_res of NONE => (cr_res,cr_vis)
-       | SOME c => (c::cr_res,cr_vis)) = ([],visited')` by fs[] >>
-    Cases_on `wr_res` >> fs[]) >>
-  (* Kill the original big conjunction — we've extracted everything *)
-  qpat_x_assum `(case _ of NONE => _ | SOME _ => _) = _ /\ _` kall_tac >>
-  (* Case-split on whether rd0 is in head or tail BEFORE gvs *)
-  `rd0 = op_rd \/ MEM (rd0, pred0) ops` by fs[MEM] >>
-  qpat_x_assum `MEM _ (_::_)` kall_tac
+    Cases_on `wr_res`
+    >- (qpat_x_assum `(case _ of NONE => _ | SOME _ => _) = _`
+          mp_tac >> simp[])
+    >- (qpat_x_assum `(case _ of NONE => _ | SOME _ => _) = _`
+          mp_tac >> simp[]))
+  (* strip_assume_tac has already split MEM on the head and tail. *)
   (* Head case: rd0 = op_rd *)
   >- (
     qpat_x_assum `!w v1 v2 v3. mem_ssa_collect_phi_clobbers _ _ _ = _ /\ _ ==> _` kall_tac >>
@@ -7087,7 +7090,9 @@ Proof
     disch_then drule >> disch_then (qspec_then `def_id` mp_tac) >> simp[])
   (* Tail case: MEM (rd0, pred0) ops *)
   >> (
-    gvs[] >>
+    qpat_x_assum `wr_res = NONE` SUBST_ALL_TAC >>
+    qpat_x_assum `cr_res = []` SUBST_ALL_TAC >>
+    qpat_x_assum `cr_vis = visited'` SUBST_ALL_TAC >>
     Cases_on `MEM def_id wr_vis`
     >- (
       qpat_x_assum `mem_ssa_collect_phi_clobbers _ _ _ = _`
@@ -7095,7 +7100,7 @@ Proof
           |> REWRITE_RULE [GSYM AND_IMP_INTRO])) >>
       disch_then drule >> disch_then (qspec_then `def_id` mp_tac) >> simp[])
     >> (
-      first_x_assum (qspecl_then [`walker`, `wr_vis`, `cr_vis`, `def_id`] mp_tac) >>
+      first_x_assum (qspecl_then [`walker`, `wr_vis`, `visited'`, `def_id`] mp_tac) >>
       simp[] >> disch_then irule >>
       conj_tac >| [
         first_assum ACCEPT_TAC,
@@ -7894,7 +7899,10 @@ Triviality node_succ_in_mono:
     node_succ_in ms y v2
 Proof
   rw[node_succ_in_def] >>
-  rpt CASE_TAC >> gvs[] >>
+  Cases_on `FLOOKUP ms.ms_nodes y` >> gvs[] >>
+  rename1 `FLOOKUP ms.ms_nodes y = SOME node` >>
+  Cases_on `node` >> gvs[] >>
+  CASE_TAC >> gvs[] >>
   TRY (metis_tac[]) >>
   gvs[EVERY_MEM, FORALL_PROD] >> metis_tac[]
 QED
@@ -7955,17 +7963,36 @@ Proof
   >> Cases_on `h`
   >> PURE_REWRITE_TAC [mem_ssa_collect_phi_clobbers_def, LET_THM]
   >> BETA_TAC
-  >> pairarg_tac >> simp[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"]
-  >> pairarg_tac >> simp[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"]
+  >> pairarg_tac >> ASM_REWRITE_TAC[] >> BETA_TAC
+  >> pairarg_tac >> ASM_REWRITE_TAC[] >> BETA_TAC
   >> strip_tac
   >> reverse (Cases_on `result`)
-  >- fs[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"]
-  >> fs[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"]
+  >- (qpat_x_assum `(SOME x,visited1) = (result',visited1')` mp_tac >>
+      PURE_REWRITE_TAC[pairTheory.PAIR_EQ] >> strip_tac >>
+      qpat_x_assum `SOME x = result'` (assume_tac o SYM) >>
+      qpat_x_assum `visited1 = visited1'` (assume_tac o SYM) >>
+      strip_tac >>
+      `F` by (
+        qpat_x_assum `_ = ([],visited'')` mp_tac >> BETA_TAC >>
+        ASM_REWRITE_TAC[] >>
+        Cases_on `mem_ssa_collect_phi_clobbers
+          (λv rd. mem_ssa_walk_clobber ms fuel v rd qloc) visited1 ops` >>
+        simp[]) >>
+      qpat_x_assum `F` mp_tac >> simp[])
+  >> qpat_x_assum `(NONE,visited1) = (result',visited1')` mp_tac
+  >> PURE_REWRITE_TAC[pairTheory.PAIR_EQ] >> strip_tac
+  >> qpat_x_assum `NONE = result'` (assume_tac o SYM)
+  >> qpat_x_assum `visited1 = visited1'` (assume_tac o SYM)
+  >> qpat_x_assum `_ = ([],visited'')` mp_tac
+  >> ASM_REWRITE_TAC[pairTheory.UNCURRY, optionTheory.option_case_def]
+  >> BETA_TAC >> ASM_REWRITE_TAC[optionTheory.option_case_def]
+  >> strip_tac
   >> sg `fuel >= CARD (FDOM ms.ms_nodes DIFF set visited1)`
-  >- (mp_tac (Q.SPECL [`FDOM ms.ms_nodes`, `visited`, `visited1`, `fuel`]
+  >- (irule (Q.SPECL [`FDOM ms.ms_nodes`, `visited`, `visited1`, `fuel`]
         fuel_diff_mono) >>
-      simp[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"] >>
-      metis_tac[walk_clobber_visited_mono])
+      rpt conj_tac
+      >- simp[]
+      >- metis_tac[walk_clobber_visited_mono])
   >> first_x_assum (qspecl_then [`ms`, `fuel`, `qloc`, `visited1`, `visited''`]
        mp_tac)
   >> (impl_tac >- (rpt conj_tac >> first_assum ACCEPT_TAC))
@@ -7989,26 +8016,36 @@ Proof
          (qspec_then `y` mp_tac) >> simp[])
   (* Part 2: each (rd,pred) in ops has rd in visited'' *)
   >> rpt strip_tac
+  >> Cases_on `(rd,pred) = (q,r)`
   (* Case: rd = q (head element) *)
   >- (
     gvs[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"] >>
-    sg `fuel >= 1`
-    >- (irule fuel_positive_lemma >>
-        qexists_tac `FDOM ms.ms_nodes DIFF set visited` >>
-        qexists_tac `q` >>
-        simp[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"]) >>
-    sg `MEM q visited1`
-    >- (Cases_on `fuel` >- gvs[] >>
-        drule walk_clobber_visits_current >>
-        simp[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"]) >>
-    drule collect_phi_walk_visited_mono >> metis_tac[])
+    `fuel >= 1` by
+      (irule fuel_positive_lemma >>
+       qexists_tac `FDOM ms.ms_nodes DIFF set visited` >>
+       qexists_tac `q` >>
+       simp[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"]) >>
+    `MEM q visited1` by
+      (Cases_on `fuel` >- gvs[] >>
+       drule walk_clobber_visits_current >>
+       simp[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"]) >>
+    mp_tac (Q.SPECL [`ops`, `ms`, `fuel`, `qloc`, `visited1`, `[]`,
+      `visited''`] collect_phi_walk_visited_mono) >>
+    ASM_REWRITE_TAC[] >> strip_tac >>
+    qpat_x_assum `!x. MEM x visited1 ==> MEM x visited''`
+      (qspec_then `q` mp_tac) >> ASM_REWRITE_TAC[])
   (* Case: MEM (rd,pred) ops *)
-  >> Cases_on `MEM rd visited1`
-  >- (drule collect_phi_walk_visited_mono >> metis_tac[])
-  >> qpat_x_assum `!rd' pred'. MEM (rd',pred') ops /\ _ ==> _`
-       (qspecl_then [`rd`, `pred`] mp_tac) >>
-  simp[Excl "CARD_DIFF_EQN", Excl "CARD_DIFF"] >>
-  metis_tac[walk_clobber_visited_mono]
+  >> `MEM (rd,pred) ops` by
+       (qpat_x_assum `MEM (rd,pred) ((q,r)::ops)` mp_tac >> simp[]) >>
+  Cases_on `MEM rd visited1`
+  >- (mp_tac (Q.SPECL [`ops`, `ms`, `fuel`, `qloc`, `visited1`, `[]`,
+        `visited''`] collect_phi_walk_visited_mono) >>
+      ASM_REWRITE_TAC[] >> strip_tac >>
+      qpat_x_assum `!x. MEM x visited1 ==> MEM x visited''`
+        (qspec_then `rd` mp_tac) >> ASM_REWRITE_TAC[]) >>
+  qpat_x_assum `!rd' pred'. MEM (rd',pred') ops /\ _ ==> _`
+    (qspecl_then [`rd`, `pred`] mp_tac) >>
+  ASM_REWRITE_TAC[]
 QED
 
 (* Key lemma: new nodes in NONE walk output have node_succ_in.

--- a/venom/analysis/variable_range/proofs/rangeAnalysisProofsScript.sml
+++ b/venom/analysis/variable_range/proofs/rangeAnalysisProofsScript.sml
@@ -1592,8 +1592,14 @@ Proof
     fs[listTheory.DROP_LENGTH_NIL,
        dfAnalyzeDefsTheory.df_fold_forward_def]
     \\ qpat_x_assum `exec_block _ _ _ _ = OK _` mp_tac
-    \\ asm_simp_tac std_ss [Once exec_block_def, get_instruction_def]
-    \\ simp[]
+    \\ PURE_ONCE_REWRITE_TAC[exec_block_def]
+    \\ ASM_REWRITE_TAC[get_instruction_def]
+    \\ IF_CASES_TAC
+    >- (qpat_x_assum `LENGTH bb.bb_instructions <
+          LENGTH bb.bb_instructions` mp_tac \\ simp[])
+    \\ PURE_ONCE_REWRITE_TAC[optionTheory.option_case_def]
+    \\ strip_tac
+    \\ qpat_x_assum `Error _ = OK _` mp_tac \\ simp[]
   )
   \\ `idx < LENGTH bb.bb_instructions` by DECIDE_TAC
   \\ `DROP idx bb.bb_instructions =
@@ -1601,7 +1607,8 @@ Proof
        imp_res_tac rich_listTheory.DROP_CONS_EL \\ fs[])
   \\ asm_simp_tac std_ss [dfAnalyzeDefsTheory.df_fold_forward_def, LET_THM]
   \\ qpat_x_assum `exec_block _ _ _ _ = OK _` mp_tac
-  \\ asm_simp_tac std_ss [Once exec_block_def, get_instruction_def]
+  \\ PURE_ONCE_REWRITE_TAC[exec_block_def]
+  \\ ASM_REWRITE_TAC[get_instruction_def]
   \\ Cases_on `step_inst fuel ctx (EL idx bb.bb_instructions) s`
   \\ simp[] \\ rename [`step_inst _ _ _ _ = OK step_st`]
   \\ reverse (Cases_on `is_terminator (EL idx bb.bb_instructions).inst_opcode`)
@@ -2488,6 +2495,20 @@ End
 
 (* ===== range_apply_condition_sound ===== *)
 
+Triviality dfg_eq_literal_constraints[local]:
+  !env lhs rhs.
+    (!u wu wl. lhs = Var u /\ rhs = Lit wl /\
+               FLOOKUP env u = SOME wu ==> wu = wl) /\
+    (!u wu wl. rhs = Var u /\ lhs = Lit wl /\
+               FLOOKUP env u = SOME wu ==> wu = wl) ==>
+    !v literal. (lhs = Var v /\ rhs = Lit literal \/
+                 rhs = Var v /\ lhs = Lit literal) ==>
+      !actual. FLOOKUP env v = SOME actual ==> actual = literal
+Proof
+  rpt gen_tac >> strip_tac >> rpt gen_tac >> strip_tac >>
+  rpt gen_tac >> strip_tac >> gvs[]
+QED
+
 (* Soundness of range_apply_condition: if the DFG accurately reflects
    the execution state, and the condition operand's truth value matches
    is_true, then applying the condition refinement preserves in_range_state. *)
@@ -2533,9 +2554,16 @@ Proof
       irule range_apply_eq_sound >> simp[] >>
       strip_tac >>
       `dfg_eq_sound dfg env` by fs[dfg_sound_def] >>
-      pop_assum mp_tac >> simp[dfg_eq_sound_def] >>
-      disch_then drule >> simp[] >> strip_tac >>
-      rpt conj_tac >> rpt strip_tac >> gvs[] >> res_tac >> gvs[])
+      pop_assum mp_tac >> PURE_REWRITE_TAC[dfg_eq_sound_def] >>
+      disch_then (qspecl_then [`s`, `x`, `h`, `h'`] mp_tac) >>
+      impl_tac >- simp[] >>
+      disch_then (qspec_then `w` mp_tac) >> simp[] >> strip_tac >>
+      rpt conj_tac
+      >- (rpt strip_tac >> gvs[] >> res_tac >> gvs[])
+      >- (qspecl_then [`env`, `h`, `h'`] mp_tac
+            dfg_eq_literal_constraints >>
+          impl_tac >- (conj_tac >> FIRST_ASSUM ACCEPT_TAC) >>
+          simp[]))
   \\ IF_CASES_TAC
   (* COMPARE: LT/GT/SLT/SGT *)
   >- (gvs[] >>

--- a/venom/codegen/proofs/allocMonoScript.sml
+++ b/venom/codegen/proofs/allocMonoScript.sml
@@ -842,8 +842,7 @@ Proof
   (* JMP reorder *)
   `ps2.ps_alloc.sa_fn_eom = ps1.ps_alloc.sa_fn_eom` by
     (qpat_x_assum `(if _ then _ else _) = (join_ops,ps2)` mp_tac >>
-     IF_CASES_TAC >> gvs[] >> strip_tac >> gvs[] >>
-     every_case_tac >> gvs[] >> metis_tac[reorder_plan_fn_eom]) >>
+     simp[AllCaseEqs()] >> metis_tac[reorder_plan_fn_eom]) >>
   `ps3 = ps2` by
     (qpat_x_assum `(if _ then _ else _) = (operands',ps3)` mp_tac >>
      rpt IF_CASES_TAC >> gvs[] >> strip_tac >> gvs[]) >>
@@ -885,8 +884,8 @@ Proof
   (* JMP reorder *)
   `ps1.ps_alloc.sa_next_offset <= ps2.ps_alloc.sa_next_offset` by
     (qpat_x_assum `(if _ then _ else _) = (join_ops,ps2)` mp_tac >>
-     IF_CASES_TAC >> gvs[] >> strip_tac >> gvs[] >>
-     every_case_tac >> gvs[] >> metis_tac[reorder_plan_next_offset]) >>
+     simp[AllCaseEqs()] >> strip_tac >> gvs[] >>
+     metis_tac[reorder_plan_next_offset]) >>
   `ps3 = ps2` by
     (qpat_x_assum `(if _ then _ else _) = (operands',ps3)` mp_tac >>
      rpt IF_CASES_TAC >> gvs[] >> strip_tac >> gvs[]) >>

--- a/venom/codegen/proofs/genBlockSimScript.sml
+++ b/venom/codegen/proofs/genBlockSimScript.sml
@@ -703,7 +703,9 @@ Proof
   qpat_x_assum `step_inst _ _ _ _ = Halt _` mp_tac >>
   simp[Once step_inst_def] >>
   Cases_on `is_terminator RETURN` >> simp[] >>
-  simp[step_inst_base_def] >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = RETURN`
+    (fn th => PURE_REWRITE_TAC[th]) >>
   every_case_tac >> gvs[halt_state_def, set_returndata_def]
 QED
 
@@ -725,7 +727,9 @@ Proof
   qpat_x_assum `step_inst _ _ _ _ = Abort _ _` mp_tac >>
   simp[Once step_inst_def] >>
   Cases_on `is_terminator REVERT` >> simp[] >>
-  simp[step_inst_base_def] >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = REVERT`
+    (fn th => PURE_REWRITE_TAC[th]) >>
   every_case_tac >> gvs[revert_state_def, set_returndata_def]
 QED
 
@@ -753,7 +757,9 @@ Proof
   qpat_x_assum `step_inst _ _ _ _ = Halt _` mp_tac >>
   simp[Once step_inst_def] >>
   Cases_on `is_terminator SELFDESTRUCT` >> simp[] >>
-  simp[step_inst_base_def] >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = SELFDESTRUCT`
+    (fn th => PURE_REWRITE_TAC[th]) >>
   every_case_tac >> gvs[halt_state_def, LET_THM]
 QED
 
@@ -775,8 +781,11 @@ Proof
   qpat_x_assum `step_inst _ _ _ _ = Abort _ _` mp_tac >>
   simp[Once step_inst_def] >>
   Cases_on `is_terminator RETURNDATACOPY` >> simp[] >>
-  simp[step_inst_base_def] >>
-  every_case_tac >> gvs[halt_state_def, set_returndata_def]
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = RETURNDATACOPY`
+    (fn th => PURE_REWRITE_TAC[th]) >>
+  every_case_tac >> gvs[halt_state_def, set_returndata_def] >>
+  IF_CASES_TAC >> gvs[halt_state_def, set_returndata_def]
 QED
 
 (* What step_inst ASSERT_UNREACHABLE abort produces *)
@@ -794,7 +803,9 @@ Proof
   qpat_x_assum `step_inst _ _ _ _ = Abort _ _` mp_tac >>
   simp[Once step_inst_def] >>
   Cases_on `is_terminator ASSERT_UNREACHABLE` >> simp[] >>
-  simp[step_inst_base_def] >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = ASSERT_UNREACHABLE`
+    (fn th => PURE_REWRITE_TAC[th]) >>
   every_case_tac
 QED
 
@@ -1535,9 +1546,13 @@ Resume gen_inst_abort_sim[invalid]:
    vs' = vs with <| vs_returndata := []; vs_halted := T |>` by
     (qpat_x_assum `step_inst _ _ _ _ = _` mp_tac >>
      simp[Once step_inst_def] >>
-     Cases_on `is_terminator inst.inst_opcode` >> simp[] >>
-     simp[step_inst_base_def] >>
-     Cases_on `inst.inst_opcode` >> gvs[halt_state_def, set_returndata_def]) >>
+     qpat_x_assum `inst.inst_opcode = INVALID`
+       (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+     simp[is_terminator_def] >>
+     ONCE_REWRITE_TAC[step_inst_base_def] >>
+     qpat_x_assum `inst.inst_opcode = INVALID`
+       (fn th => PURE_REWRITE_TAC[th]) >>
+     simp[halt_state_def, set_returndata_def]) >>
   gvs[] >>
   (* Use gen_inst_terminal_setup to get AsmOK intermediate *)
   qspecl_then [`fuel`, `ctx`, `label_offsets`, `offset_to_pc`, `prog`,
@@ -2286,7 +2301,13 @@ Proof
   (* step_inst for PARAM: vs' = update_var out val vs *)
   qpat_x_assum `step_inst _ _ _ _ = OK _` mp_tac >>
   simp[step_inst_def, step_inst_base_def] >>
-  rpt (CASE_TAC >> simp[]) >> strip_tac >> gvs[] >>
+  TRY CASE_TAC >> simp[] >>
+  TRY CASE_TAC >> simp[] >>
+  TRY CASE_TAC >> simp[] >>
+  TRY CASE_TAC >> simp[] >>
+  TRY CASE_TAC >> simp[] >>
+  TRY CASE_TAC >> simp[] >>
+  strip_tac >> gvs[] >>
   (* venom_asm_rel preserved: out is fresh *)
   irule venom_asm_rel_update_var >>
   simp[] >> conj_tac

--- a/venom/codegen/proofs/opcodeClassScript.sml
+++ b/venom/codegen/proofs/opcodeClassScript.sml
@@ -117,8 +117,13 @@ Proof
   rpt strip_tac >>
   drule terminator_opcode_cases >> strip_tac >> gvs[] >>
   qpat_x_assum `step_inst_base inst vs = Halt vs'` mp_tac >>
-  ASM_REWRITE_TAC[step_inst_base_def] >>
-  gvs[AllCaseEqs()]
+  ASM_REWRITE_TAC[step_inst_base_def]
+  >- gvs[AllCaseEqs()]
+  >- gvs[AllCaseEqs()]
+  >- gvs[AllCaseEqs()]
+  >- gvs[AllCaseEqs()]
+  >- gvs[AllCaseEqs()]
+  >- gvs[AllCaseEqs()]
 QED
 
 Triviality step_inst_base_abort_terminator_opcodes[local]:

--- a/venom/codegen/proofs/prefixSimScript.sml
+++ b/venom/codegen/proofs/prefixSimScript.sml
@@ -97,8 +97,16 @@ Theorem prefix_mstore_preserves[local]:
     asm_step lo o2pc (AsmOp "MSTORE") st = AsmOK st' ==> ^side_fields
 Proof
   rpt strip_tac \\
-  fs(all_handler_defs) \\
-  every_case_tac \\ gvs[]
+  qpat_x_assum `asm_step _ _ _ _ = AsmOK _` mp_tac \\
+  PURE_ONCE_REWRITE_TAC[asm_step_def] \\
+  simp_tac std_ss [] \\
+  PURE_ONCE_REWRITE_TAC[asm_step_op_def] \\
+  simp[asm_step_arith_def] \\
+  simp[asm_step_compare_def] \\
+  simp[asm_step_bitwise_def] \\
+  simp[asm_step_memory_def] \\
+  simp[asm_mstore_def, LET_THM, asm_next_def] \\
+  every_case_tac \\ rpt strip_tac \\ gvs[]
 QED
 
 Theorem prefix_mload_preserves[local]:

--- a/venom/codegen/proofs/stackOpSimScript.sml
+++ b/venom/codegen/proofs/stackOpSimScript.sml
@@ -390,7 +390,8 @@ Theorem asm_step_context_pc[local]:
 Proof
   rw[asm_step_context_def, asm_push_val_def, asm_state_unop_def,
      asm_next_def, LET_THM] >>
-  asm_next_pc_tac
+  simp[] >>
+  every_case_tac >> gvs[]
 QED
 
 Theorem asm_dup_pc[local]:

--- a/venom/passes/affine_folding/proofs/affineFoldingProofsScript.sml
+++ b/venom/passes/affine_folding/proofs/affineFoldingProofsScript.sml
@@ -850,9 +850,8 @@ Theorem af_rewrite_inst_not_phi[local]:
     af_rewrite_inst dfg vi inst = SOME result ==>
     result.inst_opcode <> PHI
 Proof
-  simp[af_rewrite_inst_def, vi_base_def, vi_offset_def,
-       af_extract_val_lit_def, af_extract_sub_val_lit_def] >>
-  rpt gen_tac >> rpt (BasicProvers.PURE_CASE_TAC >> gvs[]) >> rw[] >> gvs[]
+  rpt strip_tac >>
+  drule af_rewrite_inst_cases >> strip_tac >> gvs[]
 QED
 
 Theorem af_transform_inst_not_phi[local]:

--- a/venom/passes/assert_combiner/proofs/acAbortProofsScript.sml
+++ b/venom/passes/assert_combiner/proofs/acAbortProofsScript.sml
@@ -591,6 +591,27 @@ Proof
     metis_tac[] >> metis_tac[optionTheory.IS_SOME_DEF]
 QED
 
+Triviality cand_preds_eval_transfer[local]:
+  !cands mp dfg insts s_t V mc mc_h h s_iz.
+    ac_sim_precond cands mp dfg insts s_t V /\
+    MEM mc cands /\ MEM mc_h cands /\
+    mc_h.mc_second_id = h.inst_id /\
+    (!opr. (!x. opr = Var x ==>
+       x <> ac_or_var h.inst_id /\ x <> ac_iz_var h.inst_id) ==>
+       eval_operand opr s_iz = eval_operand opr s_t) ==>
+    IS_SOME (eval_operand mc.mc_second_pred s_iz) /\
+    IS_SOME (eval_operand mc.mc_first_pred s_iz)
+Proof
+  rpt gen_tac >> strip_tac >>
+  qspecl_then [`cands`, `mp`, `dfg`, `insts`, `s_t`, `V`, `mc`, `mc_h`]
+    mp_tac ac_sim_precond_cand_eval_fresh >>
+  impl_tac >- (rpt conj_tac >> first_assum ACCEPT_TAC) >>
+  strip_tac >>
+  conj_tac >> irule eval_transfer_is_some >>
+  rpt conj_tac >> TRY (first_assum ACCEPT_TAC) >>
+  rpt strip_tac >> metis_tac[]
+QED
+
 Triviality alookup_extended_mp_or_iz_fresh[local]:
   !h insts cands mp dfg s V id x mc i.
     ac_sim_precond cands mp dfg (h::insts) s V /\
@@ -671,7 +692,14 @@ Proof
       >- ((`MEM i (h::insts)` by metis_tac[MEM]) >>
           metis_tac[ac_sim_precond_def]))
   (* G2: pred_op output freshness *)
-  >- (simp_tac (srw_ss()) [operand_11] >> metis_tac[MEM, ac_sim_precond_def])
+  >- (simp_tac (srw_ss()) [operand_11] >> rpt strip_tac >>
+      `MEM i (h::insts)` by simp[] >>
+      qspecl_then
+        [`cands`, `mp`, `dfg`, `h::insts`, `s_t`, `V`, `i`,
+         `ac_or_var h.inst_id`, `mc_h`] mp_tac
+        ac_sim_precond_outputs_fresh_for_cands >>
+      impl_tac >- (rpt conj_tac >> first_assum ACCEPT_TAC) >>
+      simp[])
   (* G3: operand eval transfer *)
   >- (rpt strip_tac >>
       (`MEM i (h::insts)` by metis_tac[MEM]) >>
@@ -687,7 +715,8 @@ Proof
       metis_tac[ac_sim_precond_def, ac_cands_ordered_def, MEM])
   (* G6: cand pred eval transfer *)
   >- (rpt strip_tac >>
-      metis_tac[eval_transfer_is_some, ac_sim_precond_def])
+      drule_all_then strip_assume_tac cand_preds_eval_transfer >>
+      first_assum ACCEPT_TAC)
   (* G7: ALOOKUP mp_new or/iz freshness *)
   >- metis_tac[alookup_extended_mp_or_iz_fresh]
   (* G8: ALOOKUP mp_new eval *)

--- a/venom/passes/assert_combiner/proofs/acChainProofsScript.sml
+++ b/venom/passes/assert_combiner/proofs/acChainProofsScript.sml
@@ -735,6 +735,23 @@ Proof
   )
 QED
 
+(* Shared helper tactic for the non-output cases of ac_dfg_inv_step_ssa. *)
+fun ac_ssa_case2_tac op_name =
+  (Q.SUBGOAL_THEN `lookup_var v s' = lookup_var v s` ASSUME_TAC >-
+    metis_tac[step_preserves_non_output_vars]) >>
+  (Q.SUBGOAL_THEN `IS_SOME (lookup_var v s)` ASSUME_TAC >- gvs[]) >>
+  (Q.SUBGOAL_THEN `!op'. MEM op' inst.inst_operands ==>
+     eval_operand op' s' = eval_operand op' s` ASSUME_TAC >-
+    (rpt strip_tac >>
+     first_x_assum (qspecl_then [`v`, `inst`, `op'`] mp_tac) >>
+     simp[])) >>
+  qpat_x_assum `ac_dfg_inv dfg s` mp_tac >>
+  simp[ac_dfg_inv_def] >> strip_tac >>
+  first_x_assum (qspecl_then [`v`, `inst`, op_name] mp_tac) >>
+  simp[] >> strip_tac >>
+  first_x_assum (qspecl_then [op_name] mp_tac) >>
+  simp[MEM] >> strip_tac >> gvs[]
+
 (* SSA-friendly variant: replaces no-redefine with a weaker condition
    that DFG-tracked operand variables are not among h's outputs.
    This is derivable from SSA ordering (def_dominates_uses). *)
@@ -773,24 +790,6 @@ Proof
       >- metis_tac[step_preserves_non_output_vars]
       >- metis_tac[step_preserves_labels, ac_is_safe_between_def,
                    venomInstPropsTheory.step_preserves_labels])) >>
-  (* Shared helper tactic for Case 2: v not in h's outputs *)
-  let val case2_tac = fn op_name =>
-    (Q.SUBGOAL_THEN `lookup_var v s' = lookup_var v s` ASSUME_TAC >-
-      metis_tac[step_preserves_non_output_vars]) >>
-    (Q.SUBGOAL_THEN `IS_SOME (lookup_var v s)` ASSUME_TAC >- gvs[]) >>
-    (Q.SUBGOAL_THEN `!op'. MEM op' inst.inst_operands ==>
-       eval_operand op' s' = eval_operand op' s` ASSUME_TAC >-
-      (rpt strip_tac >>
-       first_x_assum (qspecl_then [`v`, `inst`, `op'`] mp_tac) >>
-       simp[])) >>
-    qpat_x_assum `ac_dfg_inv dfg s` mp_tac >>
-    simp[ac_dfg_inv_def] >> strip_tac >>
-    first_x_assum (qspecl_then [`v`, `inst`, op_name] mp_tac) >>
-    simp[] >> strip_tac >>
-    first_x_assum (qspecl_then [op_name] mp_tac) >>
-    simp[MEM] >> strip_tac >>
-    gvs[]
-  in
   simp[ac_dfg_inv_def] >> rpt conj_tac
   >- (
     (* ISZERO conjunct *)
@@ -810,7 +809,7 @@ Proof
       imp_res_tac step_iszero_con >>
       gvs[update_var_def, lookup_var_def,
           finite_mapTheory.FLOOKUP_UPDATE])
-    >- case2_tac `input_op`)
+    >- ac_ssa_case2_tac `input_op`)
   >- (
     (* ASSIGN conjunct *)
     rpt gen_tac >> strip_tac >>
@@ -829,8 +828,7 @@ Proof
       imp_res_tac step_assign_con >>
       gvs[update_var_def, lookup_var_def, eval_operand_def,
           finite_mapTheory.FLOOKUP_UPDATE])
-    >- case2_tac `src_op`)
-  end
+    >- ac_ssa_case2_tac `src_op`)
 QED
 
 
@@ -1638,7 +1636,23 @@ Proof
   rpt gen_tac >> strip_tac >>
   `!dfg' p'. ALL_DISTINCT (MAP (\mc. mc.mc_second_id)
      (ac_scan_block dfg' insts p'))` by metis_tac[] >>
-  rpt (CASE_TAC >> gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP]) >>
+  gvs[LET_THM, ALL_DISTINCT, MAP, MEM_MAP] >>
   spose_not_then strip_assume_tac >>
   drule ac_scan_second_id_mem >> strip_tac >>
   gvs[ALL_DISTINCT, MEM_MAP]

--- a/venom/passes/assert_combiner/proofs/acSimPrecondProofsScript.sml
+++ b/venom/passes/assert_combiner/proofs/acSimPrecondProofsScript.sml
@@ -323,6 +323,30 @@ Proof
   >> metis_tac[]
 QED
 
+(* Branch-local solver for lookup obligations introduced by mp extension. *)
+fun ac_extend_mp_lookup_tac () =
+  rpt strip_tac >>
+  qmatch_asmsub_rename_tac `if id = key then SOME pred else ALOOKUP mp key` >>
+  Cases_on `id = key`
+  >- (gvs[] >> metis_tac[])
+  >- (gvs[] >> metis_tac[])
+
+fun ac_extend_mp_candidate_tac () =
+  rpt gen_tac >> strip_tac >>
+  qmatch_asmsub_rename_tac `if id = key then SOME pred else ALOOKUP mp key` >>
+  Cases_on `id = key`
+  >- (qpat_x_assum `(if id = key then SOME pred else ALOOKUP mp key) = _`
+        mp_tac >> ASM_REWRITE_TAC[] >> simp[] >> strip_tac >>
+      qpat_x_assum `!mc x. MEM mc cands /\ pred = Var x /\ _ ==> _`
+        (qspecl_then [`mc`, `x`] mp_tac) >>
+      impl_tac
+      >- (rpt conj_tac
+          >- FIRST_ASSUM ACCEPT_TAC
+          >- ASM_REWRITE_TAC[]
+          >- (qexists_tac `i` >> ASM_REWRITE_TAC[])) >>
+      ASM_REWRITE_TAC[] >> simp[])
+  >- (gvs[] >> metis_tac[])
+
 (* mp extension without head drop *)
 Triviality ac_sim_precond_extend_mp[local]:
   !cands mp id pred dfg insts s V.
@@ -338,19 +362,9 @@ Proof
   rpt strip_tac >>
   qpat_x_assum `ac_sim_precond _ _ _ _ _ _` mp_tac >>
   simp[ac_sim_precond_def] >> strip_tac >>
-  rpt conj_tac >> TRY (metis_tac[])
-  >- (rpt strip_tac >>
-      qmatch_asmsub_rename_tac `if id = key then SOME pred else ALOOKUP mp key` >>
-      Cases_on `id = key` >> gvs[] >> metis_tac[])
-  >- (rpt strip_tac >>
-      qmatch_asmsub_rename_tac `if id = key then SOME pred else ALOOKUP mp key` >>
-      Cases_on `id = key` >> gvs[] >> metis_tac[])
-  >- (rpt strip_tac >>
-      qmatch_asmsub_rename_tac `if id = key then SOME pred else ALOOKUP mp key` >>
-      Cases_on `id = key` >> gvs[] >> metis_tac[])
-  >- (rpt strip_tac >>
-      qmatch_asmsub_rename_tac `if id = key then SOME pred else ALOOKUP mp key` >>
-      Cases_on `id = key` >> gvs[] >> metis_tac[])
+  rpt conj_tac >> TRY (metis_tac[]) >|
+  [ac_extend_mp_lookup_tac (), ac_extend_mp_candidate_tac (),
+   ac_extend_mp_lookup_tac (), ac_extend_mp_lookup_tac ()]
 QED
 
 (* Head-drop + mp extension: compose transfer_same + extend_mp *)
@@ -414,6 +428,29 @@ Theorem ac_sim_precond_outputs_notin_V:
   !cands mp dfg insts s V.
     ac_sim_precond cands mp dfg insts s V ==>
     (!i x. MEM i insts /\ MEM x i.inst_outputs ==> x NOTIN V)
+Proof
+  simp[ac_sim_precond_def] >> metis_tac[]
+QED
+
+Theorem ac_sim_precond_outputs_fresh_for_cands:
+  !cands mp dfg insts s V i x mc.
+    ac_sim_precond cands mp dfg insts s V /\
+    MEM i insts /\ MEM x i.inst_outputs /\ MEM mc cands ==>
+    x <> ac_or_var mc.mc_second_id /\
+    x <> ac_iz_var mc.mc_second_id
+Proof
+  simp[ac_sim_precond_def] >> metis_tac[]
+QED
+
+Theorem ac_sim_precond_cand_eval_fresh:
+  !cands mp dfg insts s V mc mc'.
+    ac_sim_precond cands mp dfg insts s V /\
+    MEM mc cands /\ MEM mc' cands ==>
+    IS_SOME (eval_operand mc.mc_second_pred s) /\
+    IS_SOME (eval_operand mc.mc_first_pred s) /\
+    (!x. (mc.mc_second_pred = Var x \/ mc.mc_first_pred = Var x) ==>
+      x <> ac_or_var mc'.mc_second_id /\
+      x <> ac_iz_var mc'.mc_second_id)
 Proof
   simp[ac_sim_precond_def] >> metis_tac[]
 QED

--- a/venom/passes/assert_combiner/proofs/assertCombinerProofsScript.sml
+++ b/venom/passes/assert_combiner/proofs/assertCombinerProofsScript.sml
@@ -1522,7 +1522,11 @@ Triviality ac_apply_merge_step_no_phi:
 Proof
   Cases_on `st` >>
   rw[ac_apply_merge_step_def, LET_THM] >>
-  rpt (CASE_TAC >> gvs[EVERY_APPEND])
+  TRY CASE_TAC >> gvs[EVERY_APPEND] >>
+  TRY CASE_TAC >> gvs[EVERY_APPEND] >>
+  TRY CASE_TAC >> gvs[EVERY_APPEND] >>
+  TRY CASE_TAC >> gvs[EVERY_APPEND] >>
+  TRY CASE_TAC >> gvs[EVERY_APPEND]
 QED
 
 Triviality ac_apply_merge_fold_no_phi:

--- a/venom/passes/assert_elim/proofs/assertElimProofsScript.sml
+++ b/venom/passes/assert_elim/proofs/assertElimProofsScript.sml
@@ -64,7 +64,15 @@ Theorem step_inst_assert_1:
           then Abort Revert_abort (revert_state (set_returndata [] s))
           else OK s
 Proof
-  rpt strip_tac >> simp[step_inst_def, step_inst_base_def]
+  rpt strip_tac >>
+  ONCE_REWRITE_TAC[step_inst_def] >>
+  qpat_x_assum `inst.inst_opcode = ASSERT`
+    (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+  simp[is_terminator_def] >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = ASSERT`
+    (fn th => PURE_REWRITE_TAC[th]) >>
+  simp[]
 QED
 
 Theorem step_inst_assert_bad_arity[local]:
@@ -75,7 +83,15 @@ Theorem step_inst_assert_bad_arity[local]:
     (!a b rest. inst.inst_operands = a::b::rest ==>
        step_inst fuel ctx inst s = Error "assert requires 1 operand")
 Proof
-  rpt strip_tac >> simp[step_inst_def, step_inst_base_def]
+  rpt strip_tac >>
+  ONCE_REWRITE_TAC[step_inst_def] >>
+  qpat_x_assum `inst.inst_opcode = ASSERT`
+    (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+  simp[is_terminator_def] >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = ASSERT`
+    (fn th => PURE_REWRITE_TAC[th]) >>
+  simp[]
 QED
 
 (* in_range_state implies in_range for any looked-up variable *)

--- a/venom/passes/assert_elim/proofs/dfgSoundStepScript.sml
+++ b/venom/passes/assert_elim/proofs/dfgSoundStepScript.sml
@@ -259,13 +259,19 @@ Proof
   Cases_on `v = k`
   >- (* v = k: use new-key hypothesis *)
      (`w = nv` by (qpat_x_assum `FLOOKUP _ v = _` mp_tac >>
-                   simp[FLOOKUP_UPDATE]) >>
+                   PURE_REWRITE_TAC[finite_mapTheory.FLOOKUP_UPDATE] >>
+                   ASM_REWRITE_TAC[] >> strip_tac >>
+                   qpat_x_assum `SOME nv = SOME w`
+                     (assume_tac o REWRITE_RULE[optionTheory.SOME_11]) >>
+                   ASM_REWRITE_TAC[]) >>
       rw[] >> first_x_assum drule_all >> strip_tac >>
       rpt conj_tac >> rpt strip_tac >>
       res_tac >> metis_tac[flookup_thm])
   >> (* v <> k: use old dfg_eq_sound *)
-     qpat_x_assum `FLOOKUP _ v = _` mp_tac >> simp[FLOOKUP_UPDATE] >>
-     strip_tac >>
+     `k <> v` by metis_tac[] >>
+     qpat_x_assum `FLOOKUP _ v = _` mp_tac >>
+     PURE_REWRITE_TAC[finite_mapTheory.FLOOKUP_UPDATE] >>
+     ASM_REWRITE_TAC[] >> strip_tac >>
      qpat_x_assum `dfg_eq_sound _ _` mp_tac >>
      PURE_ONCE_REWRITE_TAC [dfg_eq_sound_def] >> strip_tac >>
      first_x_assum drule_all >> strip_tac >>
@@ -404,17 +410,15 @@ Proof
   Induct >> simp[fn_insts_blocks_def, MEM_APPEND] >> metis_tac[]
 QED
 
-(* Helper: if step_inst_base adds a new variable to vs_vars,
-   it must be the single output. Key link for SSA derivation. *)
-Theorem step_inst_base_new_var_singleton:
-  !inst s s' v.
-    step_inst_base inst s = OK s' /\
-    ~is_terminator inst.inst_opcode /\
-    v NOTIN FDOM s.vs_vars /\ v IN FDOM s'.vs_vars ==>
-    inst.inst_outputs = [v]
-Proof
-  rw[step_inst_base_def] >>
-  gvs[AllCaseEqs(), is_terminator_def] >>
+(* A well-formed non-INVOKE instruction has at most one output. *)
+fun inst_wf_output_tac () = rpt strip_tac >> gvs[]
+
+fun dfg_eq_condition_tac () =
+  simp[exec_pure2_def, eval_operand_def, lookup_var_def,
+       update_var_def, FLOOKUP_DEF, bool_to_word_def] >>
+  rpt strip_tac >> gvs[FUPD11_SAME_KEY_AND_BASE, AllCaseEqs()]
+
+fun step_vars_fupdate_finish_tac () =
   fs[exec_pure1_def, exec_pure2_def, exec_pure3_def,
      exec_read0_def, exec_read1_def, exec_write2_def,
      exec_ext_call_def, exec_delegatecall_def,
@@ -426,6 +430,54 @@ Proof
      write_memory_with_expansion_def, mcopy_def,
      revert_state_def, eval_operands_def,
      lookup_var_def, FLOOKUP_UPDATE, FDOM_FUPDATE]
+
+Theorem inst_wf_noninvoke_outputs_at_most_one:
+  !inst. inst_wf inst /\ inst.inst_opcode <> INVOKE ==>
+    LENGTH inst.inst_outputs <= 1
+Proof
+  PURE_ONCE_REWRITE_TAC[inst_wf_def] >>
+  Cases_on `inst.inst_opcode` >|
+  [inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (),
+   inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac (), inst_wf_output_tac ()]
+QED
+
+(* Helper: if a well-formed step_inst_base adds a new variable to vs_vars,
+   it must be the single output. Key link for SSA derivation. *)
+Theorem step_inst_base_new_var_singleton:
+  !inst s s' v.
+    step_inst_base inst s = OK s' /\ inst_wf inst /\
+    ~is_terminator inst.inst_opcode /\
+    v NOTIN FDOM s.vs_vars /\ v IN FDOM s'.vs_vars ==>
+    inst.inst_outputs = [v]
+Proof
+  rpt strip_tac >>
+  `inst.inst_opcode <> INVOKE` by
+    (CCONTR_TAC >> gvs[step_inst_base_def]) >>
+  `inst.inst_opcode <> PHI` by
+    (CCONTR_TAC >> gvs[step_inst_base_def]) >>
+  `FDOM s'.vs_vars = FDOM s.vs_vars UNION set inst.inst_outputs` by
+    (irule venomExecPropsTheory.step_inst_base_fdom >> simp[]) >>
+  `v IN FDOM s.vs_vars UNION set inst.inst_outputs` by
+    (qpat_x_assum `FDOM s'.vs_vars = _` (SUBST1_TAC o SYM) >>
+     first_assum ACCEPT_TAC) >>
+  `v IN set inst.inst_outputs` by
+    (qpat_x_assum `v NOTIN FDOM s.vs_vars` mp_tac >>
+     qpat_x_assum `v IN FDOM s.vs_vars UNION _` mp_tac >>
+     simp[] >> metis_tac[]) >>
+  `LENGTH inst.inst_outputs <= 1` by
+    metis_tac[inst_wf_noninvoke_outputs_at_most_one] >>
+  Cases_on `inst.inst_outputs` >> gvs[] >>
+  Cases_on `t` >> gvs[]
 QED
 
 (* Helper: if step_inst_base adds a new output to FDOM, the resulting
@@ -440,18 +492,22 @@ Theorem step_inst_base_vars_fupdate:
     s'.vs_vars = s.vs_vars |+ (out, THE (FLOOKUP s'.vs_vars out))
 Proof
   rw[step_inst_base_def] >>
-  gvs[AllCaseEqs(), is_terminator_def] >>
-  fs[exec_pure1_def, exec_pure2_def, exec_pure3_def,
-     exec_read0_def, exec_read1_def, exec_write2_def,
-     exec_ext_call_def, exec_delegatecall_def,
-     exec_create_def, exec_alloca_def,
-     extract_venom_result_def] >>
-  gvs[AllCaseEqs()] >>
-  rpt (CHANGED_TAC (rpt (pairarg_tac >> gvs[]))) >>
-  gvs[update_var_def, mstore_def, mstore8_def, sstore_def, tstore_def,
-     write_memory_with_expansion_def, mcopy_def,
-     revert_state_def, eval_operands_def,
-     lookup_var_def, FLOOKUP_UPDATE, FDOM_FUPDATE]
+  gvs[AllCaseEqs(), is_terminator_def] >|
+  [step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (),
+   step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac (), step_vars_fupdate_finish_tac ()]
 QED
 
 (* SSA uniqueness: DFG entry for a variable maps to the unique instruction
@@ -569,10 +625,10 @@ Proof
   >- ((* EQ *)
       rpt strip_tac >> gvs[MEM] >>
       qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
-      simp[step_inst_base_def, exec_pure2_def, eval_operand_def,
-           lookup_var_def, update_var_def, FLOOKUP_DEF,
-           bool_to_word_def] >>
-      rpt strip_tac >> gvs[FUPD11_SAME_KEY_AND_BASE, AllCaseEqs()]) >>
+      PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[] >|
+      [dfg_eq_condition_tac (), dfg_eq_condition_tac (),
+       dfg_eq_condition_tac ()]) >>
   (* LT/GT/SLT/SGT *)
   rpt strip_tac >> gvs[MEM] >>
   qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
@@ -692,12 +748,14 @@ Theorem dfg_sound_step_inst_new_var:
 Proof
   rpt gen_tac >> DISCH_TAC >> fs[] >>
   (* Derive key facts *)
+  `inst_wf inst` by metis_tac[fn_insts_inst_wf] >>
   `inst.inst_outputs = [out]` by
-    metis_tac[step_inst_base_new_var_singleton] >>
+    (mp_tac (Q.SPECL [`inst`, `s`, `s'`, `out`]
+       step_inst_base_new_var_singleton) >>
+     impl_tac >- simp[] >> simp[]) >>
   `s'.vs_vars = s.vs_vars |+ (out, THE (FLOOKUP s'.vs_vars out))` by
     metis_tac[step_inst_base_vars_fupdate] >>
   qabbrev_tac `nv = THE (FLOOKUP s'.vs_vars out)` >>
-  `inst_wf inst` by metis_tac[fn_insts_inst_wf] >>
   (* SSA uniqueness: dfg entry for out maps to inst *)
   `!dinst0. dfg_get_def (dfg_build_function fn) out = SOME dinst0 ==>
      dinst0 = inst` by (

--- a/venom/passes/assign_elim/proofs/assignElimSoundScript.sml
+++ b/venom/passes/assign_elim/proofs/assignElimSoundScript.sml
@@ -119,7 +119,12 @@ Proof
   `inst.inst_opcode <> INVOKE` by simp[] >>
   `step_inst fuel ctx inst s = step_inst_base inst s`
     by metis_tac[step_inst_non_invoke] >>
-  simp[step_inst_base_def] >>
+  qpat_x_assum `step_inst fuel ctx inst s = step_inst_base inst s`
+    (fn th => PURE_REWRITE_TAC[th]) >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = ASSIGN`
+    (fn th => PURE_REWRITE_TAC[th]) >>
+  simp[] >>
   Cases_on `inst.inst_operands` >> simp[] >>
   Cases_on `t` >> simp[] >>
   Cases_on `inst.inst_outputs` >> simp[] >>

--- a/venom/passes/branch_opt/proofs/branchOptProofsScript.sml
+++ b/venom/passes/branch_opt/proofs/branchOptProofsScript.sml
@@ -382,16 +382,23 @@ Proof
   (* SOME case: simplify original's case expression *)
   rename1 `FLOOKUP st.vs_vars v = SOME val` >>
   Cases_on `val = 0w` >> simp[jump_to_def] >>
-  (* Unroll transformed exec_block for the JNZ step *)
-  ONCE_REWRITE_TAC[exec_block_def] >>
-  gvs[venomInstTheory.get_instruction_def, step_inst_non_invoke,
-      venomInstTheory.is_terminator_def, EL_APPEND2,
-      listTheory.LENGTH_FRONT,
-      step_inst_base_def, eval_operand_def, lookup_var_def,
-      FLOOKUP_UPDATE, bool_to_word_def, jump_to_def] >>
-  IF_CASES_TAC >>
-  simp[lift_result_def, state_equiv_def, execution_equiv_def,
-       lookup_var_def, FLOOKUP_UPDATE]
+  (* Unroll transformed exec_block for the JNZ step.  Keep the two value
+     branches separate so simplification does not traverse both large goals. *)
+  ONCE_REWRITE_TAC[exec_block_def]
+  >- (gvs[venomInstTheory.get_instruction_def, step_inst_non_invoke,
+          venomInstTheory.is_terminator_def, EL_APPEND2,
+          listTheory.LENGTH_FRONT, step_inst_base_def, eval_operand_def,
+          lookup_var_def, FLOOKUP_UPDATE, bool_to_word_def, jump_to_def] >>
+      IF_CASES_TAC >>
+      simp[lift_result_def, state_equiv_def, execution_equiv_def,
+           lookup_var_def, FLOOKUP_UPDATE])
+  >- (gvs[venomInstTheory.get_instruction_def, step_inst_non_invoke,
+          venomInstTheory.is_terminator_def, EL_APPEND2,
+          listTheory.LENGTH_FRONT, step_inst_base_def, eval_operand_def,
+          lookup_var_def, FLOOKUP_UPDATE, bool_to_word_def, jump_to_def] >>
+      IF_CASES_TAC >>
+      simp[lift_result_def, state_equiv_def, execution_equiv_def,
+           lookup_var_def, FLOOKUP_UPDATE])
 QED
 
 (* ISZERO insertion: original has N instructions, transformed has N+1.
@@ -920,8 +927,47 @@ Theorem branch_opt_phi_prefix_length[local]:
     phi_prefix_length bb.bb_instructions
 Proof
   rw[branch_opt_block_def, LET_THM] >> fs[NULL_EQ] >>
-  rpt (CASE_TAC >> gvs[phi_prefix_length_front_append1_non_phi,
-                       phi_prefix_length_front_append2_non_phi])
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       gvs[phi_prefix_length_front_append1_non_phi,
+           phi_prefix_length_front_append2_non_phi]) >>
+  gvs[phi_prefix_length_front_append1_non_phi,
+      phi_prefix_length_front_append2_non_phi]
 QED
 
 Theorem branch_opt_phi_prefix_el[local]:
@@ -932,7 +978,20 @@ Theorem branch_opt_phi_prefix_el[local]:
 Proof
   rpt strip_tac >>
   rw[branch_opt_block_def, LET_THM] >> fs[NULL_EQ] >>
-  rpt (CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  gvs[] >>
   `phi_prefix_length bb.bb_instructions < LENGTH bb.bb_instructions` by
     (irule phi_prefix_length_lt_last_non_phi >> simp[]) >>
   simp[EL_FRONT_APPEND1, EL_FRONT_APPEND2]
@@ -974,11 +1033,33 @@ Theorem bo_block_sim_from_phi_idx[local]:
 Proof
   rpt strip_tac >> gvs[] >>
   simp[branch_opt_block_def, LET_THM] >>
-  rpt (CASE_TAC >> simp[lift_result_refl, state_equiv_refl, execution_equiv_refl])
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >>
+       simp[lift_result_refl, state_equiv_refl, execution_equiv_refl])
   >- (
     irule lift_result_subset >> qexists_tac `{}` >> simp[EMPTY_SUBSET] >>
-    `inst_wf x` by
-      (qspecl_then [`fn`, `s'`, `x`] mp_tac dfg_inst_wf >> simp[]) >>
+    `inst_wf x` by (drule_all dfg_inst_wf >> simp[]) >>
     `?op. x.inst_operands = [op]` by
       (irule iszero_operand_singleton >> simp[]) >>
     pop_assum strip_assume_tac >>
@@ -998,21 +1079,6 @@ Proof
       (irule phi_prefix_length_lt_last_non_phi >> fs[NULL_EQ]) >>
     irule (SIMP_RULE (srw_ss()) [LET_THM] bo_block_sim_iszero_insertion_from_idx) >>
     simp[])
-  >- (
-    irule lift_result_subset >> qexists_tac `{}` >> simp[EMPTY_SUBSET] >>
-    `inst_wf x` by
-      (qspecl_then [`fn`, `s'`, `x`] mp_tac dfg_inst_wf >> simp[]) >>
-    `?op. x.inst_operands = [op]` by
-      (irule iszero_operand_singleton >> simp[]) >>
-    pop_assum strip_assume_tac >>
-    `phi_prefix_length bb.bb_instructions < LENGTH bb.bb_instructions` by
-      (irule phi_prefix_length_lt_last_non_phi >> fs[NULL_EQ]) >>
-    gvs[] >>
-    irule (SIMP_RULE (srw_ss()) [LET_THM] bo_block_sim_iszero_removal_from_idx) >>
-    simp[] >>
-    qexistsl_tac [`dfg_build_function fn`, `x`] >> simp[] >>
-    rpt strip_tac >>
-    first_x_assum irule >> simp[])
 QED
 
 Theorem bo_same_block_run_block_equiv[local]:

--- a/venom/passes/cfg_normalization/proofs/cfgNormBaseScript.sml
+++ b/venom/passes/cfg_normalization/proofs/cfgNormBaseScript.sml
@@ -1095,7 +1095,7 @@ Theorem step_inst_update_phi_other[local]:
     step_inst fuel ctx inst s
 Proof
   rw[step_inst_def, is_terminator_def] >>
-  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> simp[] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> ASM_REWRITE_TAC[] >>
   simp[resolve_phi_update_phi_ops_other]
 QED
 
@@ -1884,8 +1884,10 @@ Triviality step_inst_base_ok_terminator_jump:
     inst.inst_opcode = DJMP
 Proof
   rpt strip_tac >>
-  Cases_on `inst.inst_opcode` >> gvs[is_terminator_def] >>
-  term_ok_jump_tac
+  Cases_on `inst.inst_opcode` >> gvs[is_terminator_def]
+  >- term_ok_jump_tac >- term_ok_jump_tac >- term_ok_jump_tac
+  >- term_ok_jump_tac >- term_ok_jump_tac >- term_ok_jump_tac
+  >- term_ok_jump_tac
 QED
 
 (* Unified helper: step_inst_base on a non-PHI instruction with
@@ -5861,10 +5863,17 @@ Proof
   `EVERY inst_wf target_bb.bb_instructions` by
     (simp[listTheory.EVERY_MEM] >>
      fs[venomWfTheory.fn_inst_wf_def] >> metis_tac[]) >>
-  `target_bb.bb_instructions <> []` by fs[venomWfTheory.bb_well_formed_def] >>
+  `target_bb.bb_instructions <> []` by
+    (qpat_x_assum `bb_well_formed target_bb` mp_tac >>
+     simp[venomWfTheory.bb_well_formed_def]) >>
   `!i. i < LENGTH target_bb.bb_instructions - 1 ==>
      ~is_terminator (EL i target_bb.bb_instructions).inst_opcode` by
-    (fs[venomWfTheory.bb_well_formed_def] >> rpt strip_tac >> res_tac >> fs[]) >>
+    (qpat_x_assum `bb_well_formed target_bb` mp_tac >>
+     PURE_REWRITE_TAC[venomWfTheory.bb_well_formed_def] >>
+     strip_tac >> rpt strip_tac >> CCONTR_TAC >>
+     qpat_x_assum `!j. j < LENGTH target_bb.bb_instructions /\ _ ==> _`
+       (qspec_then `i` mp_tac) >>
+     impl_tac >- simp[] >> simp[]) >>
   (* v_after1.vs_current_bb is in bb_succs (hence in fn_labels, hence <> split_lbl) *)
   `MEM v_after1.vs_current_bb (bb_succs target_bb)` by
     (mp_tac (Q.SPECL [`m`, `ctx`, `target_bb`, `v1`, `v_after1`]

--- a/venom/passes/cfg_normalization/proofs/cfgNormProofScript.sml
+++ b/venom/passes/cfg_normalization/proofs/cfgNormProofScript.sml
@@ -1048,7 +1048,12 @@ Theorem cfg_norm_inv_inj:
     split_block_name p1 t1 = split_block_name p2 t2 ==>
     p1 = p2 /\ t1 = t2
 Proof
-  inv_tac
+  rpt strip_tac >>
+  qpat_x_assum `cfg_norm_inv func0 func` mp_tac >>
+  PURE_REWRITE_TAC[cfg_norm_inv_def] >> strip_tac >>
+  qpat_x_assum `!p1 t1 p2 t2. _`
+    (qspecl_then [`p1`, `t1`, `p2`, `t2`] mp_tac) >>
+  simp[]
 QED
 
 Theorem cfg_norm_inv_split_fresh:

--- a/venom/passes/concretize_mem_loc/proofs/concretizeMemLocProofsScript.sml
+++ b/venom/passes/concretize_mem_loc/proofs/concretizeMemLocProofsScript.sml
@@ -1782,10 +1782,15 @@ QED
 (* Clause 5: allocas_non_overlapping *)
 Resume step_alloca_fresh_goal[c5]:
   rpt strip_tac >>
-  Cases_on `inst.inst_id = a1` >> Cases_on `inst.inst_id = a2` >>
-  gvs[] >>
-  TRY (drule_all nao_ge_alloca_end >> simp[] >> NO_TAC) >>
-  metis_tac[]
+  Cases_on `inst.inst_id = a1`
+  >- (Cases_on `inst.inst_id = a2`
+      >- metis_tac[]
+      >- (gvs[] >>
+          drule_all nao_ge_alloca_end >> simp[]))
+  >- (Cases_on `inst.inst_id = a2`
+      >- (gvs[] >>
+          drule_all nao_ge_alloca_end >> simp[])
+      >- (gvs[] >> metis_tac[]))
 QED
 
 Finalise step_alloca_fresh_goal
@@ -2179,9 +2184,17 @@ Proof
   rw[concretize_rel_def, LET_THM] >> res_tac >> gvs[]
 QED
 
-val pp_empty_outputs_tac =
-  simp[step_inst_base_def, exec_pure2_def] >>
-  rpt CASE_TAC >> gvs[];
+Triviality exec_pure2_empty_outputs_error:
+  !f inst s. inst.inst_outputs = [] ==>
+    ?e. exec_pure2 f inst s = Error e
+Proof
+  rpt strip_tac >>
+  Cases_on `inst.inst_operands` >> simp[exec_pure2_def] >>
+  Cases_on `t` >> simp[exec_pure2_def] >>
+  Cases_on `t'` >> simp[exec_pure2_def] >>
+  Cases_on `eval_operand h s` >> simp[exec_pure2_def] >>
+  Cases_on `eval_operand h' s` >> simp[exec_pure2_def]
+QED
 
 Triviality pp_empty_outputs_error:
   !inst s. is_pointer_preserving_op inst.inst_opcode /\
@@ -2189,11 +2202,15 @@ Triviality pp_empty_outputs_error:
            ?e. step_inst_base inst s = Error e
 Proof
   rpt strip_tac >>
-  Cases_on `inst.inst_opcode` >> fs[is_pointer_preserving_op_def]
-  >- pp_empty_outputs_tac
-  >- pp_empty_outputs_tac
-  >- pp_empty_outputs_tac
-  >- pp_empty_outputs_tac
+  Cases_on `inst.inst_opcode` >> fs[is_pointer_preserving_op_def] >>
+  simp[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_outputs = []`
+    (fn th => PURE_REWRITE_TAC[exec_pure2_def, th]) >>
+  Cases_on `inst.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `t'` >> simp[] >>
+  Cases_on `eval_operand h s` >> simp[] >>
+  Cases_on `eval_operand h' s` >> simp[]
 QED
 
 (* Helper: binary pv op, Case 1: first operand is pv Var *)
@@ -2699,7 +2716,12 @@ Proof
   (* Expand step_inst_base and case split operands *)
   asm_rewrite_tac[step_inst_base_def] >>
   simp[exec_write2_def, lift_result_def] >>
-  rpt (BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def]) >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
   (* Frame lemma closes all remaining goals *)
   simp[sstore_def, tstore_def, contract_storage_def, contract_transient_def,
        halt_state_def, set_returndata_def, revert_state_def,
@@ -2750,7 +2772,14 @@ Proof
           eval_operand op s1 = eval_operand op s2` by
       metis_tac[cr_non_mem_eval_operand_agree] >>
     ASM_REWRITE_TAC[step_inst_base_def] >> gvs[] >>
-    rpt (BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def]) >>
+    TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+    TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+    TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+    TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+    TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+    TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+    TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
+    TRY BasicProvers.TOP_CASE_TAC >> gvs[lift_result_def] >>
     irule concretize_rel_jump_to >> metis_tac[]
   )
 QED
@@ -5016,14 +5045,18 @@ Proof
       qpat_x_assum `concretize_rel _ _ _ _ _ _` mp_tac >>
       ONCE_REWRITE_TAC[concretize_rel_def] >> simp[LET_THM] >>
       strip_tac >> first_x_assum (qspec_then `v_dst` mp_tac) >> simp[]) >>
-    simp[step_inst_base_def, eval_operand_def,
-         lookup_var_def, lift_result_def]) >>
+    ONCE_REWRITE_TAC[step_inst_base_def] >>
+    qpat_x_assum `inst.inst_opcode = RETURNDATACOPY`
+      (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+    simp[eval_operand_def, lookup_var_def, lift_result_def]) >>
   rename1 `lookup_var v_dst s1 = SOME w1` >>
   `lookup_var v_dst s1 <> NONE` by simp[] >>
   drule_all cr_pv_var_displacement >> strip_tac >>
   gvs[] >>
   (* Unfold step_inst_base for RETURNDATACOPY *)
   ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = RETURNDATACOPY`
+    (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
   simp[eval_operand_def, lookup_var_def] >>
   (* Substitute s2 evals with s1 evals *)
   qpat_x_assum `eval_operand op_src s1 = eval_operand op_src s2`
@@ -6411,6 +6444,12 @@ Proof
   rw[alloca_overflow_safe_def, fn_remaining_alloca_size_def] >> metis_tac[]
 QED
 
+val terminator_alloca_frame_tac =
+  gvs[step_inst_base_def, LET_THM] >>
+  rpt (BasicProvers.PURE_FULL_CASE_TAC >>
+       gvs[jump_to_def, halt_state_def, revert_state_def,
+           set_returndata_def]);
+
 Triviality step_terminator_ok_preserves_alloca_overflow_safe:
   !fuel ctx inst s s' fn amap.
     step_inst fuel ctx inst s = OK s' /\
@@ -6425,11 +6464,17 @@ Proof
   irule alloca_overflow_safe_state_eq >>
   qexists_tac `s` >> simp[] >>
   qpat_x_assum `is_terminator _` mp_tac >>
-  Cases_on `inst.inst_opcode` >> simp[is_terminator_def] >>
-  gvs[step_inst_base_def, LET_THM] >>
-  rpt (BasicProvers.PURE_FULL_CASE_TAC >>
-       gvs[jump_to_def, halt_state_def, revert_state_def,
-           set_returndata_def])
+  Cases_on `inst.inst_opcode` >> simp[is_terminator_def]
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
+  >- terminator_alloca_frame_tac
 QED
 
 Triviality alloca_overflow_safe_exec_block:
@@ -6726,11 +6771,31 @@ Proof
             (s2_phi with vs_inst_idx := p))` by (
         irule exec_block_bmt_sim >> simp[Abbr `p`] >> metis_tac[]) >>
       pop_assum strip_assume_tac >>
-      Cases_on `exec_block fuel ctx bb (s1_phi with vs_inst_idx := p)` >>
-      Cases_on `exec_block fuel ctx (block_map_transform (concretize_inst amap) bb)
-            (s2_phi with vs_inst_idx := p)` >>
-      gvs[lift_result_def] >>
-      TRY (qexists `init'` >> simp[lift_result_def] >> NO_TAC) >>
+      qpat_x_assum
+        `lift_result (concretize_rel amap fn livesets init')
+           (concretize_rel amap fn livesets init')
+           (concretize_rel amap fn livesets init')
+           (exec_block fuel ctx bb (s1_phi with vs_inst_idx := p))
+           (exec_block fuel ctx
+             (block_map_transform (concretize_inst amap) bb)
+             (s2_phi with vs_inst_idx := p))` mp_tac >>
+      (Cases_on `exec_block fuel ctx bb (s1_phi with vs_inst_idx := p)` THEN_LT
+       TRYALL (Cases_on
+         `exec_block fuel ctx (block_map_transform (concretize_inst amap) bb)
+            (s2_phi with vs_inst_idx := p)`)) >>
+      PURE_REWRITE_TAC[lift_result_def] >> simp_tac std_ss [] >> TRY strip_tac >>
+      (ALL_TAC THEN_LT TRYALL
+        (qpat_x_assum
+           `exec_block fuel ctx bb (s1_phi with vs_inst_idx := p) = r1`
+           (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+         qpat_x_assum
+           `exec_block fuel ctx (block_map_transform (concretize_inst amap) bb)
+              (s2_phi with vs_inst_idx := p) = r2`
+           (fn th => assume_tac th >> PURE_REWRITE_TAC[th]))) >>
+      (ALL_TAC THEN_LT TRYALL
+        (qexists `init'` >> simp[lift_result_def] >>
+         TRY (first_assum ACCEPT_TAC) >> NO_TAC)) >>
+      simp_tac bool_ss [venomExecSemanticsTheory.exec_result_case_def] >>
       imp_res_tac concretize_rel_fields >>
       IF_CASES_TAC >> gvs[]
       >- (qexists `init'` >> simp[lift_result_def]) >>
@@ -6773,7 +6838,8 @@ Proof
         simp[Abbr `p`] >> metis_tac[]) >>
       last_x_assum
         (qspecl_then [`amap`, `fn`, `livesets`, `init'`, `ctx`, `v`, `v'`] mp_tac) >>
-      simp[function_map_transform_def] >>
+      PURE_REWRITE_TAC[function_map_transform_def] >>
+      simp_tac std_ss [] >>
       impl_tac >- (rpt conj_tac >> simp[] >> metis_tac[]) >>
       disch_then (qx_choose_then `init''` assume_tac) >>
       qexists `init''` >> simp[function_map_transform_def]) >>

--- a/venom/passes/dead_store_elim/proofs/deadStoreElimProofsScript.sml
+++ b/venom/passes/dead_store_elim/proofs/deadStoreElimProofsScript.sml
@@ -1814,10 +1814,6 @@ Triviality exec_alloca_init[local]:
         lookup_var out v = SOME (n2w 0)
 Proof
   rpt strip_tac >>
-  Cases_on `inst.inst_opcode` >> gvs[] >>
-  gvs[step_inst_base_def, exec_alloca_def, init_venom_state_def,
-       update_var_def, lookup_var_def, FLOOKUP_UPDATE,
-       venom_state_component_equality] >>
   qexists `<| vs_memory := []; vs_transient := empty_transient_storage;
     vs_vars := FEMPTY |+ (out,0w); vs_prev_bb := NONE;
     vs_current_bb := ""; vs_inst_idx := 0; vs_returndata := [];
@@ -1828,7 +1824,12 @@ Proof
     vs_code := []; vs_params := []; vs_prev_hashes := [];
     vs_allocas := FEMPTY |+ (inst.inst_id,(0,w2n alloc_size));
     vs_alloca_next := w2n alloc_size |>` >>
-  simp[FLOOKUP_UPDATE]
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = ALLOCA`
+    (fn th => PURE_REWRITE_TAC[th]) >>
+  simp[exec_alloca_def] >>
+  simp[init_venom_state_def, update_var_def, lookup_var_def] >>
+  simp[FLOOKUP_UPDATE, venom_state_component_equality]
 QED
 
 (* alloca_step_breaks_safety was TRUE under the old alloca_safe_access

--- a/venom/passes/dft/proofs/dftBlockSimScript.sml
+++ b/venom/passes/dft/proofs/dftBlockSimScript.sml
@@ -349,10 +349,13 @@ Proof
   rpt strip_tac >>
   gvs[step_inst_non_invoke] >>
   qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
-  simp[step_inst_base_def] >>
   Cases_on `inst.inst_opcode` >>
   gvs[is_effect_free_op_def, is_terminator_def,
       is_alloca_op_def, is_ext_call_op_def] >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = op`
+    (fn th => PURE_REWRITE_TAC[th]) >>
+  simp[] >>
   simp[exec_write2_def] >>
   rpt strip_tac >> gvs[AllCaseEqs()] >>
   simp[side_effect_lookup_var, lookup_var_def]
@@ -469,7 +472,16 @@ Proof
       (* No account-reading effects: generic theorem applies *)
       `inst_a.inst_opcode <> PHI` by
         (Cases_on `inst_a.inst_opcode` >> simp[] >>
-         gvs[step_inst_non_invoke, step_inst_base_def]) >>
+         qpat_x_assum `inst_a.inst_opcode = PHI`
+           (fn op_th =>
+             qpat_x_assum `step_inst_base inst_a ss = OK va`
+               (fn ok_th =>
+                 mp_tac ok_th >>
+                 mp_tac (MATCH_MP
+                   (Q.SPECL [`inst_a`, `ss`]
+                     venomExecProofsTheory.step_inst_base_phi_error)
+                   op_th))) >>
+         simp[]) >>
       irule step_inst_base_effect_free_output_determined_vars >>
       qexistsl_tac [`inst_a`, `ss`, `vb`] >>
       rpt conj_tac >> gvs[] >>
@@ -608,6 +620,16 @@ Proof
   rw[exec_read1_def] >> gvs[AllCaseEqs()] >> metis_tac[]
 QED
 
+fun pure_step_finish_tac () =
+  gvs[inst_wf_def] >>
+  FIRST [
+    drule exec_pure1_structure >> strip_tac >> gvs[] >> metis_tac[],
+    drule exec_pure2_structure >> strip_tac >> gvs[] >> metis_tac[],
+    drule exec_pure3_structure >> strip_tac >> gvs[] >> metis_tac[],
+    drule exec_read0_structure >> strip_tac >> gvs[] >> metis_tac[],
+    drule exec_read1_structure >> strip_tac >> gvs[] >> metis_tac[],
+    gvs[AllCaseEqs()] >> metis_tac[]]
+
 (* A pure (empty read/write effects), eligible step_inst_base either
    produces no outputs (NOP) and returns the state unchanged, or produces
    exactly one output via update_var. *)
@@ -630,15 +652,24 @@ Proof
       write_effects_def, read_effects_def] >>
   qpat_x_assum `step_inst_base inst ss = OK v2` mp_tac >>
   ASM_REWRITE_TAC[step_inst_base_def] >>
-  strip_tac >>
-  gvs[inst_wf_def] >>
-  FIRST [
-    drule exec_pure1_structure >> strip_tac >> gvs[] >> metis_tac[],
-    drule exec_pure2_structure >> strip_tac >> gvs[] >> metis_tac[],
-    drule exec_pure3_structure >> strip_tac >> gvs[] >> metis_tac[],
-    drule exec_read0_structure >> strip_tac >> gvs[] >> metis_tac[],
-    drule exec_read1_structure >> strip_tac >> gvs[] >> metis_tac[],
-    gvs[AllCaseEqs()] >> metis_tac[]]
+  strip_tac >|
+  [pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac (),
+   pure_step_finish_tac (), pure_step_finish_tac (), pure_step_finish_tac ()]
 QED
 
 Triviality empty_effect_non_effect_free_opcode_cases[local]:
@@ -1033,7 +1064,11 @@ Triviality effect_free_output_determined[local]:
 Proof
   rpt strip_tac >>
   imp_res_tac effect_free_step_eq_base >> gvs[] >>
-  `inst.inst_opcode <> PHI` by (CCONTR_TAC >> gvs[step_inst_base_def]) >>
+  `inst.inst_opcode <> PHI` by
+    (CCONTR_TAC >>
+     qpat_x_assum `~(inst.inst_opcode <> PHI)` mp_tac >> simp[] >> strip_tac >>
+     qpat_x_assum `step_inst_base inst s1 = OK r1` mp_tac >>
+     ASM_REWRITE_TAC[step_inst_base_def] >> simp[]) >>
   qspecl_then [`inst`, `s1`, `s2`, `r1`, `r2`] mp_tac
     step_inst_base_effect_free_output_determined_vars >>
   impl_tac >- (

--- a/venom/passes/dft/proofs/dftCommutationScript.sml
+++ b/venom/passes/dft/proofs/dftCommutationScript.sml
@@ -599,8 +599,8 @@ Proof
 QED
 
 val base_frame_tac =
-  ASM_REWRITE_TAC[step_inst_base_def] >>
-  simp[] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
   gvs all_rwts2 >>
   TRY (gvs(all_rwts2 @ custom_defs) >>
        rpt (CHANGED_TAC (BasicProvers.TOP_CASE_TAC >>
@@ -696,11 +696,26 @@ Proof
   >- base_frame_tac (* BLOBHASH *)
   >- base_frame_tac (* BLOBBASEFEE *)
   >- base_frame_tac (* SHA3 *)
-  >- base_frame_tac (* CALL *)
-  >- base_frame_tac (* STATICCALL *)
-  >- base_frame_tac (* DELEGATECALL *)
-  >- base_frame_tac (* CREATE *)
-  >- base_frame_tac (* CREATE2 *)
+  >- (PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[opcode_case_def] >>
+      gvs all_rwts2 >>
+      rpt (CHANGED_TAC (BasicProvers.TOP_CASE_TAC >> gvs all_rwts2)))
+  >- (PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[opcode_case_def] >>
+      gvs all_rwts2 >>
+      rpt (CHANGED_TAC (BasicProvers.TOP_CASE_TAC >> gvs all_rwts2)))
+  >- (PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[opcode_case_def] >>
+      gvs all_rwts2 >>
+      rpt (CHANGED_TAC (BasicProvers.TOP_CASE_TAC >> gvs all_rwts2)))
+  >- (PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[opcode_case_def] >>
+      gvs all_rwts2 >>
+      rpt (CHANGED_TAC (BasicProvers.TOP_CASE_TAC >> gvs all_rwts2)))
+  >- (PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[opcode_case_def] >>
+      gvs all_rwts2 >>
+      rpt (CHANGED_TAC (BasicProvers.TOP_CASE_TAC >> gvs all_rwts2)))
   >- base_frame_tac (* LOG *)
   >- base_frame_tac (* SELFDESTRUCT *)
   >- base_frame_tac (* INVALID *)

--- a/venom/passes/dft/proofs/dftCorrectnessScript.sml
+++ b/venom/passes/dft/proofs/dftCorrectnessScript.sml
@@ -519,8 +519,10 @@ Proof
   (* Only ASSERT, ASSERT_UNREACHABLE, RETURNDATACOPY remain *)
   qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
   ONCE_REWRITE_TAC[step_inst_base_def] >>
-  simp[AllCaseEqs(), revert_state_def, halt_state_def,
-       set_returndata_def, LET_THM] >>
+  ASM_REWRITE_TAC[venomInstTheory.opcode_case_def] >>
+  simp[AllCaseEqs()] >>
+  simp[revert_state_def, halt_state_def] >>
+  simp[set_returndata_def, LET_THM] >>
   rpt strip_tac >> gvs[]
 QED
 
@@ -548,11 +550,15 @@ Proof
      ONCE_REWRITE_TAC[step_inst_base_def] unfolds once with known opcode. *)
   qpat_x_assum `step_inst_base _ s = _` mp_tac >>
   ONCE_REWRITE_TAC [step_inst_base_def] >>
-  simp[AllCaseEqs(), revert_state_def, halt_state_def,
-       set_returndata_def, LET_THM] >>
+  ASM_REWRITE_TAC[venomInstTheory.opcode_case_def] >>
+  simp[AllCaseEqs()] >>
+  simp[revert_state_def, halt_state_def] >>
+  simp[set_returndata_def, LET_THM] >>
   strip_tac >> gvs[] >>
   ONCE_REWRITE_TAC [step_inst_base_def] >>
-  simp[revert_state_def, halt_state_def, set_returndata_def, LET_THM] >>
+  ASM_REWRITE_TAC[venomInstTheory.opcode_case_def] >>
+  simp[revert_state_def, halt_state_def] >>
+  simp[set_returndata_def, LET_THM] >>
   (* RETURNDATACOPY: also needs sx.vs_returndata = s.vs_returndata *)
   metis_tac[write_effects_sound_returndata,
             eff_ind_returndatacopy_no_write_rd]
@@ -6641,7 +6647,9 @@ Proof
   (* Now replay the executable pseudo opcode.  PHI is impossible under
      final semantics because step_inst_base PHI is Error. *)
   fs[step_inst_non_invoke] >>
-  Cases_on `a.inst_opcode` >> gvs[is_pseudo_def, Once step_inst_base_def, AllCaseEqs()] >>
+  Cases_on `a.inst_opcode` >> gvs[is_pseudo_def]
+  >- gvs[Once step_inst_base_def, AllCaseEqs()] >>
+  gvs[Once step_inst_base_def, AllCaseEqs()] >>
   `EL (w2n idx) s.vs_params = val` by
     (fs[update_var_def, venom_state_component_equality] >>
      metis_tac[FUPD11_SAME_KEY_AND_BASE]) >>

--- a/venom/passes/dft/proofs/dftPermSimScript.sml
+++ b/venom/passes/dft/proofs/dftPermSimScript.sml
@@ -305,8 +305,7 @@ Triviality effects_independent_invoke_empty:
   !op. effects_independent INVOKE op ==>
        write_effects op = {} /\ read_effects op = {} /\ op <> INVOKE
 Proof
-  Cases >> simp[effects_independent_def, write_effects_def,
-                read_effects_def, all_effects_def] >> EVAL_TAC
+  Cases >> EVAL_TAC
 QED
 
 (* Given effects_independent between INVOKE and op, derive all useful facts:
@@ -1140,6 +1139,9 @@ val comm_lemmas =
    wordsTheory.WORD_XOR_COMM,
    arithmeticTheory.GREATER_DEF, wordsTheory.WORD_GREATER];
 
+fun flip_commutative_finish_tac () =
+  simp[] >> irule exec_pure2_swap >> rw comm_lemmas >> rw[EQ_SYM_EQ]
+
 (*
  * flip_operands preserves step_inst_base.
  * For commutative ops: operands swapped, opcode same -> exec_pure2_swap.
@@ -1154,9 +1156,10 @@ Proof
   drule commutative_cases >> drule commutative_not_comparator >>
   strip_tac >> strip_tac >> gvs[] >>
   ASM_REWRITE_TAC[flip_operands_def] >>
-  ASM_REWRITE_TAC[step_inst_base_def] >>
-  simp[] >>
-  irule exec_pure2_swap >> rw comm_lemmas >> rw[EQ_SYM_EQ]
+  ASM_REWRITE_TAC[step_inst_base_def] >|
+  [flip_commutative_finish_tac (), flip_commutative_finish_tac (),
+   flip_commutative_finish_tac (), flip_commutative_finish_tac (),
+   flip_commutative_finish_tac (), flip_commutative_finish_tac ()]
 QED
 
 Triviality flip_comparator:
@@ -1168,9 +1171,13 @@ Proof
   drule comparator_cases >> strip_tac >> gvs[] >>
   ASM_REWRITE_TAC[flip_operands_def, is_comparator_def,
                   flip_comparison_opcode_def] >>
+  simp[LET_THM] >>
   ASM_REWRITE_TAC[step_inst_base_def] >>
-  (* exec_pure2_opcode_irrel strips the opcode update *)
-  simp[] >>
+  PURE_REWRITE_TAC[venomInstTheory.instruction_accfupds,
+                   combinTheory.K_THM] >>
+  BETA_TAC >> ASM_REWRITE_TAC[] >>
+  PURE_REWRITE_TAC[venomInstTheory.opcode_case_def,
+                   exec_pure2_opcode_irrel] >>
   irule exec_pure2_swap >> rw comm_lemmas
 QED
 

--- a/venom/passes/dft/proofs/dftWfScript.sml
+++ b/venom/passes/dft/proofs/dftWfScript.sml
@@ -1067,7 +1067,7 @@ QED
 
 Resume add_deps_on_barrier_foldl_backward[barrier]:
   (* Barrier case: acc unchanged, last_bar becomes SOME h *)
-  simp[] >>
+  asm_simp_tac std_ss [] >>
   first_x_assum (qspecl_then [`prefix ++ [h]`, `prefix ++ h :: suffix'`,
                               `SOME h`, `acc`] mp_tac) >>
   rewrite_tac[GSYM APPEND_ASSOC, APPEND] >>
@@ -1080,7 +1080,7 @@ Resume add_deps_on_barrier_foldl_backward[barrier]:
 QED
 
 Resume add_deps_on_barrier_foldl_backward[non_barrier]:
-  simp[] >>
+  asm_simp_tac std_ss [] >>
   qmatch_goalsub_abbrev_tac `FOLDL _ (new_acc, last_bar) suffix'` >>
   first_x_assum (qspecl_then [`prefix ++ [h]`, `prefix ++ h :: suffix'`,
                               `last_bar`, `new_acc`] mp_tac) >>
@@ -1168,7 +1168,7 @@ Proof
   >> rename1 `h :: to_process`
   >> Cases_on `is_barrier h`
   (* Barrier case *)
-  >- (simp[Once FOLDL, LET_THM] >>
+  >- (asm_simp_tac std_ss [Once FOLDL, LET_THM] >>
       qmatch_goalsub_abbrev_tac `FOLDL _ (new_acc, new_prev) to_process` >>
       first_x_assum (qspecl_then
            [`prefix ++ [h]`, `nps`, `new_prev`, `new_acc`] mp_tac) >>
@@ -1176,7 +1176,7 @@ Proof
       (impl_tac >- suspend "barrier_step") >>
       simp[])
   (* Non-barrier case *)
-  >> (simp[Once FOLDL, LET_THM] >>
+  >> (asm_simp_tac std_ss [Once FOLDL, LET_THM] >>
       qmatch_goalsub_abbrev_tac `FOLDL _ (new_acc, new_prev) to_process` >>
       first_x_assum (qspecl_then
            [`prefix ++ [h]`, `nps`, `new_prev`, `new_acc`] mp_tac) >>

--- a/venom/passes/literals_codesize/literalsCodesizeCorrectnessScript.sml
+++ b/venom/passes/literals_codesize/literalsCodesizeCorrectnessScript.sml
@@ -40,13 +40,20 @@ QED
 
 (* ===== Obligations ===== *)
 
+fun lit_codesize_case_tac thms =
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs thms)
+
 (* lit_codesize_inst preserves instruction IDs — the transform only
    replaces opcodes, not identifiers. *)
 Triviality lit_codesize_inst_id:
   !inst. (lit_codesize_inst inst).inst_id = inst.inst_id
 Proof
   rw[literalsCodesizeDefsTheory.lit_codesize_inst_def] >>
-  rpt (BasicProvers.TOP_CASE_TAC >> gvs[])
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >>
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >>
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >>
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >>
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >> gvs[]
 QED
 
 (* lit_codesize_inst preserves instruction outputs — the transform only
@@ -55,7 +62,11 @@ Triviality lit_codesize_inst_outputs:
   !inst. (lit_codesize_inst inst).inst_outputs = inst.inst_outputs
 Proof
   rw[literalsCodesizeDefsTheory.lit_codesize_inst_def] >>
-  rpt (BasicProvers.TOP_CASE_TAC >> gvs[])
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >>
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >>
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >>
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >>
+  lit_codesize_case_tac [] >> lit_codesize_case_tac [] >> gvs[]
 QED
 
 (* Terminator instructions pass through lit_codesize_inst unchanged —
@@ -64,7 +75,17 @@ Triviality lit_codesize_inst_terminator_identity:
   !inst. is_terminator inst.inst_opcode ==> lit_codesize_inst inst = inst
 Proof
   rw[literalsCodesizeDefsTheory.lit_codesize_inst_def] >>
-  rpt (BasicProvers.TOP_CASE_TAC >> gvs[venomInstTheory.is_terminator_def])
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  gvs[venomInstTheory.is_terminator_def]
 QED
 
 (* lit_codesize_inst never introduces a terminator — only non-terminator
@@ -74,7 +95,17 @@ Triviality lit_codesize_inst_nonterminator:
     ~is_terminator (lit_codesize_inst inst).inst_opcode
 Proof
   rw[literalsCodesizeDefsTheory.lit_codesize_inst_def] >>
-  rpt (BasicProvers.TOP_CASE_TAC >> gvs[venomInstTheory.is_terminator_def])
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  lit_codesize_case_tac [venomInstTheory.is_terminator_def] >>
+  gvs[venomInstTheory.is_terminator_def]
 QED
 
 (* PHI opcodes are unchanged by lit_codesize_inst. *)

--- a/venom/passes/literals_codesize/proofs/literalsCodesizeProofsScript.sml
+++ b/venom/passes/literals_codesize/proofs/literalsCodesizeProofsScript.sml
@@ -128,10 +128,12 @@ Theorem lit_codesize_assign_not_step[local]:
       (inst with <|inst_opcode := NOT; inst_operands := [Lit (~c)]|>) s =
     step_inst fuel ctx inst s
 Proof
-  rw[venomExecSemanticsTheory.step_inst_def,
-     venomExecSemanticsTheory.step_inst_base_def,
-     venomExecSemanticsTheory.exec_pure1_def,
-     venomStateTheory.eval_operand_def]
+  rpt strip_tac >>
+  ASM_REWRITE_TAC[venomExecSemanticsTheory.step_inst_def] >>
+  PURE_REWRITE_TAC[venomExecSemanticsTheory.step_inst_base_def] >>
+  ASM_REWRITE_TAC[] >>
+  simp[venomExecSemanticsTheory.exec_pure1_def,
+       venomStateTheory.eval_operand_def]
 QED
 
 Theorem lit_codesize_assign_shl_step[local]:
@@ -151,12 +153,12 @@ Proof
   `trailing_zeros c < 256` by (irule trailing_zeros_bound >> simp[]) >>
   `trailing_zeros c < dimword(:256)` by
     (fs[wordsTheory.dimword_def] >> CONV_TAC fcpLib.INDEX_CONV >> fs[]) >>
-  rw[venomExecSemanticsTheory.step_inst_def,
-     venomExecSemanticsTheory.step_inst_base_def,
-     venomExecSemanticsTheory.exec_pure2_def,
-     venomStateTheory.eval_operand_def,
-     arithmeticTheory.LESS_MOD,
-     lsr_lsl_trailing_zeros]
+  ASM_REWRITE_TAC[venomExecSemanticsTheory.step_inst_def] >>
+  PURE_REWRITE_TAC[venomExecSemanticsTheory.step_inst_base_def] >>
+  ASM_REWRITE_TAC[] >>
+  simp[venomExecSemanticsTheory.exec_pure2_def,
+       venomStateTheory.eval_operand_def,
+       arithmeticTheory.LESS_MOD, lsr_lsl_trailing_zeros]
 QED
 
 (* Core lemma: each well-formed rewritten instruction produces the

--- a/venom/passes/lower_dload/proofs/lowerDloadClassifyScript.sml
+++ b/venom/passes/lower_dload/proofs/lowerDloadClassifyScript.sml
@@ -225,8 +225,10 @@ end;
 val ld_classify_one_tac =
   rpt strip_tac >>
   qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
-  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> simp[] >> strip_tac >>
-  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> simp[] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >> strip_tac >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
   (* Fast path: exec_pure helpers (ADD, SUB, MUL, ...) ~45 opcodes *)
   TRY (
     (drule_all exec_pure1_ld_ok ORELSE

--- a/venom/passes/lower_dload/proofs/lowerDloadProofsScript.sml
+++ b/venom/passes/lower_dload/proofs/lowerDloadProofsScript.sml
@@ -80,7 +80,9 @@ Theorem step_jmp_ok_preserves_layout:
 Proof
   rpt strip_tac >>
   qpat_x_assum `step_inst fuel ctx inst s = OK s'` mp_tac >>
-  simp[Once step_inst_def, step_inst_base_def, jump_to_def] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_def] >> ASM_REWRITE_TAC[] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >> simp[jump_to_def] >>
   gvs[AllCaseEqs(), PULL_EXISTS] >> rw[] >> gvs[]
 QED
 
@@ -94,7 +96,9 @@ Theorem step_jnz_ok_preserves_layout[local]:
 Proof
   rpt strip_tac >>
   qpat_x_assum `step_inst fuel ctx inst s = OK s'` mp_tac >>
-  simp[Once step_inst_def, step_inst_base_def, jump_to_def] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_def] >> ASM_REWRITE_TAC[] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >> simp[jump_to_def] >>
   gvs[AllCaseEqs(), PULL_EXISTS] >> rw[] >> gvs[]
 QED
 
@@ -108,14 +112,17 @@ Theorem step_djmp_ok_preserves_layout[local]:
 Proof
   rpt strip_tac >>
   qpat_x_assum `step_inst fuel ctx inst s = OK s'` mp_tac >>
-  simp[Once step_inst_def, step_inst_base_def, jump_to_def] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_def] >> ASM_REWRITE_TAC[] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >> simp[jump_to_def] >>
   gvs[AllCaseEqs(), PULL_EXISTS] >> rw[] >> gvs[]
 QED
 
 val term_ok_jump_tac =
   qpat_x_assum `step_inst_base _ _ = OK _` mp_tac >>
-  simp[step_inst_base_def, eval_operands_def, eval_operand_def,
-       AllCaseEqs()] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
+  simp[eval_operands_def, eval_operand_def, AllCaseEqs()] >>
   rpt CASE_TAC >> gvs[];
 
 Theorem step_inst_base_ok_terminator_jump[local]:
@@ -126,8 +133,14 @@ Theorem step_inst_base_ok_terminator_jump[local]:
     inst.inst_opcode = DJMP
 Proof
   rpt strip_tac >>
-  Cases_on `inst.inst_opcode` >> gvs[is_terminator_def] >>
-  term_ok_jump_tac
+  Cases_on `inst.inst_opcode` >> gvs[is_terminator_def]
+  >- term_ok_jump_tac
+  >- term_ok_jump_tac
+  >- term_ok_jump_tac
+  >- term_ok_jump_tac
+  >- term_ok_jump_tac
+  >- term_ok_jump_tac
+  >- term_ok_jump_tac
 QED
 
 Theorem step_non_ok_terminator[local]:
@@ -489,8 +502,22 @@ Proof
   rpt strip_tac >>
   ld_derive_agree_tac >> ld_derive_fields_tac >>
   simp[step_inst_base_def, LET_THM] >>
-  rpt (BasicProvers.PURE_FULL_CASE_TAC >>
-       gvs[] >> TRY (res_tac >> gvs[])) >>
+  BasicProvers.PURE_FULL_CASE_TAC >> gvs[lift_result_def] >>
+  TRY (res_tac >> gvs[]) >>
+  BasicProvers.PURE_FULL_CASE_TAC >> gvs[lift_result_def] >>
+  TRY (res_tac >> gvs[]) >>
+  BasicProvers.PURE_FULL_CASE_TAC >> gvs[lift_result_def] >>
+  TRY (res_tac >> gvs[]) >>
+  BasicProvers.PURE_FULL_CASE_TAC >> gvs[lift_result_def] >>
+  TRY (res_tac >> gvs[]) >>
+  BasicProvers.PURE_FULL_CASE_TAC >> gvs[lift_result_def] >>
+  TRY (res_tac >> gvs[]) >>
+  BasicProvers.PURE_FULL_CASE_TAC >> gvs[lift_result_def] >>
+  TRY (res_tac >> gvs[]) >>
+  BasicProvers.PURE_FULL_CASE_TAC >> gvs[lift_result_def] >>
+  TRY (res_tac >> gvs[]) >>
+  BasicProvers.PURE_FULL_CASE_TAC >> gvs[lift_result_def] >>
+  TRY (res_tac >> gvs[]) >>
   gvs[lift_result_def] >> ld_close_tac
 QED
 
@@ -728,21 +755,33 @@ Proof
     fs[code_layout_valid_def] >>
   (* Step through all 4 instructions with dimword and var distinctness *)
   ONCE_REWRITE_TAC[run_insts_def] >>
-  simp[step_inst_non_invoke, step_inst_base_def, LET_THM,
-       exec_alloca_def, eval_operand_def] >>
+  simp[step_inst_non_invoke] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
+  simp[LET_THM, exec_alloca_def, eval_operand_def] >>
   BasicProvers.EVERY_CASE_TAC >> gvs[] >>
   ONCE_REWRITE_TAC[run_insts_def] >>
-  simp[step_inst_non_invoke, step_inst_base_def, LET_THM,
-       exec_pure2_def, eval_operand_def, lookup_var_def, update_var_def,
-       FLOOKUP_UPDATE] >>
+  simp[step_inst_non_invoke] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
+  simp[] >>
+  simp[LET_THM, exec_pure2_def, eval_operand_def, lookup_var_def,
+       update_var_def, FLOOKUP_UPDATE] >>
   ONCE_REWRITE_TAC[run_insts_def] >>
-  simp[step_inst_non_invoke, step_inst_base_def, LET_THM,
-       eval_operand_def, lookup_var_def, update_var_def,
-       FLOOKUP_UPDATE] >>
+  simp[step_inst_non_invoke] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
+  simp[LET_THM, eval_operand_def, lookup_var_def,
+       update_var_def, FLOOKUP_UPDATE] >>
   ONCE_REWRITE_TAC[run_insts_def] >>
-  simp[step_inst_non_invoke, step_inst_base_def, LET_THM,
-       exec_read1_def, eval_operand_def, lookup_var_def, update_var_def,
-       FLOOKUP_UPDATE, run_insts_def] >>
+  qmatch_goalsub_abbrev_tac `step_inst fuel ctx _ mload_state` >>
+  simp[step_inst_non_invoke] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
+  simp[] >>
+  simp[LET_THM, exec_read1_def, eval_operand_def, run_insts_def] >>
+  qunabbrev_tac `mload_state` >>
+  simp[lookup_var_def, update_var_def, FLOOKUP_UPDATE] >>
   simp[FLOOKUP_UPDATE] >>
   (* Step 1: Simplify 32 MOD dimword(:256) -> 32 *)
   simp_tac (srw_ss() ++ dimword_256_ss) [] >>

--- a/venom/passes/lower_dload/proofs/lowerDloadSimScript.sml
+++ b/venom/passes/lower_dload/proofs/lowerDloadSimScript.sml
@@ -62,7 +62,8 @@ Theorem step_inst_base_ADD_single[local]:
       (SOME v1, SOME v2) => OK (update_var out (word_add v1 v2) s)
     | _ => Error "undefined operand"
 Proof
-  rw[step_inst_base_def, exec_pure2_def]
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  simp[] >> rw[exec_pure2_def]
 QED
 
 Theorem step_inst_base_CODECOPY3[local]:
@@ -78,7 +79,7 @@ Theorem step_inst_base_CODECOPY3[local]:
           OK (write_memory_with_expansion (w2n dst) bytes s)
     | _ => Error "undefined operand"
 Proof
-  rw[step_inst_base_def]
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> simp[]
 QED
 
 (* DLOADBYTES Error -> expansion also errors.
@@ -433,8 +434,14 @@ Proof
   simp[EVERY_APPEND] >>
   rename1 `lower_dload_inst h` >>
   simp[lower_dload_inst_def] >>
-  rpt (CASE_TAC >> gvs[]) >>
-  simp[is_terminator_def, EVERY_DEF]
+  CASE_TAC >> gvs[is_terminator_def, EVERY_DEF] >>
+  CASE_TAC >> gvs[is_terminator_def, EVERY_DEF] >>
+  CASE_TAC >> gvs[is_terminator_def, EVERY_DEF] >>
+  CASE_TAC >> gvs[is_terminator_def, EVERY_DEF] >>
+  CASE_TAC >> gvs[is_terminator_def, EVERY_DEF] >>
+  CASE_TAC >> gvs[is_terminator_def, EVERY_DEF] >>
+  CASE_TAC >> gvs[is_terminator_def, EVERY_DEF] >>
+  CASE_TAC >> gvs[is_terminator_def, EVERY_DEF]
 QED
 
 (* Shared inductive prefix for exec_block prefix factoring lemmas.

--- a/venom/passes/make_ssa/proofs/makeSsaHelperScript.sml
+++ b/venom/passes/make_ssa/proofs/makeSsaHelperScript.sml
@@ -406,22 +406,31 @@ Proof
   rpt gen_tac >>
   ONCE_REWRITE_TAC[step_inst_base_def] >>
   Cases_on `inst.inst_opcode` >>
-  rw[] >>
+  PURE_REWRITE_TAC[venomInstTheory.opcode_case_def] >>
   (* Uniform handler for all exec_* helpers + direct cases *)
-  gvs[exec_pure1_def, exec_pure2_def, exec_pure3_def,
-      exec_read0_def, exec_read1_def, exec_write2_def,
-      exec_alloca_def, exec_ext_call_def, exec_delegatecall_def,
-      exec_create_def, extract_venom_result_def,
-      AllCaseEqs(), LET_THM,
-      update_var_def, FDOM_FUPDATE,
-      jump_to_def, mcopy_def, mstore_def, mstore8_def, sstore_def, tstore_def,
-      halt_state_def, revert_state_def, set_returndata_def] >>
+  gvs[exec_pure1_def] >>
+  gvs[exec_pure2_def] >>
+  gvs[exec_pure3_def] >>
+  gvs[exec_read0_def, exec_read1_def] >>
+  gvs[exec_write2_def, exec_alloca_def] >>
+  gvs[exec_ext_call_def] >>
+  gvs[exec_delegatecall_def] >>
+  gvs[exec_create_def] >>
+  gvs[extract_venom_result_def] >>
+  gvs[AllCaseEqs(), LET_THM] >>
+  gvs[update_var_def, FDOM_FUPDATE] >>
+  gvs[jump_to_def, mcopy_def, mstore_def, mstore8_def] >>
+  gvs[sstore_def, tstore_def] >>
+  gvs[halt_state_def, revert_state_def, set_returndata_def] >>
   rpt strip_tac >> gvs[SUBSET_DEF, IN_INSERT, IN_UNION] >>
   (* Remaining: ext_call/staticcall/delegatecall/create/create2 lambda pairs,
      DLOADBYTES, CODECOPY write_memory_with_expansion *)
   TRY (gvs[write_memory_with_expansion_def, LET_THM] >> NO_TAC) >>
   TRY (pairarg_tac >> gvs[update_var_def, FDOM_FUPDATE] >>
-       gvs[SUBSET_DEF, IN_INSERT, IN_UNION] >> NO_TAC)
+       gvs[SUBSET_DEF, IN_INSERT, IN_UNION] >> NO_TAC) >>
+  TRY (Cases_on `result` >> gvs[AllCaseEqs()]) >>
+  TRY (Cases_on `y` >> gvs[AllCaseEqs()]) >>
+  rpt gen_tac >> strip_tac >> gvs[]
 QED
 
 (* FOLDL update_var adds output names to vs_vars *)
@@ -500,13 +509,21 @@ Proof
   rpt gen_tac >>
   ONCE_REWRITE_TAC[step_inst_base_def] >>
   Cases_on `inst.inst_opcode` >>
-  rw[is_terminator_def, opcode_has_output_def] >>
-  gvs[exec_pure1_def, exec_pure2_def, exec_pure3_def,
-      exec_read0_def, exec_read1_def, exec_write2_def,
-      exec_alloca_def, exec_ext_call_def, exec_delegatecall_def,
-      exec_create_def, extract_venom_result_def,
-      AllCaseEqs(), LET_THM,
-      update_var_def, FDOM_FUPDATE]
+  PURE_REWRITE_TAC[venomInstTheory.opcode_case_def] >>
+  gvs[is_terminator_def] >>
+  gvs[opcode_has_output_def] >>
+  gvs[exec_pure1_def] >>
+  gvs[exec_pure2_def] >>
+  gvs[exec_pure3_def] >>
+  gvs[exec_read0_def, exec_read1_def] >>
+  gvs[exec_write2_def, exec_alloca_def] >>
+  gvs[exec_ext_call_def] >>
+  gvs[exec_delegatecall_def] >>
+  gvs[exec_create_def] >>
+  gvs[extract_venom_result_def] >>
+  gvs[AllCaseEqs(), LET_THM] >>
+  gvs[update_var_def, FDOM_FUPDATE] >>
+  rpt strip_tac >> gvs[FDOM_FUPDATE]
 QED
 
 (* Non-terminator step_inst: outputs end up in FDOM (incl. INVOKE) *)
@@ -542,19 +559,28 @@ Proof
   rpt gen_tac >>
   ONCE_REWRITE_TAC[step_inst_base_def] >>
   Cases_on `inst.inst_opcode` >>
-  rw[] >>
-  gvs[exec_pure1_def, exec_pure2_def, exec_pure3_def,
-      exec_read0_def, exec_read1_def, exec_write2_def,
-      exec_alloca_def, exec_ext_call_def, exec_delegatecall_def,
-      exec_create_def, extract_venom_result_def,
-      AllCaseEqs(), LET_THM,
-      update_var_def, FDOM_FUPDATE,
-      jump_to_def, mcopy_def, mstore_def, mstore8_def, sstore_def, tstore_def,
-      halt_state_def, revert_state_def, set_returndata_def] >>
+  PURE_REWRITE_TAC[venomInstTheory.opcode_case_def] >>
+  gvs[exec_pure1_def] >>
+  gvs[exec_pure2_def] >>
+  gvs[exec_pure3_def] >>
+  gvs[exec_read0_def, exec_read1_def] >>
+  gvs[exec_write2_def, exec_alloca_def] >>
+  gvs[exec_ext_call_def] >>
+  gvs[exec_delegatecall_def] >>
+  gvs[exec_create_def] >>
+  gvs[extract_venom_result_def] >>
+  gvs[AllCaseEqs(), LET_THM] >>
+  gvs[update_var_def, FDOM_FUPDATE] >>
+  gvs[jump_to_def, mcopy_def, mstore_def, mstore8_def] >>
+  gvs[sstore_def, tstore_def] >>
+  gvs[halt_state_def, revert_state_def, set_returndata_def] >>
   rpt strip_tac >> gvs[SUBSET_DEF, IN_INSERT, IN_UNION] >>
   TRY (gvs[write_memory_with_expansion_def, LET_THM] >> NO_TAC) >>
   TRY (pairarg_tac >> gvs[update_var_def, FDOM_FUPDATE] >>
-       gvs[SUBSET_DEF, IN_INSERT, IN_UNION] >> NO_TAC)
+       gvs[SUBSET_DEF, IN_INSERT, IN_UNION] >> NO_TAC) >>
+  TRY (Cases_on `result` >> gvs[AllCaseEqs()]) >>
+  TRY (Cases_on `y` >> gvs[AllCaseEqs()]) >>
+  rpt gen_tac >> strip_tac >> gvs[]
 QED
 
 (* bind_outputs adds exactly the output variables *)
@@ -778,18 +804,27 @@ Proof
   rpt gen_tac >>
   ONCE_REWRITE_TAC[step_inst_base_def] >>
   Cases_on `inst.inst_opcode` >>
-  rw[] >>
-  gvs[exec_pure1_def, exec_pure2_def, exec_pure3_def,
-      exec_read0_def, exec_read1_def, exec_write2_def,
-      exec_alloca_def, exec_ext_call_def, exec_delegatecall_def,
-      exec_create_def, extract_venom_result_def,
-      AllCaseEqs(), LET_THM,
-      update_var_def, lookup_var_def, FLOOKUP_UPDATE,
-      jump_to_def, mcopy_def, mstore_def, mstore8_def, sstore_def, tstore_def,
-      halt_state_def, revert_state_def, set_returndata_def] >>
+  PURE_REWRITE_TAC[venomInstTheory.opcode_case_def] >>
+  gvs[exec_pure1_def] >>
+  gvs[exec_pure2_def] >>
+  gvs[exec_pure3_def] >>
+  gvs[exec_read0_def, exec_read1_def] >>
+  gvs[exec_write2_def, exec_alloca_def] >>
+  gvs[exec_ext_call_def] >>
+  gvs[exec_delegatecall_def] >>
+  gvs[exec_create_def] >>
+  gvs[extract_venom_result_def] >>
+  gvs[AllCaseEqs(), LET_THM] >>
+  gvs[update_var_def, lookup_var_def, FLOOKUP_UPDATE] >>
+  gvs[jump_to_def, mcopy_def, mstore_def, mstore8_def] >>
+  gvs[sstore_def, tstore_def] >>
+  gvs[halt_state_def, revert_state_def, set_returndata_def] >>
   rpt strip_tac >> gvs[FLOOKUP_UPDATE] >>
   TRY (gvs[write_memory_with_expansion_def, LET_THM] >> NO_TAC) >>
-  TRY (pairarg_tac >> gvs[update_var_def, lookup_var_def, FLOOKUP_UPDATE] >> NO_TAC)
+  TRY (pairarg_tac >> gvs[update_var_def, lookup_var_def, FLOOKUP_UPDATE] >> NO_TAC) >>
+  TRY (Cases_on `result` >> gvs[AllCaseEqs()]) >>
+  TRY (Cases_on `y` >> gvs[AllCaseEqs()]) >>
+  gvs[lookup_var_def]
 QED
 
 (* vars_colon_free preservation through step_inst_base *)
@@ -2798,11 +2833,61 @@ Proof
   pop_assum (ASSUME_TAC o ONCE_REWRITE_RULE [step_inst_base_def]) >>
   pop_assum mp_tac >>
   Cases_on `inst.inst_opcode` >> simp[is_terminator_def] >>
-  simp[exec_pure1_def, exec_pure2_def, exec_pure3_def,
-       exec_read0_def, exec_read1_def, exec_write2_def,
-       exec_alloca_def, exec_ext_call_def, exec_delegatecall_def,
-       exec_create_def, extract_venom_result_def,
-       AllCaseEqs(), LET_THM] >>
+  PURE_REWRITE_TAC[exec_pure1_def] >>
+  PURE_REWRITE_TAC[exec_pure2_def] >>
+  PURE_REWRITE_TAC[exec_pure3_def] >>
+  PURE_REWRITE_TAC[exec_read0_def, exec_read1_def] >>
+  PURE_REWRITE_TAC[exec_write2_def, exec_alloca_def] >>
+  PURE_REWRITE_TAC[exec_ext_call_def] >>
+  PURE_REWRITE_TAC[exec_delegatecall_def] >>
+  PURE_REWRITE_TAC[exec_create_def] >>
+  PURE_REWRITE_TAC[extract_venom_result_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.TOP_CASE_TAC >> TRY BasicProvers.TOP_CASE_TAC >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
   rpt strip_tac >> gvs[is_terminator_def]
 QED
 

--- a/venom/passes/make_ssa/proofs/makeSsaSimScript.sml
+++ b/venom/passes/make_ssa/proofs/makeSsaSimScript.sml
@@ -471,7 +471,9 @@ Proof
   `!i. i < LENGTH bb.bb_instructions - 1 ==>
        ~is_terminator (EL i bb.bb_instructions).inst_opcode` by (
     rpt strip_tac >> spose_not_then strip_assume_tac >>
-    gvs[bb_well_formed_def] >> res_tac >> DECIDE_TAC) >>
+    qpat_x_assum `bb_well_formed bb`
+      (STRIP_ASSUME_TAC o REWRITE_RULE [bb_well_formed_def]) >>
+    res_tac >> DECIDE_TAC) >>
   `MEM v.vs_current_bb (bb_succs bb)` by (
     mp_tac run_block_current_bb_in_succs >>
     disch_then (qspecl_then [`fuel`, `ctx`, `bb`, `s1`, `v`] mp_tac) >>
@@ -1971,6 +1973,7 @@ Proof
       qexists_tac `rs0` >>
       PURE_REWRITE_TAC [GSYM (!func'_eq_ref)] >>
       rpt conj_tac >>
+      TRY (first_assum ACCEPT_TAC) >>
       gvs[] >>
       TRY (`~(v1:venom_state).vs_halted` by metis_tac[run_block_OK_not_halted] >>
            `~(v2:venom_state).vs_halted` by metis_tac[run_block_OK_not_halted] >>
@@ -1981,7 +1984,10 @@ Proof
     `~v2.vs_halted` by metis_tac[run_block_OK_not_halted] >>
     ASM_REWRITE_TAC[] >>
     first_assum ACCEPT_TAC) >>
-  gvs[ssa_result_equiv_def, result_equiv_def]
+  TRY (first_assum ACCEPT_TAC) >>
+  qpat_x_assum `ssa_result_equiv _ _` mp_tac >>
+  PURE_REWRITE_TAC[ssa_result_equiv_def] >>
+  simp_tac std_ss [exec_result_case_def, result_equiv_def]
 QED
 
 

--- a/venom/passes/make_ssa/proofs/makeSsaSsaFormScript.sml
+++ b/venom/passes/make_ssa/proofs/makeSsaSsaFormScript.sml
@@ -37,7 +37,9 @@ Proof
   first_x_assum drule >> strip_tac >>
   rpt gen_tac >> strip_tac >> gvs[]
   (* Case 1: x = version_var h ver (the newly produced output) *)
-  >- (imp_res_tac version_var_inj >> gvs[] >>
+  >- (imp_res_tac version_var_inj >>
+      qpat_x_assum `v = h` SUBST_ALL_TAC >>
+      qpat_x_assum `n = ver` SUBST_ALL_TAC >>
       imp_res_tac push_version_counter >>
       imp_res_tac rename_outputs_counter_mono >>
       first_x_assum (qspec_then `h` mp_tac) >>

--- a/venom/passes/make_ssa/proofs/ssaPipelinePropsScript.sml
+++ b/venom/passes/make_ssa/proofs/ssaPipelinePropsScript.sml
@@ -4109,7 +4109,11 @@ Resume phi_coverage[case_eq_phi]:
   ) >>
   conj_tac >- (
     `phi_extends func.fn_blocks (add_phi_nodes dom_frontiers pred_map live_in func.fn_blocks defs)` by simp[add_phi_nodes_phi_extends] >>
-    fs[phi_extends_def]
+    qpat_x_assum
+      `LENGTH (add_phi_nodes dom_frontiers pred_map live_in func.fn_blocks defs) =
+       LENGTH func.fn_blocks`
+      (fn th => PURE_REWRITE_TAC [GSYM th]) >>
+    first_assum ACCEPT_TAC
   ) >>
   qexistsl [`lbl_a`, `lbl_b`, `j_a`] >>
   simp[] >>

--- a/venom/passes/make_ssa/proofs/ssaRenamedSimScript.sml
+++ b/venom/passes/make_ssa/proofs/ssaRenamedSimScript.sml
@@ -58,8 +58,15 @@ Triviality exec_pure2_renamed:
                   s1' s2'
 Proof
   rw[exec_pure2_def] >>
-  BasicProvers.every_case_tac >> gvs[] >>
+  Cases_on `inst1.inst_operands` >> gvs[] >>
+  Cases_on `t` >> gvs[] >>
+  Cases_on `t'` >> gvs[] >>
+  Cases_on `eval_operand h s1` >> gvs[] >>
+  Cases_on `eval_operand h' s1` >> gvs[] >>
   imp_res_tac eval_operand_renamed >> gvs[] >>
+  Cases_on `inst1.inst_outputs` >> gvs[] >>
+  Cases_on `t` >> gvs[] >>
+  Cases_on `inst2.inst_outputs` >> gvs[] >>
   irule ssa_sim_update_var >> gvs[]
 QED
 
@@ -127,6 +134,26 @@ Proof
   BasicProvers.every_case_tac >> gvs[] >>
   imp_res_tac eval_operand_renamed >> gvs[] >>
   irule ssa_sim_update_var >> gvs[]
+QED
+
+Triviality exec_mload_renamed:
+  !inst1 inst2 sigma s1 s2 s1'.
+    ssa_sim sigma s1 s2 /\
+    inst2.inst_operands = MAP (renamed_operand sigma) inst1.inst_operands /\
+    LENGTH inst2.inst_outputs = LENGTH inst1.inst_outputs /\
+    (inst1.inst_outputs <> [] ==>
+     !x. ~MEM x inst1.inst_outputs /\ lookup_var x s1 <> NONE ==>
+         sigma x <> HD inst2.inst_outputs) /\
+    exec_read1 (\addr s. mload (w2n addr) s) inst1 s1 = OK s1' ==>
+    ?s2'. exec_read1 (\addr s. mload (w2n addr) s) inst2 s2 = OK s2' /\
+          ssa_sim ((HD inst1.inst_outputs =+ HD inst2.inst_outputs) sigma)
+                  s1' s2'
+Proof
+  rpt gen_tac >> strip_tac >>
+  irule exec_read1_renamed >>
+  conj_tac >- first_assum ACCEPT_TAC >>
+  conj_tac >- first_assum ACCEPT_TAC >>
+  qexists_tac `s1` >> gvs[ssa_sim_def, mload_def]
 QED
 
 (* exec_write2: no output variable, modifies state *)
@@ -373,7 +400,16 @@ Proof
   rpt gen_tac >> strip_tac >>
   gvs[inst_renamed_def, output_fresh_def] >>
   Cases_on `inst1.inst_opcode` >> gvs[is_terminator_def] >>
-  gvs step_base_reduces >>
+  gvs (List.take (step_base_reduces, 10)) >>
+  gvs (List.take (List.drop (step_base_reduces, 10), 10)) >>
+  gvs (List.take (List.drop (step_base_reduces, 20), 10)) >>
+  gvs (List.take (List.drop (step_base_reduces, 30), 10)) >>
+  gvs (List.take (List.drop (step_base_reduces, 40), 10)) >>
+  gvs (List.take (List.drop (step_base_reduces, 50), 10)) >>
+  gvs (List.take (List.drop (step_base_reduces, 60), 10)) >>
+  gvs (List.take (List.drop (step_base_reduces, 70), 10)) >>
+  gvs (List.take (List.drop (step_base_reduces, 80), 10)) >>
+  gvs (List.drop (step_base_reduces, 90)) >>
   (* Phase 1: pure opcodes — closed by drule_all + simp[opcode_has_output_def] *)
   TRY (drule_all exec_pure2_renamed >>
        simp[opcode_has_output_def] >> NO_TAC) >>
@@ -384,8 +420,31 @@ Proof
   (* Phase 2: remaining goals — get field equalities, unfold defs *)
   imp_res_tac ssa_sim_fields >>
   imp_res_tac vs_alloca_next_ssa_sim >>
-  gvs[exec_read0_def, exec_read1_def, exec_write2_def,
-      exec_alloca_def, LET_THM, AllCaseEqs(), renamed_operand_def] >>
+  TRY (simp[opcode_has_output_def] >>
+       irule exec_read0_renamed >>
+       conj_tac >- first_assum ACCEPT_TAC >>
+       qexists_tac `s1` >> gvs[] >> NO_TAC) >>
+  TRY (simp[opcode_has_output_def] >>
+       irule exec_read1_renamed >>
+       conj_tac >- first_assum ACCEPT_TAC >>
+       conj_tac >- first_assum ACCEPT_TAC >>
+       qexists_tac `s1` >>
+       gvs[mload_def, sload_def, tload_def,
+           contract_storage_def, contract_transient_def] >> NO_TAC) >>
+  TRY (simp[opcode_has_output_def] >>
+       irule exec_write2_renamed >>
+       conj_tac >- first_assum ACCEPT_TAC >>
+       qexists_tac `s1` >>
+       gvs[mstore_def, mstore8_def, sstore_def, tstore_def,
+           contract_storage_def, contract_transient_def,
+           ssa_sim_def] >> NO_TAC) >>
+  gvs[exec_read0_def] >>
+  gvs[exec_read1_def] >>
+  gvs[exec_write2_def] >>
+  gvs[exec_alloca_def] >>
+  gvs[LET_THM] >>
+  gvs[AllCaseEqs()] >>
+  gvs[renamed_operand_def] >>
   TRY (imp_res_tac eval_operand_renamed >> gvs[]) >>
   TRY (imp_res_tac eval_operands_renamed >> gvs[]) >>
   (* Phase 3: ext calls — drule_all + simp[opcode_has_output_def] *)
@@ -411,11 +470,13 @@ Proof
   (* Phase 7: LOG needs Cases_on rest to simplify HD (MAP f rest) *)
   TRY (Cases_on `rest` >> gvs[]) >>
   (* Phase 8: state-modifying / trivial — sigma unchanged (opcode_has_output = F) *)
-  gvs[mcopy_def, write_memory_with_expansion_def,
-      mload_def, mstore_def, mstore8_def, sload_def, sstore_def, tload_def, tstore_def,
-      contract_storage_def, contract_transient_def,
-      ssa_sim_def, update_var_def, lookup_var_def,
-      GSYM MAP_APPEND, rich_listTheory.MAP_HD] >>
+  gvs[mcopy_def, write_memory_with_expansion_def] >>
+  gvs[mload_def, mstore_def, mstore8_def] >>
+  gvs[sload_def, sstore_def, contract_storage_def] >>
+  gvs[tload_def, tstore_def, contract_transient_def] >>
+  gvs[ssa_sim_def] >>
+  gvs[update_var_def, lookup_var_def] >>
+  gvs[GSYM MAP_APPEND, rich_listTheory.MAP_HD] >>
   qmatch_goalsub_abbrev_tac `s2.vs_logs ++ [log_entry] = _` >>
   qexists_tac `s2 with vs_logs := s2.vs_logs ++ [log_entry]` >>
   simp[Abbr`log_entry`] >>
@@ -464,17 +525,38 @@ val term_setup_tac =
    then uses gvs to simplify and eliminate Error/contradiction branches.
    The ssa_result_equiv_def + renamed_operand_def in gvs ensure that after
    both sides resolve to constructors, the result matches. *)
-val term_resolve_tac =
-  gvs[renamed_operand_def, extract_labels_renamed] >>
-  rpt (BasicProvers.TOP_CASE_TAC >>
-       gvs[ssa_result_equiv_def, renamed_operand_def, extract_labels_renamed,
-           execution_equiv_UNIV, halt_state_def, set_returndata_def,
-           revert_state_def]) >>
+val term_resolve_pre_tac =
+  gvs[renamed_operand_def, extract_labels_renamed];
+
+val term_resolve_case_tac =
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[ssa_result_equiv_def, renamed_operand_def, extract_labels_renamed,
+      execution_equiv_UNIV, halt_state_def, set_returndata_def,
+      revert_state_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[ssa_result_equiv_def, renamed_operand_def, extract_labels_renamed,
+      execution_equiv_UNIV, halt_state_def, set_returndata_def,
+      revert_state_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[ssa_result_equiv_def, renamed_operand_def, extract_labels_renamed,
+      execution_equiv_UNIV, halt_state_def, set_returndata_def,
+      revert_state_def] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[ssa_result_equiv_def, renamed_operand_def, extract_labels_renamed,
+      execution_equiv_UNIV, halt_state_def, set_returndata_def,
+      revert_state_def];
+
+val term_resolve_post_tac =
   TRY (imp_res_tac eval_operand_renamed >> gvs[]) >>
   TRY (imp_res_tac eval_operands_renamed >> gvs[execution_equiv_UNIV]) >>
   TRY (qexists_tac `sigma` >> irule jump_to_ssa_sim >> simp[]) >>
   gvs[ssa_result_equiv_def, execution_equiv_UNIV, halt_state_def,
       set_returndata_def, revert_state_def];
+
+val term_resolve_tac =
+  term_resolve_pre_tac >>
+  term_resolve_case_tac >> term_resolve_case_tac >>
+  term_resolve_case_tac >> term_resolve_case_tac >> term_resolve_post_tac;
 
 (* Split into per-terminator trivialities to avoid every_case_tac on 7+ goals *)
 Triviality step_term_jmp:
@@ -484,7 +566,9 @@ Triviality step_term_jmp:
     (!e. step_inst_base inst1 s1 <> Error e) ==>
     ssa_result_equiv (step_inst_base inst1 s1) (step_inst_base inst2 s2)
 Proof
-  term_setup_tac >> gvs step_base_reduces >> term_resolve_tac
+  term_setup_tac >> gvs step_base_reduces >> term_resolve_pre_tac >>
+  term_resolve_case_tac >> term_resolve_case_tac >>
+  term_resolve_case_tac >> term_resolve_case_tac >> term_resolve_post_tac
 QED
 
 Triviality step_term_jnz:
@@ -494,7 +578,9 @@ Triviality step_term_jnz:
     (!e. step_inst_base inst1 s1 <> Error e) ==>
     ssa_result_equiv (step_inst_base inst1 s1) (step_inst_base inst2 s2)
 Proof
-  term_setup_tac >> gvs step_base_reduces >> term_resolve_tac
+  term_setup_tac >> gvs step_base_reduces >> term_resolve_pre_tac >>
+  term_resolve_case_tac >> term_resolve_case_tac >>
+  term_resolve_case_tac >> term_resolve_case_tac >> term_resolve_post_tac
 QED
 
 Triviality step_term_djmp:

--- a/venom/passes/mem2var/mem2varCorrectnessScript.sml
+++ b/venom/passes/mem2var/mem2varCorrectnessScript.sml
@@ -232,8 +232,10 @@ Proof
   Cases_on `FIND (\(ao,_0,_1). MEM (Var ao) inst.inst_operands)
                   (m2v_promo_list fn)` >> simp[] >>
   PairCases_on `x` >> simp[m2v_promote_inst_def] >>
-  Cases_on `inst.inst_opcode` >> simp[is_terminator_def] >>
-  rpt (CASE_TAC >> simp[is_terminator_def])
+  Cases_on `inst.inst_opcode` >> simp[is_terminator_def]
+  >- (rpt (CASE_TAC >> simp[is_terminator_def]))
+  >- (rpt (CASE_TAC >> simp[is_terminator_def]))
+  >- (rpt (CASE_TAC >> simp[is_terminator_def]))
 QED
 
 (* m2v_rewrite_inst on non-terminal gives non-terminal singleton *)
@@ -1067,13 +1069,15 @@ Proof
                              s1.vs_alloca_next = s2.vs_alloca_next` >>
             simp[] >> metis_tac[m2v_inv_implies_equiv])))
   >> irule (SRULE [] block_sim_function_with_pred2_bb)
-  >> BETA_TAC >> simp[m2v_bt_preserves_label]
+  >> BETA_TAC
+  >> conj_tac >- (rpt strip_tac >> irule m2v_bt_preserves_label)
   >> conj_tac >- (rpt strip_tac >> gvs[] >>
        metis_tac[m2v_inv_implies_equiv])
   >> conj_tac >- (rpt strip_tac >> gvs[] >>
        metis_tac[m2v_inv_control_flow])
   (* predicate: original-side invariants + fn_reachable + pvars_at_current *)
-  >> qexists `\s1 s2. m2v_fresh_undef fn s1 /\ alloca_inv s1 /\
+  >> conj_tac
+  >- (qexists `\s1 s2. m2v_fresh_undef fn s1 /\ alloca_inv s1 /\
        s1.vs_alloca_next < dimword (:256) /\
        m2v_nonpromoted_access_safe fn s1 /\
        alloca_bridge fn s1 /\
@@ -1120,7 +1124,8 @@ Proof
   qpat_x_assum `m2v_pvars_at_current _ _`
     (mp_tac o REWRITE_RULE[m2v_pvars_at_current_def, m2v_pvars_set_def,
                            lookup_var_def]) >>
-  simp[m2v_pvars_at_current_def, m2v_pvars_set_def, lookup_var_def]
+  simp[m2v_pvars_at_current_def, m2v_pvars_set_def, lookup_var_def])
+  >- simp[]
 QED
 
 Resume m2v_transform_function_correct[nas]:
@@ -1158,7 +1163,8 @@ Resume m2v_transform_function_correct[reach]:
     >- (rpt strip_tac >>
         `i = PRE (LENGTH bk.bb_instructions)` by
           (first_x_assum irule >> simp[]) >>
-        gvs[])
+        qpat_x_assum `i = PRE _` SUBST_ALL_TAC >>
+        qpat_x_assum `PRE _ < _ - 1` mp_tac >> simp[])
     >- simp[]
     >- simp[]) >>
   simp[]

--- a/venom/passes/mem2var/proofs/mem2varBlockSimHelpersScript.sml
+++ b/venom/passes/mem2var/proofs/mem2varBlockSimHelpersScript.sml
@@ -1,6 +1,6 @@
 Theory mem2varBlockSimHelpers
 Ancestors
-  mem2varProofs passSharedTransfer passSharedField instIdxIndep
+  mem2varProofs passSharedFrame passSharedTransfer passSharedField instIdxIndep
   venomMemProps venomMemProofs venomExecProofs venomInstProofs
   mem2varDefs
   venomExecSemantics venomState venomWf
@@ -104,7 +104,19 @@ Proof
   CASE_TAC >> simp[] >>
   PairCases_on `x` >> simp[] >>
   simp[m2v_promote_inst_def] >>
-  rpt (CASE_TAC >> gvs[is_terminator_def])
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  TRY (BasicProvers.TOP_CASE_TAC >> gvs[is_terminator_def]) >>
+  gvs[is_terminator_def]
 QED
 
 (* FRONT of a well-formed block's instructions are non-terminators *)
@@ -2067,9 +2079,15 @@ Theorem m2v_step_promoted_mload:
          m2v_inv_noix fn v1 v2
 Proof
   rpt strip_tac >>
-  gvs[step_inst_non_invoke, step_inst_base_def, exec_read1_def,
-      eval_operand_def, AllCaseEqs()] >>
-  suspend "main"
+  gvs[step_inst_non_invoke] >> suspend "base"
+QED
+
+Resume m2v_step_promoted_mload[base]:
+  gvs[step_inst_base_def] >> suspend "exec"
+QED
+
+Resume m2v_step_promoted_mload[exec]:
+  gvs[exec_read1_def, eval_operand_def, AllCaseEqs()] >> suspend "main"
 QED
 
 Resume m2v_step_promoted_mload[main]:
@@ -2761,12 +2779,15 @@ Proof
 QED
 
 (* step_inst_base wrapper: dispatch all 5 ext_call opcodes *)
-val ext_call_step_tac =
+val ext_call_source_unfold_tac =
   qpat_x_assum `step_inst_base _ s1 = _` mp_tac >>
-  ASM_REWRITE_TAC[step_inst_base_def] >> simp[] >>
-  every_case_tac >> gvs[] >>
-  ASM_REWRITE_TAC[step_inst_base_def] >> simp[] >>
-  every_case_tac >> gvs[];
+  ASM_REWRITE_TAC[step_inst_base_def];
+
+val ext_call_source_cases_tac = gvs[AllCaseEqs()];
+
+val ext_call_target_tac =
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  gvs[AllCaseEqs()];
 
 Triviality m2v_step_ext_call:
   m2v_inv_noix fn s1 s2 /\ m2v_non32_ok fn s1 s2 /\
@@ -2786,11 +2807,51 @@ Triviality m2v_step_ext_call:
 Proof
   rpt strip_tac >>
   (Cases_on `inst.inst_opcode` >> gvs[is_ext_call_op_def])
-  >- (ext_call_step_tac >> suspend "call")
-  >- (ext_call_step_tac >> suspend "static")
-  >- (ext_call_step_tac >> suspend "deleg")
-  >- (ext_call_step_tac >> suspend "create") >>
-  ext_call_step_tac >> suspend "create2"
+  >- (ext_call_source_unfold_tac >> suspend "call_unfold")
+  >- (ext_call_source_unfold_tac >> suspend "static_unfold")
+  >- (ext_call_source_unfold_tac >> suspend "deleg_unfold")
+  >- (ext_call_source_unfold_tac >> suspend "create_unfold") >>
+  ext_call_source_unfold_tac >> suspend "create2_unfold"
+QED
+
+Resume m2v_step_ext_call[call_unfold]:
+  ext_call_source_cases_tac >> suspend "call_source"
+QED
+
+Resume m2v_step_ext_call[static_unfold]:
+  ext_call_source_cases_tac >> suspend "static_source"
+QED
+
+Resume m2v_step_ext_call[deleg_unfold]:
+  ext_call_source_cases_tac >> suspend "deleg_source"
+QED
+
+Resume m2v_step_ext_call[create_unfold]:
+  ext_call_source_cases_tac >> suspend "create_source"
+QED
+
+Resume m2v_step_ext_call[create2_unfold]:
+  ext_call_source_cases_tac >> suspend "create2_source"
+QED
+
+Resume m2v_step_ext_call[call_source]:
+  ext_call_target_tac >> suspend "call"
+QED
+
+Resume m2v_step_ext_call[static_source]:
+  ext_call_target_tac >> suspend "static"
+QED
+
+Resume m2v_step_ext_call[deleg_source]:
+  ext_call_target_tac >> suspend "deleg"
+QED
+
+Resume m2v_step_ext_call[create_source]:
+  ext_call_target_tac >> suspend "create"
+QED
+
+Resume m2v_step_ext_call[create2_source]:
+  ext_call_target_tac >> suspend "create2"
 QED
 
 (* Shared tactic for all 5 ext_call Resume blocks:
@@ -2800,7 +2861,7 @@ fun m2v_inv_call_ctx th =
   List.nth (CONJUNCTS (REWRITE_RULE [m2v_inv_noix_def] th), 7);
 
 val m2v_ext_call_tac =
-  strip_tac >>
+  strip_tac >> gvs[] >>
   FIRST [match_mp_tac exec_ext_call_m2v_inv,
          match_mp_tac exec_delegatecall_m2v_inv,
          match_mp_tac exec_create_m2v_inv] >>
@@ -3585,8 +3646,19 @@ QED
 Resume m2v_nonpromoted_mem_dispatch[mstore]:
   ho_match_mp_tac m2v_step_nonpromoted_mstore >>
   qpat_x_assum `step_inst _ _ _ s1 = _` mp_tac >>
-  simp[step_inst_non_invoke, step_inst_base_def, exec_write2_def,
-       AllCaseEqs()] >>
+  simp[step_inst_non_invoke] >> suspend "mstore_base"
+QED
+
+Resume m2v_nonpromoted_mem_dispatch[mstore_base]:
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> ASM_REWRITE_TAC[] >>
+  suspend "mstore_exec"
+QED
+
+Resume m2v_nonpromoted_mem_dispatch[mstore_exec]:
+  simp[exec_write2_def, AllCaseEqs()] >> suspend "mstore_done"
+QED
+
+Resume m2v_nonpromoted_mem_dispatch[mstore_done]:
   strip_tac >> gvs[] >>
   rename1 `eval_operand _ s2 = SOME data_v` >>
   `eval_operand op1 s1 = SOME addr` by gvs[] >>
@@ -3611,7 +3683,8 @@ QED
 Resume m2v_nonpromoted_mem_dispatch[mload]:
   ho_match_mp_tac m2v_step_nonpromoted_read1 >>
   qexistsl [`\addr s. mload (w2n addr) s`, `s1`] >>
-  gvs[step_inst_non_invoke, step_inst_base_def] >>
+  ASM_REWRITE_TAC[step_inst_non_invoke, step_inst_base_def,
+                  is_alloca_op_def] >> gvs[] >>
   rpt strip_tac >>
   irule mload_mem_byte_eq >> rpt strip_tac >>
   qpat_x_assum `m2v_inv_noix _ _ _` mp_tac >>
@@ -3620,7 +3693,11 @@ Resume m2v_nonpromoted_mem_dispatch[mload]:
   mp_tac (Q.SPECL [`fn`, `s1`, `bb`, `inst`] nas_read_range_disjoint) >>
   simp[mem_read_ops_def, is_immutable_op_def, eval_operand_def] >>
   disch_then irule >>
-  qpat_x_assum `exec_read1 _ _ _ = OK _` mp_tac >>
+  `step_inst fuel ctx inst s1 = step_inst_base inst s1` by
+    (irule step_inst_non_invoke >> simp[]) >>
+  qpat_x_assum `step_inst fuel ctx inst s1 = OK v1` mp_tac >>
+  ASM_REWRITE_TAC[] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> ASM_REWRITE_TAC[] >>
   simp[exec_read1_def, AllCaseEqs()] >> strip_tac >> gvs[] >>
   simp[eval_operand_def, lt_32_dimword_256, arithmeticTheory.LESS_MOD]
 QED
@@ -4444,16 +4521,7 @@ Theorem step_inst_base_abort_input_equiv:
     s1.vs_labels = s2.vs_labels ==>
     ?s2'. step_inst_base inst s2 = Abort a s2'
 Proof
-  rpt strip_tac >>
-  qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
-  step_base_result_tac >>
-  rpt (first_x_assum (fn th =>
-    mp_tac (REWRITE_RULE [eval_operand_def] th))) >>
-  rpt (CHANGED_TAC (
-    TRY (Cases_on `cond_op` >> gvs[eval_operand_def]) >>
-    TRY (Cases_on `op_destOffset` >> gvs[eval_operand_def]) >>
-    TRY (Cases_on `op_offset` >> gvs[eval_operand_def]) >>
-    TRY (Cases_on `op_size` >> gvs[eval_operand_def])))
+  ACCEPT_TAC passSharedFrameTheory.step_inst_base_abort_input_equiv
 QED
 
 (* Characterize abort state form for non-terminal step_inst_base *)
@@ -4631,12 +4699,33 @@ Resume m2v_pvars_set_after_dispatch[mstore_cond]:
   (* ao=fao since both are first operand; uniqueness gives pvar=fpvar, 32=fsz *)
   mp_tac (Q.SPECL [`fn`,`ao`,`pvar`,`32`,`fpvar`,`fsz`]
     m2v_promo_list_ao_unique) >> simp[] >> strip_tac >> gvs[] >>
-  (* MSTORE+sz=32: promote_inst produces ASSIGN to pvar *)
-  gvs[m2v_promote_inst_def] >>
-  (* step_inst on ASSIGN: exec_read1 writes to output *)
-  gvs[step_inst_non_invoke, is_terminator_def,
-      step_inst_base_def, exec_read1_def, AllCaseEqs(),
-      lookup_var_update]
+  (* MSTORE+sz=32: promote_inst produces ASSIGN to pvar.  Keep the two
+     operand-shape branches in separate suspended goals. *)
+  gvs[m2v_promote_inst_def]
+  >- (gvs[step_inst_non_invoke, is_terminator_def] >>
+      suspend "mstore_cond_a_base")
+  >- (gvs[step_inst_non_invoke, is_terminator_def] >>
+      suspend "mstore_cond_b_base")
+QED
+
+Resume m2v_pvars_set_after_dispatch[mstore_cond_a_base]:
+  gvs[step_inst_base_def] >> suspend "mstore_cond_a_exec"
+QED
+
+Resume m2v_pvars_set_after_dispatch[mstore_cond_b_base]:
+  gvs[step_inst_base_def] >> suspend "mstore_cond_b_exec"
+QED
+
+Resume m2v_pvars_set_after_dispatch[mstore_cond_a_exec]:
+  gvs[exec_read1_def, AllCaseEqs(), lookup_var_update] >>
+  rpt strip_tac >>
+  gvs[update_var_def, lookup_var_def, finite_mapTheory.FLOOKUP_UPDATE]
+QED
+
+Resume m2v_pvars_set_after_dispatch[mstore_cond_b_exec]:
+  gvs[exec_read1_def, AllCaseEqs(), lookup_var_update] >>
+  rpt strip_tac >>
+  gvs[update_var_def, lookup_var_def, finite_mapTheory.FLOOKUP_UPDATE]
 QED
 
 (* Preservation condition: IS_SOME preserved across step *)

--- a/venom/passes/mem2var/proofs/mem2varBlockSimScript.sml
+++ b/venom/passes/mem2var/proofs/mem2varBlockSimScript.sml
@@ -89,7 +89,17 @@ QED
 Resume m2v_per_block_sim_at[terminal]:
   (* idx = last index *)
   SUBGOAL_THEN ``idx = PRE (LENGTH bb.bb_instructions)`` assume_tac
-  >- gvs[bb_well_formed_def, Abbr `inst`] >>
+  >- (qpat_x_assum `bb_well_formed bb` mp_tac >>
+      PURE_REWRITE_TAC[bb_well_formed_def] >> strip_tac >>
+      qpat_x_assum `!i. i < LENGTH bb.bb_instructions /\ _ ==> _`
+        (qspec_then `idx` mp_tac) >>
+      impl_tac
+      >- (conj_tac >- FIRST_ASSUM ACCEPT_TAC >>
+          qpat_x_assum `Abbrev (inst = bb.bb_instructions❲idx❳)`
+            (fn th => SUBST1_TAC
+              (GSYM (REWRITE_RULE [markerTheory.Abbrev_def] th))) >>
+          FIRST_ASSUM ACCEPT_TAC) >>
+      simp[]) >>
   (* inst = LAST bb.bb_instructions *)
   SUBGOAL_THEN ``inst = LAST bb.bb_instructions`` assume_tac
   >- (gvs[Abbr `inst`] >>
@@ -311,11 +321,33 @@ Resume m2v_per_block_sim_at[nonterminal]:
     `HD (m2v_rewrite_inst fn (EL idx bb.bb_instructions))`,
     `bb`, `m2v_bt fn bb`, `fuel`, `ctx`, `s1`, `s2`]
     m2v_exec_block_step_chain) >>
-  simp[Abbr `inst`] >>
   (impl_tac >- (
     rpt conj_tac
+    (* source index is in range *)
+    >- (qpat_x_assum `Abbrev (idx = s1.vs_inst_idx)`
+          (fn th => SUBST1_TAC
+            (GSYM (REWRITE_RULE [markerTheory.Abbrev_def] th))) >>
+        FIRST_ASSUM ACCEPT_TAC)
+    (* target and source indices agree *)
+    >- (qpat_x_assum `Abbrev (idx = s1.vs_inst_idx)`
+          (fn th => SUBST1_TAC
+            (GSYM (REWRITE_RULE [markerTheory.Abbrev_def] th))) >>
+        FIRST_ASSUM ACCEPT_TAC)
+    (* selected source instruction *)
+    >- (qpat_x_assum `Abbrev (idx = s1.vs_inst_idx)`
+          (fn th => SUBST1_TAC
+            (GSYM (REWRITE_RULE [markerTheory.Abbrev_def] th))) >>
+        REFL_TAC)
     (* get_instruction on transformed block *)
-    >- (irule m2v_bt_get_inst_nonterm >> simp[])
+    >- (qpat_x_assum `Abbrev (idx = s1.vs_inst_idx)`
+          (fn th => SUBST1_TAC
+            (GSYM (REWRITE_RULE [markerTheory.Abbrev_def] th))) >>
+        irule m2v_bt_get_inst_nonterm >> simp[])
+    (* source instruction is non-terminal *)
+    >- (qpat_x_assum `Abbrev (inst = bb.bb_instructions❲idx❳)`
+          (fn th => SUBST1_TAC
+            (GSYM (REWRITE_RULE [markerTheory.Abbrev_def] th))) >>
+        FIRST_ASSUM ACCEPT_TAC)
     (* inst2 is non-terminal *)
     >- (irule m2v_rewrite_nonterm >> simp[])
     (* Step-level simulation: Error ∨ lift_result *)
@@ -325,10 +357,16 @@ Resume m2v_per_block_sim_at[nonterminal]:
   simp[]
 QED
 Resume m2v_per_block_sim_at[step_sim]:
-  qabbrev_tac `inst = EL idx bb.bb_instructions` >>
   (* Derive no-invoke for this instruction *)
   SUBGOAL_THEN ``inst.inst_opcode <> INVOKE`` assume_tac
-  >- (gvs[EVERY_EL, Abbr `inst`]) >>
+  >- (qpat_x_assum `Abbrev (inst = bb.bb_instructions❲idx❳)`
+        (fn th => SUBST1_TAC
+          (REWRITE_RULE [markerTheory.Abbrev_def] th)) >>
+      qpat_x_assum `EVERY (λi. i.inst_opcode <> INVOKE) bb.bb_instructions`
+        (fn th => irule
+          (SIMP_RULE (srw_ss()) []
+            (Q.SPEC `idx` (REWRITE_RULE [EVERY_EL] th)))) >>
+      FIRST_ASSUM ACCEPT_TAC) >>
   Cases_on `step_inst fuel ctx inst s1`
   (* OK: dispatch handles all opcodes + non32_ok preservation *)
   >- suspend "ok_case"
@@ -407,6 +445,14 @@ Resume m2v_per_block_sim_at[abort_non32]:
 QED
 Resume m2v_per_block_sim_at[ih_cont]:
   rpt strip_tac >>
+  qpat_x_assum `(λs1 s2. _) s1' s2'`
+    (strip_assume_tac o SIMP_RULE (srw_ss()) []) >>
+  SUBGOAL_THEN
+    ``~is_terminator (EL idx bb.bb_instructions).inst_opcode`` assume_tac
+  >- (qpat_x_assum `Abbrev (inst = bb.bb_instructions❲idx❳)`
+        (fn th => SUBST1_TAC
+          (GSYM (REWRITE_RULE [markerTheory.Abbrev_def] th))) >>
+      FIRST_ASSUM ACCEPT_TAC) >>
   SUBGOAL_THEN ``MEM (EL idx bb.bb_instructions) (fn_insts fn)``
     assume_tac
   >- (irule MEM_fn_insts >> qexists `bb` >> simp[MEM_EL] >>
@@ -451,13 +497,15 @@ Resume m2v_per_block_sim_at[ih_cont]:
       simp[]) >>
   (impl_tac >- (
     simp[vs_inst_idx_update_transparent_export] >>
-    rpt conj_tac
-    >> TRY (first_assum ACCEPT_TAC)
-    >> TRY (irule m2v_inv_noix_update_idx >> simp[] >> NO_TAC)
-    >> TRY (MATCH_MP_TAC m2v_non32_ok_update_idx >> simp[] >> NO_TAC)
-    >> TRY (irule m2v_ao_undef_sync_update_idx >> simp[] >> NO_TAC)
-    >> TRY (irule m2v_pvars_set_update_idx >> simp[] >> NO_TAC)
-    >> (irule nao_dispatch_preserved >> metis_tac[]))) >>
+    rpt conj_tac >> TRY (first_assum ACCEPT_TAC) >>
+    FIRST
+      [(irule m2v_inv_noix_update_idx >> simp[]),
+       (MATCH_MP_TAC m2v_non32_ok_update_idx >> simp[]),
+       (irule m2v_ao_undef_sync_update_idx >> simp[]),
+       (irule m2v_pvars_set_update_idx >> simp[]),
+       (irule (Q.SPECL [`fn`, `bb`, `idx`, `fuel`, `ctx`, `s1`, `s2`,
+                         `s1'`, `s2'`] nao_dispatch_preserved) >>
+        rpt conj_tac >> FIRST_ASSUM ACCEPT_TAC)])) >>
   simp[]
 QED
 Finalise m2v_per_block_sim_at

--- a/venom/passes/mem2var/proofs/mem2varProofsScript.sml
+++ b/venom/passes/mem2var/proofs/mem2varProofsScript.sml
@@ -750,6 +750,14 @@ Theorem step_inst_base_ok_preserves_allocas:
     s'.vs_allocas = s.vs_allocas
 Proof
   rpt strip_tac >>
+  mp_tac (Q.SPECL [`inst`, `s`, `s'`]
+    venomMemPropsTheory.step_inst_base_preserves_allocas) >>
+  ASM_REWRITE_TAC[] >> simp[]
+QED
+
+(* Legacy direct proof retained below is unnecessary now that the shared
+   memory-frame theorem is available. *)
+(*
   fs[step_inst_base_def, AllCaseEqs()] >>
   gvs[AllCaseEqs(),
       exec_pure1_def, exec_pure2_def, exec_pure3_def,
@@ -763,6 +771,7 @@ Proof
       revert_state_def, eval_operands_def, jump_to_def,
       lookup_var_def, FLOOKUP_UPDATE, halt_state_def, set_returndata_def]
 QED
+*)
 
 (* Alloca bridge: relates lookup_var of alloca outputs to vs_allocas.
    Two clauses:

--- a/venom/passes/memory_copy_elision/memoryCopyElisionCorrectnessScript.sml
+++ b/venom/passes/memory_copy_elision/memoryCopyElisionCorrectnessScript.sml
@@ -339,7 +339,15 @@ Proof
     qspecl_then [`aliases`,`bp`,`uc`,`bb`,`i`] mp_tac
       (REWRITE_RULE [LET_THM] lse_block_trace) >>
     simp[Abbr `bb'`, lse_block_length] >> strip_tac >>
-    gvs[bb_well_formed_def, is_terminator_def])
+    `is_terminator bb.bb_instructions❲i❳.inst_opcode` by (
+      qpat_x_assum
+        `is_terminator (load_store_elim_block aliases bp uc bb).bb_instructions❲i❳.inst_opcode`
+        mp_tac >>
+      ASM_REWRITE_TAC[is_terminator_def]) >>
+    qpat_x_assum `bb_well_formed bb`
+      (STRIP_ASSUME_TAC o REWRITE_RULE [bb_well_formed_def]) >>
+    qpat_x_assum `!k. _ ==> k = PRE (LENGTH bb.bb_instructions)`
+      (qspec_then `i` mp_tac) >> simp[])
   (* PHI ordering: bb'[j] = PHI /\ i<j => bb'[i] = PHI *)
   >> (
     rpt strip_tac >>

--- a/venom/passes/memory_copy_elision/proofs/memoryCopyElisionProofsScript.sml
+++ b/venom/passes/memory_copy_elision/proofs/memoryCopyElisionProofsScript.sml
@@ -20,7 +20,7 @@ Ancestors
   basePtrDefs basePtrProps basePtrProofs
   venomWf venomInst venomInstProps venomEffects venomExecSemantics venomExecProps
   venomState venomMemDefs venomMemProps
-  dfgAnalysisProps dfgCorrectnessProof dfgDefs dfAnalyzeDefs
+  dfgAnalysisProps dfgCorrectnessProof dfgSoundStep dfgDefs dfAnalyzeDefs
   dfIterateProps dfIterateProofs
   memAliasDefs memAliasProofs memLocDefs
   cfgDefs cfgHelpers cfgAnalysisProps
@@ -103,7 +103,14 @@ Proof
     qexists `inst` >> simp[] >>
     Cases_on `inst.inst_opcode` >> gvs[] >> NO_TAC) >>
   rpt (IF_CASES_TAC >> fs[mk_nop_inst_def, is_terminator_def]) >>
-  rpt (CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def]) >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
   imp_res_tac copy_opcode_not_term >> imp_res_tac copy_opcode_not_invoke >>
   imp_res_tac copy_opcode_not_phi >>
   fs[]
@@ -908,7 +915,7 @@ Triviality phi_filter_fwd_inst_wf_for_bp_fdom[local]:
 Proof
   rpt strip_tac >>
   rw[phi_filter_fwd_def] >>
-  Cases_on `inst.inst_opcode` >> gvs[is_ptr_opcode_def, inst_wf_def] >>
+  gvs[inst_wf_def] >>
   simp[phi_well_formed_flat_phi_pairs]
 QED
 
@@ -1132,7 +1139,9 @@ Proof
   Cases_on `t` >> gvs[] >>
   (* 2+ outputs, but non-INVOKE inst_wf constrains to 0 or 1 outputs *)
   rename1 `inst.inst_outputs = out1 :: out2 :: rest` >>
-  Cases_on `inst.inst_opcode` >> gvs[inst_wf_def]
+  `LENGTH inst.inst_outputs <= 1` by
+    metis_tac[inst_wf_noninvoke_outputs_at_most_one] >>
+  gvs[]
 QED
 
 (* Output of instruction is not in its own uses (from block-level self-use
@@ -1222,7 +1231,53 @@ Proof
   >> rpt strip_tac >> gvs[bp_get_ptrs_def, FLOOKUP_UPDATE] >>
   gvs[inst_uses_def, venomInstTheory.operand_vars_def,
        venomInstTheory.operand_var_def] >>
-  BasicProvers.EVERY_CASE_TAC >>
+  Cases_on `inst.inst_operands` >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  Cases_on `t` >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY (Cases_on `t'`) >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY (Cases_on `h`) >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY (Cases_on `h'`) >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY BasicProvers.TOP_CASE_TAC >>
   gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
   (* Remaining: ADD/SUB Var-Var with out as operand (contradiction),
      and PHI operand ptrs agreement *)
@@ -1234,13 +1289,17 @@ Proof
        (MAP SND (phi_pairs inst.inst_operands)) =
    MAP (bp_get_ptrs bp) (MAP SND (phi_pairs inst.inst_operands))` by (
     irule MAP_CONG >> simp[] >> rpt strip_tac >>
+    qmatch_goalsub_rename_tac
+      `bp_get_ptrs (DRESTRICT bp (COMPL {out})) phi_v = _` >>
     simp[bp_get_ptrs_def, FLOOKUP_DRESTRICT] >>
-    `x <> out` by (
+    `phi_v <> out` by (
       CCONTR_TAC >> gvs[] >>
       imp_res_tac phi_pairs_mem_operand_vars >>
-      metis_tac[]) >>
+      gvs[EVERY_MEM, venomInstTheory.operand_vars_def,
+          venomInstTheory.operand_var_def]) >>
     simp[]) >>
-  gvs[]
+  BasicProvers.EVERY_CASE_TAC >>
+  gvs[bp_get_ptrs_def, FLOOKUP_UPDATE, FLOOKUP_DRESTRICT]
 QED
 
 (* Per-instruction bp_ptr_sound preservation at the fixpoint.
@@ -3308,11 +3367,14 @@ Proof
    | Error e => Error e` by (
     CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [exec_block_def])) >>
     simp[get_instruction_def, Abbr `inst`, Abbr `idx`]) >>
-  pop_assum (fn th => FULL_SIMP_TAC std_ss [th]) >>
+  qpat_x_assum `exec_block fuel run_ctx bb st = OK v` (fn ok_th =>
+    qpat_x_assum `exec_block fuel run_ctx bb st = _` (fn unfold_th =>
+      assume_tac (REWRITE_RULE [unfold_th] ok_th))) >>
   Cases_on `step_inst fuel run_ctx inst st`
   >- (
     rename1 `step_inst _ _ _ _ = OK st'` >>
-    FULL_SIMP_TAC std_ss [exec_result_case_def] >>
+    qpat_x_assum `_ = OK v` (fn th =>
+      assume_tac (SIMP_RULE std_ss [exec_result_case_def] th)) >>
     `dfg_assigns_sound dfg (st' with vs_inst_idx := 0) /\
      bp_ptr_sound bp (st' with vs_inst_idx := 0) /\
      allocas_non_overlapping (st' with vs_inst_idx := 0) /\
@@ -3338,6 +3400,7 @@ Proof
     qpat_x_assum `~is_terminator inst.inst_opcode` (fn nonterm_th =>
       qpat_x_assum `(if is_terminator inst.inst_opcode then if st'.vs_halted then Halt st' else OK st' else run_block_non_phis fuel run_ctx bb (st' with vs_inst_idx := SUC idx)) = OK v`
         (fn eq_th => assume_tac (REWRITE_RULE [nonterm_th] eq_th))) >>
+    qpat_x_assum `n = LENGTH bb.bb_instructions - idx` SUBST_ALL_TAC >>
     qpat_x_assum `!m. m < LENGTH bb.bb_instructions - idx ==> _`
       (qspec_then `LENGTH bb.bb_instructions - SUC idx` mp_tac) >>
     impl_tac >- simp[Abbr `idx`] >>
@@ -5660,8 +5723,12 @@ Proof
     (mp_tac load_bp_get_read_bridge >> simp[]) >>
   (* Case split on the 3 load opcodes; all use exec_read1 *)
   Cases_on `inst.inst_opcode` >> gvs[is_load_fact_opcode_def] >>
-  gvs[step_inst_def, is_terminator_def, step_inst_base_def,
-      exec_read1_def] >>
+  gvs[step_inst_def, is_terminator_def] >>
+  qpat_x_assum `step_inst_base inst s = OK s'` mp_tac >>
+  ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[venomInstTheory.opcode_case_def] >>
+  strip_tac >>
+  gvs[exec_read1_def] >>
   (* From OK result: eval_operand ops.iao_ofst s = SOME v *)
   Cases_on `eval_operand ops.iao_ofst s` >> gvs[] >>
   rename1 `eval_operand _ s = SOME v` >>
@@ -5859,8 +5926,14 @@ Proof
   rpt gen_tac >> reverse IF_CASES_TAC >> gvs[] >- metis_tac[] >>
   simp[load_store_step_def, LET_THM] >> rpt COND_CASES_TAC >>
   gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT, invalidate_loads_def] >>
-  rpt (CASE_TAC >>
-       gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT]) >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
   rpt strip_tac >> gvs[] >> res_tac
 QED
 
@@ -6738,7 +6811,17 @@ Triviality lf_at_opcode_inv[local]:
 Proof
   Induct_on `i` >> simp[lf_at_def, FLOOKUP_EMPTY] >>
   rpt gen_tac >> reverse IF_CASES_TAC >> gvs[] >- metis_tac[] >>
-  simp[load_store_step_def, LET_THM] >> rpt COND_CASES_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT, invalidate_loads_def] >> rpt (CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT]) >> rpt strip_tac >> gvs[] >> res_tac
+  simp[load_store_step_def, LET_THM] >> rpt COND_CASES_TAC >>
+  gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT, invalidate_loads_def] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  TRY CASE_TAC >> gvs[FLOOKUP_UPDATE, FLOOKUP_DRESTRICT] >>
+  rpt strip_tac >> gvs[] >> res_tac
 QED
 
 (* ALL_DISTINCT flat-map disjointness at different indices *)

--- a/venom/passes/memory_copy_elision/proofs/memoryCopyElisionSoundScript.sml
+++ b/venom/passes/memory_copy_elision/proofs/memoryCopyElisionSoundScript.sml
@@ -673,7 +673,14 @@ Proof
     qexists `inst` >> simp[] >>
     Cases_on `inst.inst_opcode` >> gvs[] >> NO_TAC) >>
   rpt (IF_CASES_TAC >> fs[mk_nop_inst_def, is_terminator_def]) >>
-  rpt (CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def]) >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
+  TRY CASE_TAC >> fs[mk_nop_inst_def, is_terminator_def] >>
   imp_res_tac copy_opcode_not_term >> imp_res_tac copy_opcode_not_invoke >>
   imp_res_tac copy_opcode_not_phi >>
   fs[]

--- a/venom/passes/overflow_elim/proofs/overflowElimHelpers2Script.sml
+++ b/venom/passes/overflow_elim/proofs/overflowElimHelpers2Script.sml
@@ -811,7 +811,10 @@ Theorem step_inst_base_assign:
   ?w. eval_operand op st = SOME w /\
       st' = update_var out w st
 Proof
-  strip_tac >> gvs[step_inst_base_def, AllCaseEqs()]
+  strip_tac >>
+  qpat_x_assum `step_inst_base inst st = OK st'` mp_tac >>
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  simp[AllCaseEqs()] >> strip_tac >> gvs[]
 QED
 
 Theorem step_inst_base_iszero:
@@ -847,7 +850,11 @@ Theorem step_inst_base_lt:
   ?w1 w2. eval_operand op1 st = SOME w1 /\ eval_operand op2 st = SOME w2 /\
            st' = update_var out (bool_to_word (w2n w1 < w2n w2)) st
 Proof
-  strip_tac >> gvs[step_inst_base_def, exec_pure2_def, AllCaseEqs()]
+  strip_tac >>
+  qpat_x_assum `step_inst_base inst st = OK st'` mp_tac >>
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  simp[exec_pure2_def, AllCaseEqs()] >>
+  strip_tac >> gvs[]
 QED
 
 Theorem step_inst_base_gt:
@@ -856,7 +863,11 @@ Theorem step_inst_base_gt:
   ?w1 w2. eval_operand op1 st = SOME w1 /\ eval_operand op2 st = SOME w2 /\
            st' = update_var out (bool_to_word (w2n w1 > w2n w2)) st
 Proof
-  strip_tac >> gvs[step_inst_base_def, exec_pure2_def, AllCaseEqs()]
+  strip_tac >>
+  qpat_x_assum `step_inst_base inst st = OK st'` mp_tac >>
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  simp[exec_pure2_def, AllCaseEqs()] >>
+  strip_tac >> gvs[]
 QED
 
 Theorem step_inst_base_eq:
@@ -865,7 +876,11 @@ Theorem step_inst_base_eq:
   ?w1 w2. eval_operand op1 st = SOME w1 /\ eval_operand op2 st = SOME w2 /\
            st' = update_var out (bool_to_word (w1 = w2)) st
 Proof
-  strip_tac >> gvs[step_inst_base_def, exec_pure2_def, AllCaseEqs()]
+  strip_tac >>
+  qpat_x_assum `step_inst_base inst st = OK st'` mp_tac >>
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  simp[exec_pure2_def, AllCaseEqs()] >>
+  strip_tac >> gvs[]
 QED
 
 Theorem step_inst_base_slt:
@@ -874,7 +889,11 @@ Theorem step_inst_base_slt:
   ?w1 w2. eval_operand op1 st = SOME w1 /\ eval_operand op2 st = SOME w2 /\
            st' = update_var out (bool_to_word (word_lt w1 w2)) st
 Proof
-  strip_tac >> gvs[step_inst_base_def, exec_pure2_def, AllCaseEqs()]
+  strip_tac >>
+  qpat_x_assum `step_inst_base inst st = OK st'` mp_tac >>
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  simp[exec_pure2_def, AllCaseEqs()] >>
+  strip_tac >> gvs[]
 QED
 
 Theorem step_inst_base_sgt:
@@ -883,7 +902,11 @@ Theorem step_inst_base_sgt:
   ?w1 w2. eval_operand op1 st = SOME w1 /\ eval_operand op2 st = SOME w2 /\
            st' = update_var out (bool_to_word (word_gt w1 w2)) st
 Proof
-  strip_tac >> gvs[step_inst_base_def, exec_pure2_def, AllCaseEqs()]
+  strip_tac >>
+  qpat_x_assum `step_inst_base inst st = OK st'` mp_tac >>
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  simp[exec_pure2_def, AllCaseEqs()] >>
+  strip_tac >> gvs[]
 QED
 
 

--- a/venom/passes/overflow_elim/proofs/overflowElimHelpersScript.sml
+++ b/venom/passes/overflow_elim/proofs/overflowElimHelpersScript.sml
@@ -270,12 +270,21 @@ Proof
   `step_inst_base inst s = OK s'` by (fs[step_inst_def] >> gvs[]) >>
   Cases_on `?out. out NOTIN FDOM s.vs_vars /\ out IN FDOM s'.vs_vars`
   >- (fs[] >>
+      `inst_wf inst` by metis_tac[fn_insts_inst_wf] >>
       `inst.inst_outputs = [out]` by
-        metis_tac[step_inst_base_new_var_singleton] >>
+        (mp_tac (Q.SPECL [`inst`, `s`, `s'`, `out`]
+           step_inst_base_new_var_singleton) >>
+         impl_tac >- (
+           rpt conj_tac >>
+           TRY (qpat_x_assum `step_inst_base inst s = OK s'` ACCEPT_TAC) >>
+           TRY (qpat_x_assum `inst_wf inst` ACCEPT_TAC) >>
+           TRY (qpat_x_assum `~is_terminator inst.inst_opcode` ACCEPT_TAC) >>
+           TRY (qpat_x_assum `out NOTIN FDOM s.vs_vars` ACCEPT_TAC) >>
+           TRY (qpat_x_assum `out IN FDOM s'.vs_vars` ACCEPT_TAC)) >>
+         DISCH_THEN ACCEPT_TAC) >>
       `s'.vs_vars = s.vs_vars |+ (out, THE (FLOOKUP s'.vs_vars out))` by
         metis_tac[step_inst_base_vars_fupdate] >>
       qabbrev_tac `nv = THE (FLOOKUP s'.vs_vars out)` >>
-      `inst_wf inst` by metis_tac[fn_insts_inst_wf] >>
       `!d. dfg_get_def (dfg_build_function fn) out = SOME d ==>
            d = inst` by
         (rpt strip_tac >> imp_res_tac dfg_build_function_correct >>
@@ -302,12 +311,23 @@ Proof
                        (if di.inst_opcode = LT
                         then w2n w1 < w2n w2
                         else w2n w1 > w2n w2))` by
-        (rpt strip_tac >> `di = inst` by metis_tac[] >>
-         pop_assum SUBST_ALL_TAC >>
-         metis_tac[step_inst_base_arith_condition,
-                   step_inst_base_compare_condition]) >>
+        (conj_tac
+         >- (rpt strip_tac >> `di = inst` by metis_tac[] >>
+             pop_assum SUBST_ALL_TAC >>
+             mp_tac (Q.SPECL [`inst`, `s`, `s'`, `out`, `nv`,
+               `op1'`, `op2'`] step_inst_base_arith_condition) >>
+             impl_tac >- simp[] >> simp[])
+         >- (rpt strip_tac >> `di = inst` by metis_tac[] >>
+             pop_assum SUBST_ALL_TAC >>
+             mp_tac (Q.SPECL [`inst`, `s`, `s'`, `out`, `nv`,
+               `op1'`, `op2'`] step_inst_base_compare_condition) >>
+             impl_tac >- simp[] >> simp[])) >>
       fs[] >>
-      metis_tac[dfg_arith_sound_fupdate, dfg_compare_full_sound_fupdate])
+      conj_tac
+      >- (irule dfg_arith_sound_fupdate >> simp[] >>
+          rpt strip_tac >> `dinst = inst` by metis_tac[] >> gvs[])
+      >- (irule dfg_compare_full_sound_fupdate >> simp[] >>
+          rpt strip_tac >> `dinst = inst` by metis_tac[] >> gvs[]))
   >- (`s'.vs_vars = s.vs_vars` by metis_tac[step_inst_vars_unchanged] >>
       ASM_REWRITE_TAC[])
 QED
@@ -773,7 +793,15 @@ Proof
   (* Extract chain components from try_elim_add_overflow_v.
      Keep in assumptions, decompose via fs + FULL_CASE_TAC *)
   fs[try_elim_add_overflow_v_def] >>
-  rpt (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.FULL_CASE_TAC >> gvs[] >>
   (* Extract res_v, get compare and arith semantics *)
   rename1 `get_producer dfg res_op = SOME add_inst` >>
   rename1 `cmp_inst.inst_operands = [res_op; x_op]` >>

--- a/venom/passes/overflow_elim/proofs/overflowElimProofsScript.sml
+++ b/venom/passes/overflow_elim/proofs/overflowElimProofsScript.sml
@@ -111,9 +111,13 @@ Triviality step_assign_output_in_fdom[local]:
     out IN FDOM s'.vs_vars
 Proof
   rpt strip_tac >>
-  Cases_on `inst.inst_operands` >> gvs[step_inst_base_def] >>
-  Cases_on `t` >> gvs[step_inst_base_def] >>
-  Cases_on `eval_operand h s` >> gvs[update_var_def, FDOM_FUPDATE]
+  qpat_x_assum `step_inst_base inst s = OK s'` mp_tac >>
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  Cases_on `inst.inst_operands` >> simp[] >>
+  Cases_on `t` >> simp[] >>
+  Cases_on `eval_operand h s` >>
+  simp[update_var_def, FDOM_FUPDATE] >> strip_tac >>
+  gvs[FDOM_FUPDATE]
 QED
 
 Triviality step_iszero_output_in_fdom[local]:
@@ -130,11 +134,15 @@ Proof
 QED
 
 val tracked_pure2_output_finish_tac =
-  Cases_on `inst.inst_operands` >> gvs[step_inst_base_def, exec_pure2_def] >>
-  Cases_on `t` >> gvs[step_inst_base_def, exec_pure2_def] >>
-  Cases_on `t'` >> gvs[step_inst_base_def, exec_pure2_def] >>
-  Cases_on `eval_operand h s` >> gvs[step_inst_base_def, exec_pure2_def] >>
-  Cases_on `eval_operand h' s` >> gvs[update_var_def, FDOM_FUPDATE];
+  qpat_x_assum `step_inst_base inst s = OK s'` mp_tac >>
+  ASM_REWRITE_TAC[step_inst_base_def] >>
+  Cases_on `inst.inst_operands` >> simp[exec_pure2_def] >>
+  Cases_on `t` >> simp[exec_pure2_def] >>
+  Cases_on `t'` >> simp[exec_pure2_def] >>
+  Cases_on `eval_operand h s` >> simp[exec_pure2_def] >>
+  Cases_on `eval_operand h' s` >>
+  simp[update_var_def, FDOM_FUPDATE] >> strip_tac >>
+  gvs[FDOM_FUPDATE];
 
 Triviality step_pure2_output_in_fdom[local]:
   !inst s s' out.

--- a/venom/passes/phi_elimination/defs/phiTransformScript.sml
+++ b/venom/passes/phi_elimination/defs/phiTransformScript.sml
@@ -479,9 +479,11 @@ Proof
       >- (rpt strip_tac >> Cases_on `inst.inst_opcode` >> fs[is_pseudo_def]) >>
       rpt strip_tac >> metis_tac[terminator_opcode_not_phi]) >>
   gvs[APPEND_ASSOC] >>
-  qspecl_then [`\inst. inst.inst_opcode = PHI`, `phis`, `params ++ regulars ++ terms`]
+  qspecl_then [`\inst. inst.inst_opcode = PHI`, `phis`,
+               `params ++ regulars ++ terms`]
     mp_tac append_pred_prefix >>
-  simp[combinTheory.o_DEF] >>
+  simp_tac std_ss [combinTheory.o_DEF] >>
+  asm_simp_tac std_ss [EVERY_APPEND] >>
   disch_then (qspecl_then [`i`, `j`] mp_tac) >> simp[]
 QED
 

--- a/venom/passes/phi_elimination/proofs/phiBlockScript.sml
+++ b/venom/passes/phi_elimination/proofs/phiBlockScript.sml
@@ -152,18 +152,12 @@ Triviality step_inst_base_preserves_prev_bb:
     s'.vs_prev_bb = s.vs_prev_bb
 Proof
   rpt strip_tac >>
-  qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
-  simp[step_inst_base_def] >>
-  Cases_on `inst.inst_opcode` >> gvs[is_terminator_def] >>
-  simp[exec_pure2_def, exec_pure1_def, exec_pure3_def,
-       exec_read0_def, exec_read1_def, exec_write2_def,
-       exec_ext_call_def, exec_delegatecall_def,
-       exec_create_def, exec_alloca_def,
-       extract_venom_result_def] >>
-  strip_tac >> gvs[AllCaseEqs()] >>
-  rpt (pairarg_tac >> gvs[AllCaseEqs()]) >>
-  gvs[update_var_def, mstore_def, mstore8_def, sstore_def, tstore_def,
-      write_memory_with_expansion_def, mcopy_def, revert_state_def]
+  drule step_inst_base_OK_not_INVOKE >> strip_tac >>
+  `step_inst 0 ARB inst s = step_inst_base inst s` by
+    (irule step_inst_non_invoke >> simp[]) >>
+  mp_tac (Q.SPECL [`0`, `ARB`, `inst`, `s`, `s'`]
+    step_inst_preserves_prev_bb) >>
+  ASM_REWRITE_TAC[]
 QED
 
 Theorem block_step_preserves_prev_bb:
@@ -730,7 +724,8 @@ Proof
   `FILTER (\inst. is_pseudo inst.inst_opcode) insts =
    FILTER (\inst. inst.inst_opcode = PARAM) insts` by
     (irule filter_pseudo_no_phi_param >> simp[]) >>
-  Cases_on `h.inst_opcode` >> fs[is_pseudo_def]
+  Cases_on `h.inst_opcode` >> EVAL_TAC >> ASM_REWRITE_TAC[] >>
+  PURE_REWRITE_TAC[APPEND] >> REFL_TAC
 QED
 
 Triviality phi_prefix_length_filter_phi:

--- a/venom/passes/remove_unused/proofs/removeUnusedProofsScript.sml
+++ b/venom/passes/remove_unused/proofs/removeUnusedProofsScript.sml
@@ -34,7 +34,7 @@
 Theory removeUnusedProofs
 Ancestors
   removeUnusedDefs passSimulationProps analysisSimProps venomInstProps venomWf
-  execEquivProps livenessProofs passSharedDefs passSharedProps venomInst
+  opcodeClass execEquivProps livenessProofs passSharedDefs passSharedProps venomInst
   stateEquiv stateEquivProofs venomExecProofs venomExecProps
   venomState venomExecSemantics indexedLists cfgTransform cfgAnalysisProps pointerConfinedDefs
 Libs
@@ -444,7 +444,9 @@ Theorem step_inst_base_no_abort[local]:
     inst.inst_opcode = ASSERT_UNREACHABLE \/
     inst.inst_opcode = RETURNDATACOPY
 Proof
-  step_base_result_tac
+  rpt strip_tac >>
+  drule opcodeClassTheory.step_inst_base_abort_opcodes >>
+  strip_tac >> gvs[is_terminator_def]
 QED
 
 (* Effect-free non-INVOKE step_inst can only return OK or Error. *)

--- a/venom/passes/sccp/proofs/sccpConvergenceScript.sml
+++ b/venom/passes/sccp/proofs/sccpConvergenceScript.sml
@@ -571,6 +571,11 @@ QED
 
 (* sccp_transfer_inst preserves FDOM ⊆ and targets ⊆ *)
 (* Helper: sccp_transfer_inst only adds outputs to sl_vals *)
+val sccp_transfer_fdom_case_tac =
+  rpt (BasicProvers.TOP_CASE_TAC >> simp[]) >>
+  TRY (irule foldl_fupdate_bottom_fdom >> simp[]) >>
+  TRY (fs[FDOM_FUPDATE, SUBSET_DEF] >> metis_tac[]);
+
 Triviality sccp_transfer_inst_fdom[local]:
   !fn inst lat.
     set inst.inst_outputs SUBSET set (fn_all_assignments fn) /\
@@ -580,10 +585,12 @@ Triviality sccp_transfer_inst_fdom[local]:
 Proof
   rpt gen_tac >> strip_tac >>
   simp[sccp_transfer_inst_def] >>
-  rpt IF_CASES_TAC >> simp[] >>
-  rpt (BasicProvers.TOP_CASE_TAC >> simp[]) >>
-  TRY (irule foldl_fupdate_bottom_fdom >> simp[]) >>
-  TRY (fs[FDOM_FUPDATE, SUBSET_DEF] >> metis_tac[])
+  rpt IF_CASES_TAC >> simp[]
+  >- (irule foldl_fupdate_bottom_fdom >> simp[])
+  >- sccp_transfer_fdom_case_tac
+  >- sccp_transfer_fdom_case_tac
+  >- sccp_transfer_fdom_case_tac
+  >- sccp_transfer_fdom_case_tac
 QED
 
 (* Helper: labels extracted by FOLDR from operands are subset of
@@ -620,15 +627,7 @@ Proof
 QED
 
 (* Helper: sccp_transfer_inst for terminators adds only successors *)
-Triviality sccp_transfer_inst_term_targets[local]:
-  !fn inst lat.
-    is_terminator inst.inst_opcode ==>
-    (sccp_transfer_inst fn inst lat).sl_targets SUBSET
-    set (get_successors inst) UNION lat.sl_targets
-Proof
-  rpt strip_tac >>
-  simp[sccp_transfer_inst_def, get_successors_def] >>
-  rpt IF_CASES_TAC >> fs[] >>
+val sccp_term_targets_case_tac =
   rpt (BasicProvers.TOP_CASE_TAC >> fs[get_label_def, SUBSET_DEF]) >>
   rpt strip_tac >> fs[] >> rw[] >>
   TRY (imp_res_tac (SIMP_RULE std_ss [SUBSET_DEF]
@@ -642,7 +641,30 @@ Proof
            foldr_labels_tl_subset) >> simp[]) >-
        (simp[SUBSET_DEF] >> rpt strip_tac >>
          imp_res_tac (SIMP_RULE std_ss [SUBSET_DEF]
-           foldr_labels_subset_get_successors) >> simp[]))
+           foldr_labels_subset_get_successors) >> simp[]));
+
+Triviality sccp_transfer_inst_term_targets[local]:
+  !fn inst lat.
+    is_terminator inst.inst_opcode ==>
+    (sccp_transfer_inst fn inst lat).sl_targets SUBSET
+    set (get_successors inst) UNION lat.sl_targets
+Proof
+  rpt strip_tac >>
+  simp[sccp_transfer_inst_def, get_successors_def] >>
+  rpt IF_CASES_TAC >> fs[]
+  >- sccp_term_targets_case_tac
+  >- (Cases_on `inst.inst_operands`
+      >- fs[get_label_def, SUBSET_DEF]
+      >> Cases_on `t`
+      >- fs[get_label_def, SUBSET_DEF]
+      >> Cases_on `h'` >> fs[get_label_def, SUBSET_DEF]
+      >> Cases_on `t'`
+      >- fs[get_label_def, SUBSET_DEF]
+      >> Cases_on `h'` >> fs[get_label_def, SUBSET_DEF]
+      >> Cases_on `t` >> fs[get_label_def, SUBSET_DEF]
+      >> every_case_tac >> fs[get_label_def, SUBSET_DEF] >>
+      rpt strip_tac >> fs[])
+  >- sccp_term_targets_case_tac
 QED
 
 (* Helper: successors of well-formed block instructions are in fn_labels *)

--- a/venom/passes/sccp/proofs/sccpProofsBaseScript.sml
+++ b/venom/passes/sccp/proofs/sccpProofsBaseScript.sml
@@ -707,39 +707,53 @@ Proof
 QED
 
 (* exec_*_eval: each exec helper returns OK only when operands evaluate *)
+val staged_top_case_fs_tac =
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> fs[];
+
 Triviality exec_pure1_eval[local]:
   exec_pure1 f inst s = OK s' /\ MEM op inst.inst_operands ==>
   eval_operand op s <> NONE
 Proof
-  simp[exec_pure1_def] >> rpt (BasicProvers.TOP_CASE_TAC >> fs[]) >> rw[] >> fs[]
+  simp[exec_pure1_def] >> staged_top_case_fs_tac >> rw[] >> fs[]
 QED
 
 Triviality exec_pure2_eval[local]:
   exec_pure2 f inst s = OK s' /\ MEM op inst.inst_operands ==>
   eval_operand op s <> NONE
 Proof
-  simp[exec_pure2_def] >> rpt (BasicProvers.TOP_CASE_TAC >> fs[]) >> rw[] >> fs[]
+  simp[exec_pure2_def] >> staged_top_case_fs_tac >> rw[] >> fs[]
 QED
 
 Triviality exec_pure3_eval[local]:
   exec_pure3 f inst s = OK s' /\ MEM op inst.inst_operands ==>
   eval_operand op s <> NONE
 Proof
-  simp[exec_pure3_def] >> rpt (BasicProvers.TOP_CASE_TAC >> fs[]) >> rw[] >> fs[]
+  simp[exec_pure3_def] >> staged_top_case_fs_tac >> rw[] >> fs[]
 QED
 
 Triviality exec_read1_eval[local]:
   exec_read1 f inst s = OK s' /\ MEM op inst.inst_operands ==>
   eval_operand op s <> NONE
 Proof
-  simp[exec_read1_def] >> rpt (BasicProvers.TOP_CASE_TAC >> fs[]) >> rw[] >> fs[]
+  simp[exec_read1_def] >> staged_top_case_fs_tac >> rw[] >> fs[]
 QED
 
 Triviality exec_write2_eval[local]:
   exec_write2 f inst s = OK s' /\ MEM op inst.inst_operands ==>
   eval_operand op s <> NONE
 Proof
-  simp[exec_write2_def] >> rpt (BasicProvers.TOP_CASE_TAC >> fs[]) >> rw[] >> fs[]
+  simp[exec_write2_def] >> staged_top_case_fs_tac >> rw[] >> fs[]
 QED
 
 
@@ -1103,7 +1117,18 @@ Proof
   rw[transfer_sound_wf_def] >> rpt strip_tac >>
   simp[sccp_transfer_inst_def] >>
   rpt (IF_CASES_TAC >> gvs[]) >>
-  rpt (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
   rpt (IF_CASES_TAC >> gvs[]) >>
   REWRITE_TAC [FOLDL] >>
   (* Terminator goals *)
@@ -1280,7 +1305,18 @@ Theorem sccp_transfer_fdom_mono:
 Proof
   rpt strip_tac >> simp[sccp_transfer_inst_def] >>
   rpt (IF_CASES_TAC >> gvs[]) >>
-  rpt (BasicProvers.TOP_CASE_TAC >> gvs[]) >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+  TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
   rpt (IF_CASES_TAC >> gvs[]) >>
   TRY (simp[FDOM_FUPDATE] >> NO_TAC) >>
   irule foldl_fupdate_fdom >> simp[FDOM_FUPDATE]
@@ -1317,7 +1353,18 @@ Proof
   IF_CASES_TAC >> gvs[]
   >- (irule foldl_fupdate_bottom_non_mem >> simp[])
   >> IF_CASES_TAC >> gvs[]
-  >- (rpt (BasicProvers.TOP_CASE_TAC >> gvs[]))
+  >- (TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[] >>
+      TRY BasicProvers.TOP_CASE_TAC >> gvs[])
   >> Cases_on `inst.inst_outputs` >> gvs[] >>
   Cases_on `inst.inst_opcode = ASSIGN` >> gvs[] >>
   BasicProvers.EVERY_CASE_TAC >> gvs[FLOOKUP_UPDATE] >>
@@ -1410,6 +1457,16 @@ Proof
   \\ irule foldl_bottom_not_top \\ simp[FLOOKUP_UPDATE]
 QED
 
+Triviality sccp_terminator_opcode_cases[local]:
+  !op.
+    is_terminator op ==>
+    op = JMP \/ op = JNZ \/ op = DJMP \/ op = RET \/
+    op = RETURN \/ op = REVERT \/ op = STOP \/ op = SINK \/
+    op = SELFDESTRUCT \/ op = INVALID
+Proof
+  Cases \\ gvs[is_terminator_def]
+QED
+
 (* Terminators don't modify sl_vals *)
 Triviality sccp_transfer_terminator_sl_vals[local]:
   !fn inst lat.
@@ -1417,8 +1474,9 @@ Triviality sccp_transfer_terminator_sl_vals[local]:
     (sccp_transfer_inst fn inst lat).sl_vals = lat.sl_vals
 Proof
   rpt strip_tac
-  \\ simp[sccp_transfer_inst_def]
-  \\ BasicProvers.EVERY_CASE_TAC \\ gvs[is_terminator_def]
+  \\ drule sccp_terminator_opcode_cases \\ strip_tac
+  \\ gvs[sccp_transfer_inst_def]
+  \\ BasicProvers.EVERY_CASE_TAC \\ simp[]
 QED
 
 (* extract_labels ops = SOME labels means all ops are Labels, so

--- a/venom/passes/sccp/proofs/sccpSoundScript.sml
+++ b/venom/passes/sccp/proofs/sccpSoundScript.sml
@@ -205,8 +205,10 @@ Proof
   rpt strip_tac >>
   IF_CASES_TAC >> gvs[] >> (
     simp[step_inst_non_invoke] >>
-    simp[Once step_inst_base_def, eval_operand_def] >>
-    simp[Once step_inst_base_def, eval_operand_def])
+    simp[Once step_inst_base_def] >>
+    simp[eval_operand_def] >>
+    simp[Once step_inst_base_def] >>
+    simp[eval_operand_def])
 QED
 
 (* Main theorem: sccp_inst with sound lattice = original instruction *)
@@ -279,14 +281,29 @@ Proof
      (mk_nop_inst inst).inst_opcode <> INVOKE /\
      (mk_nop_inst inst).inst_opcode <> PHI` by EVAL_TAC >>
     fs[] >> NO_TAC) >>
-  rpt (CASE_TAC >> gvs[is_terminator_def]) >>
-  rpt (IF_CASES_TAC >> gvs[is_terminator_def]) >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY IF_CASES_TAC >> gvs[is_terminator_def] >>
+  TRY IF_CASES_TAC >> gvs[is_terminator_def] >>
   TRY (qpat_x_assum `is_terminator _` mp_tac) >>
   TRY (qpat_x_assum `_ = INVOKE` mp_tac) >>
   TRY (qpat_x_assum `_ = PHI` mp_tac) >>
   simp_tac (srw_ss()) [] >>
   CASE_TAC >> gvs[is_terminator_def] >>
-  rpt (CASE_TAC >> gvs[is_terminator_def])
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def] >>
+  TRY CASE_TAC >> gvs[is_terminator_def]
 QED
 
 Theorem sccp_inst_simulates:

--- a/venom/passes/shared/proofs/passSharedFieldScript.sml
+++ b/venom/passes/shared/proofs/passSharedFieldScript.sml
@@ -498,10 +498,13 @@ Proof
 QED
 
 val trans_frame_finish_tac =
-  fs[step_inst_base_def] >>
-  fs[exec_pure1_def, exec_pure2_def, exec_pure3_def,
-     exec_read0_def, exec_read1_def, exec_write2_def,
-     exec_alloca_def, extract_venom_result_def] >>
+  qpat_x_assum `step_inst_base _ _ = _` mp_tac >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
+  simp[exec_pure1_def, exec_pure2_def, exec_pure3_def,
+       exec_read0_def, exec_read1_def, exec_write2_def,
+       exec_alloca_def, extract_venom_result_def] >>
+  strip_tac >>
   gvs[AllCaseEqs()] >>
   rpt (CHANGED_TAC (rpt (pairarg_tac >> gvs[]))) >>
   fs[update_var_def, vfmStateTheory.lookup_account_def,

--- a/venom/passes/shared/proofs/passSharedFrameScript.sml
+++ b/venom/passes/shared/proofs/passSharedFrameScript.sml
@@ -436,7 +436,12 @@ Theorem effects_independent_ext_call_empty[local]:
   !op1 op2. is_ext_call_op op1 /\ effects_independent op1 op2 ==>
             write_effects op2 = {}
 Proof
-  Cases >> Cases >> EVAL_TAC
+  Cases_on `op1` >> gvs[is_ext_call_op_def]
+  >- (Cases_on `op2` >> EVAL_TAC)
+  >- (Cases_on `op2` >> EVAL_TAC)
+  >- (Cases_on `op2` >> EVAL_TAC)
+  >- (Cases_on `op2` >> EVAL_TAC)
+  >- (Cases_on `op2` >> EVAL_TAC)
 QED
 
 (* Non-terminator non-INVOKE step_inst_base can only Abort from
@@ -546,7 +551,7 @@ QED
 (* If a non-terminator aborts, it must be ASSERT/ASSERT_UNREACHABLE/RETURNDATACOPY.
    These only read operand values (+ returndata for RETURNDATACOPY).
    If those agree, the same Abort is produced on any state. *)
-Theorem step_inst_base_abort_input_equiv[local]:
+Theorem step_inst_base_abort_input_equiv:
   !inst s1 s2 a s1'.
     step_inst_base inst s1 = Abort a s1' /\
     ~is_terminator inst.inst_opcode /\

--- a/venom/passes/shared/proofs/passSharedSubstScript.sml
+++ b/venom/passes/shared/proofs/passSharedSubstScript.sml
@@ -200,7 +200,20 @@ Triviality exec_pure3_pos[local]:
          eval_operand (EL i inst.inst_operands) st) ==>
     exec_pure3 f (inst with inst_operands := new_ops) st = exec_pure3 f inst st
 Proof
-  exec_pos_prove exec_pure3_def
+  rpt strip_tac >>
+  `eval_operands new_ops st = eval_operands inst.inst_operands st` by
+    (irule eval_operands_positional >> simp[]) >>
+  simp[exec_pure3_def] >>
+  pop_assum mp_tac >> simp[eval_operands_def] >>
+  Cases_on `new_ops` >> Cases_on `inst.inst_operands` >>
+  gvs[eval_operands_def] >>
+  TRY (Cases_on `t` >> Cases_on `t'` >> gvs[eval_operands_def]) >>
+  TRY (Cases_on `t''` >> Cases_on `t` >> gvs[eval_operands_def] >>
+       TRY (Cases_on `t'` >> Cases_on `t''` >> gvs[eval_operands_def])) >>
+  TRY (Cases_on `t` >> Cases_on `t''` >> gvs[eval_operands_def] >>
+       TRY (Cases_on `t'` >> Cases_on `t` >> gvs[eval_operands_def])) >>
+  rpt strip_tac >> gvs[] >>
+  rpt (BasicProvers.EVERY_CASE_TAC >> gvs[])
 QED
 
 Triviality exec_read0_pos[local]:
@@ -298,7 +311,9 @@ Proof
   CONV_TAC (LHS_CONV (ONCE_REWRITE_CONV [step_inst_base_def])) >>
   simp (exec_map_thms @ exec_inst_operands_thms @ [eval_operands_map_thm]) >>
   CONV_TAC (RHS_CONV (ONCE_REWRITE_CONV [step_inst_base_def])) >>
-  Cases_on `inst.inst_operands` >> simp[] >>
+  Cases_on `inst.inst_operands`
+  >- simp[]
+  >> simp[] >>
   TRY (Cases_on `t` >> simp[]) >>
   TRY (FIRST [Cases_on `t'`, Cases_on `t`] >> simp[]) >>
   TRY (FIRST [Cases_on `t`, Cases_on `t'`, Cases_on `t''`] >> simp[]) >>
@@ -667,11 +682,10 @@ Triviality step_inst_base_pos_safe_long[local]:
     step_inst_base inst st
 Proof
   rpt gen_tac >> strip_tac >>
+  qpat_x_assum `inst_wf inst`
+    (fn th => ASSUME_TAC (REWRITE_RULE [inst_wf_def] th)) >>
   Cases_on `inst.inst_opcode` >>
-  gvs[is_alloca_op_def] >>
-  qpat_x_assum `inst_wf inst` mp_tac >>
-  simp[inst_wf_def] >>
-  strip_tac >> gvs[]
+  gvs[is_alloca_op_def]
   >- long_safe_finish_tac
   >- long_safe_finish_tac
   >- long_safe_finish_tac

--- a/venom/passes/shared/proofs/passSharedTransferScript.sml
+++ b/venom/passes/shared/proofs/passSharedTransferScript.sml
@@ -175,7 +175,7 @@ val transfer_determined_finish_tac =
   ASM_REWRITE_TAC[opcode_case_def] >>
   simp[exec_pure1_def, exec_pure2_def, exec_pure3_def,
        exec_read0_def, exec_read1_def, exec_write2_def] >>
-  rpt strip_tac >>
+  ntac 2 strip_tac >>
   gvs[AllCaseEqs()] >>
   rpt (CHANGED_TAC (rpt (pairarg_tac >> gvs[]))) >>
   transfer_close_tac;
@@ -469,6 +469,26 @@ Proof
   >- transfer_determined_finish_tac
   >- transfer_determined_finish_tac
   >- transfer_determined_finish_tac
+  >- (qpat_x_assum `step_inst_base _ s1 = _` mp_tac >>
+      qpat_x_assum `step_inst_base _ s2 = _` mp_tac >>
+      PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[opcode_case_def] >>
+      simp[exec_pure1_def, exec_pure2_def, exec_pure3_def,
+           exec_read0_def, exec_read1_def, exec_write2_def] >>
+      ntac 2 strip_tac >>
+      gvs[AllCaseEqs()] >>
+      rpt (CHANGED_TAC (rpt (pairarg_tac >> gvs[]))) >>
+      transfer_close_tac)
+  >- (qpat_x_assum `step_inst_base _ s1 = _` mp_tac >>
+      qpat_x_assum `step_inst_base _ s2 = _` mp_tac >>
+      PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[opcode_case_def] >>
+      simp[exec_pure1_def, exec_pure2_def, exec_pure3_def,
+           exec_read0_def, exec_read1_def, exec_write2_def] >>
+      ntac 2 strip_tac >>
+      gvs[AllCaseEqs()] >>
+      rpt (CHANGED_TAC (rpt (pairarg_tac >> gvs[]))) >>
+      transfer_close_tac)
   >- transfer_determined_finish_tac
   >- transfer_determined_finish_tac
   >- transfer_determined_finish_tac
@@ -533,9 +553,16 @@ Proof
   >- transfer_determined_finish_tac
   >- transfer_determined_finish_tac
   >- transfer_determined_finish_tac
-  >- transfer_determined_finish_tac
-  >- transfer_determined_finish_tac
-  >- transfer_determined_finish_tac
+  >- (qpat_x_assum `step_inst_base _ s1 = _` mp_tac >>
+      qpat_x_assum `step_inst_base _ s2 = _` mp_tac >>
+      PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+      ASM_REWRITE_TAC[opcode_case_def] >>
+      simp[exec_pure1_def, exec_pure2_def, exec_pure3_def,
+           exec_read0_def, exec_read1_def, exec_write2_def] >>
+      ntac 2 strip_tac >>
+      gvs[AllCaseEqs()] >>
+      rpt (CHANGED_TAC (rpt (pairarg_tac >> gvs[]))) >>
+      transfer_close_tac)
   >- transfer_determined_finish_tac
 QED
 
@@ -709,8 +736,66 @@ Proof
   Cases_on `inst.inst_opcode` >>
   gvs[is_effect_free_op_def, is_terminator_def,
       read_effects_def, write_effects_def,
-      all_effects_def, empty_effects_def] >>
-  transfer_determined_finish_tac
+      all_effects_def, empty_effects_def]
+  >- transfer_determined_finish_tac  (* ADD *)
+  >- transfer_determined_finish_tac  (* SUB *)
+  >- transfer_determined_finish_tac  (* MUL *)
+  >- transfer_determined_finish_tac  (* Div *)
+  >- transfer_determined_finish_tac  (* SDIV *)
+  >- transfer_determined_finish_tac  (* Mod *)
+  >- transfer_determined_finish_tac  (* SMOD *)
+  >- transfer_determined_finish_tac  (* Exp *)
+  >- transfer_determined_finish_tac  (* ADDMOD *)
+  >- transfer_determined_finish_tac  (* MULMOD *)
+  >- transfer_determined_finish_tac  (* EQ *)
+  >- transfer_determined_finish_tac  (* LT *)
+  >- transfer_determined_finish_tac  (* GT *)
+  >- transfer_determined_finish_tac  (* SLT *)
+  >- transfer_determined_finish_tac  (* SGT *)
+  >- transfer_determined_finish_tac  (* ISZERO *)
+  >- transfer_determined_finish_tac  (* AND *)
+  >- transfer_determined_finish_tac  (* OR *)
+  >- transfer_determined_finish_tac  (* XOR *)
+  >- transfer_determined_finish_tac  (* NOT *)
+  >- transfer_determined_finish_tac  (* SHL *)
+  >- transfer_determined_finish_tac  (* SHR *)
+  >- transfer_determined_finish_tac  (* SAR *)
+  >- transfer_determined_finish_tac  (* SIGNEXTEND *)
+  >- transfer_determined_finish_tac  (* BYTE *)
+  >- transfer_determined_finish_tac  (* MLOAD *)
+  >- transfer_determined_finish_tac  (* SLOAD *)
+  >- transfer_determined_finish_tac  (* TLOAD *)
+  >- transfer_determined_finish_tac  (* ILOAD *)
+  >- transfer_determined_finish_tac  (* DLOAD *)
+  >- transfer_determined_finish_tac  (* MEMTOP *)
+  >- transfer_determined_finish_tac  (* SHA3 *)
+  >- transfer_determined_finish_tac  (* CALLER *)
+  >- transfer_determined_finish_tac  (* ADDRESS *)
+  >- transfer_determined_finish_tac  (* CALLVALUE *)
+  >- transfer_determined_finish_tac  (* GAS *)
+  >- transfer_determined_finish_tac  (* ORIGIN *)
+  >- transfer_determined_finish_tac  (* GASPRICE *)
+  >- transfer_determined_finish_tac  (* CHAINID *)
+  >- transfer_determined_finish_tac  (* COINBASE *)
+  >- transfer_determined_finish_tac  (* TIMESTAMP *)
+  >- transfer_determined_finish_tac  (* NUMBER *)
+  >- transfer_determined_finish_tac  (* PREVRANDAO *)
+  >- transfer_determined_finish_tac  (* GASLIMIT *)
+  >- transfer_determined_finish_tac  (* BASEFEE *)
+  >- transfer_determined_finish_tac  (* BLOBBASEFEE *)
+  >- transfer_determined_finish_tac  (* BLOCKHASH *)
+  >- transfer_determined_finish_tac  (* BLOBHASH *)
+  >- transfer_determined_finish_tac  (* BALANCE *)
+  >- transfer_determined_finish_tac  (* SELFBALANCE *)
+  >- transfer_determined_finish_tac  (* CALLDATASIZE *)
+  >- transfer_determined_finish_tac  (* CALLDATALOAD *)
+  >- transfer_determined_finish_tac  (* RETURNDATASIZE *)
+  >- transfer_determined_finish_tac  (* CODESIZE *)
+  >- transfer_determined_finish_tac  (* EXTCODESIZE *)
+  >- transfer_determined_finish_tac  (* EXTCODEHASH *)
+  >- transfer_determined_finish_tac  (* ASSIGN *)
+  >- transfer_determined_finish_tac  (* PARAM *)
+  >- transfer_determined_finish_tac  (* OFFSET *)
 QED
 
 

--- a/venom/passes/shared/proofs/passSharedVarFrameScript.sml
+++ b/venom/passes/shared/proofs/passSharedVarFrameScript.sml
@@ -12,6 +12,7 @@
 Theory passSharedVarFrame
 Ancestors
   passSharedDefs venomExecSemantics venomState venomInst venomEffects venomInstProps
+  opcodeClass
 
 (* ===================================================================== *)
 (* ===== Variable/State Helpers ======================================== *)
@@ -141,7 +142,9 @@ Theorem step_inst_base_no_halt[local]:
     step_inst_base inst s = Halt s' ==>
     is_terminator inst.inst_opcode
 Proof
-  step_base_result_tac
+  rpt strip_tac >>
+  drule step_inst_base_halt_opcodes >>
+  strip_tac >> gvs[is_terminator_def]
 QED
 
 Theorem step_inst_base_no_intret[local]:

--- a/venom/passes/single_use_expansion/proofs/singleUseExpansionProofsScript.sml
+++ b/venom/passes/single_use_expansion/proofs/singleUseExpansionProofsScript.sml
@@ -661,8 +661,14 @@ Theorem step_inst_assign_ok_or_error[local]:
     (?st'. step_inst fuel ctx inst st = OK st') \/
     (?e. step_inst fuel ctx inst st = Error e)
 Proof
-  rw[venomExecSemanticsTheory.step_inst_def,
-     venomExecSemanticsTheory.step_inst_base_def] >>
+  rpt strip_tac >>
+  ONCE_REWRITE_TAC[venomExecSemanticsTheory.step_inst_def] >>
+  qpat_x_assum `inst.inst_opcode = ASSIGN`
+    (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+  simp[is_terminator_def] >>
+  ONCE_REWRITE_TAC[venomExecSemanticsTheory.step_inst_base_def] >>
+  qpat_x_assum `inst.inst_opcode = ASSIGN`
+    (fn th => PURE_REWRITE_TAC[th]) >> simp[] >>
   Cases_on `inst.inst_operands` >> gvs[] >>
   Cases_on `inst.inst_outputs` >> gvs[] >>
   Cases_on `t` >> gvs[] >>

--- a/venom/passes/tail_merge/proofs/tailMergeProofScript.sml
+++ b/venom/passes/tail_merge/proofs/tailMergeProofScript.sml
@@ -2194,7 +2194,9 @@ Proof
     by simp[subst_block_labels_inst_def, is_block_label_opcode_def,
             is_terminator_def, subst_label_map_inst_def] >>
   pop_assum SUBST1_TAC >>
-  simp[step_inst_base_def, subst_label_map_op_def, is_terminator_def] >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  PURE_REWRITE_TAC[instruction_accfupds] >>
+  ASM_REWRITE_TAC[opcode_case_def] >>
   Cases_on `inst.inst_operands` >> simp[subst_label_map_op_def] >>
   Cases_on `t` >> simp[subst_label_map_op_def] >>
   Cases_on `h` >> simp[subst_label_map_op_def] >>
@@ -2348,6 +2350,7 @@ Proof
   Cases_on `inst.inst_opcode` >> gvs[is_terminator_def] >>
   qpat_x_assum `step_inst_base inst s = OK s'` mp_tac >>
   ASM_REWRITE_TAC[step_inst_base_def] >>
+  PURE_REWRITE_TAC[opcode_case_def] >>
   gvs[AllCaseEqs()]
 QED
 

--- a/venom/passes/tail_merge/proofs/tailMergeSimScript.sml
+++ b/venom/passes/tail_merge/proofs/tailMergeSimScript.sml
@@ -171,12 +171,22 @@ Proof
   Cases_on `op1` >> Cases_on `op2` >>
   simp[canon_operand_def, LET_THM, eval_operand_def] >>
   rpt strip_tac >>
-  rpt (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
   gvs[var_corr_def, lookup_var_def, var_map_wf_def,
       alistTheory.ALOOKUP_def] >>
-  rpt strip_tac >> rpt (CASE_TAC >> gvs[]) >>
+  rpt strip_tac >>
+  TRY (CASE_TAC >> gvs[]) >>
+  TRY (CASE_TAC >> gvs[]) >>
+  TRY (CASE_TAC >> gvs[]) >>
+  TRY (CASE_TAC >> gvs[]) >>
   TRY (res_tac >> fs[] >> NO_TAC) >>
-  rpt (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
+  TRY (BasicProvers.FULL_CASE_TAC >> gvs[]) >>
   TRY (res_tac >> fs[] >> NO_TAC)
 QED
 

--- a/venom/proofs/execEquivProofsScript.sml
+++ b/venom/proofs/execEquivProofsScript.sml
@@ -233,7 +233,7 @@ Triviality step_inst_pure1_equiv:
     MEM inst.inst_opcode [NOT; ISZERO] ==>
     result_equiv vars (step_inst_base inst s1) (step_inst_base inst s2)
 Proof
-  rw[] >> simp[step_inst_base_def] >>
+  rw[] >> ASM_REWRITE_TAC[step_inst_base_def] >> simp[] >>
   irule exec_pure1_result_equiv >> simp[]
 QED
 
@@ -245,7 +245,7 @@ Triviality step_inst_pure3_equiv:
     MEM inst.inst_opcode [ADDMOD; MULMOD] ==>
     result_equiv vars (step_inst_base inst s1) (step_inst_base inst s2)
 Proof
-  rw[] >> simp[step_inst_base_def] >>
+  rw[] >> ASM_REWRITE_TAC[step_inst_base_def] >> simp[] >>
   irule exec_pure3_result_equiv >> simp[]
 QED
 
@@ -316,9 +316,10 @@ Triviality step_inst_terminator_equiv:
     MEM inst.inst_opcode [STOP; SINK] ==>
     result_equiv vars (step_inst_base inst s1) (step_inst_base inst s2)
 Proof
-  rw[] >> simp[step_inst_base_def, result_equiv_def, revert_equiv_def,
-               halt_state_def, revert_state_def,
-               execution_equiv_def, lookup_var_def] >>
+  rw[] >> ASM_REWRITE_TAC[step_inst_base_def] >>
+  simp[result_equiv_def, revert_equiv_def,
+       halt_state_def, revert_state_def,
+       execution_equiv_def, lookup_var_def] >>
   fs[state_equiv_def, execution_equiv_def, lookup_var_def]
 QED
 
@@ -334,7 +335,11 @@ Proof
   imp_res_tac eval_operand_equiv >>
   `s1.vs_memory = s2.vs_memory` by
     fs[state_equiv_def, execution_equiv_def] >>
-  rpt CASE_TAC >> gvs[result_equiv_def, revert_equiv_def,
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def,
     halt_state_def, set_returndata_def,
     execution_equiv_def, lookup_var_def] >>
   fs[state_equiv_def, execution_equiv_def, lookup_var_def]
@@ -352,7 +357,11 @@ Proof
   imp_res_tac eval_operand_equiv >>
   `s1.vs_memory = s2.vs_memory` by
     fs[state_equiv_def, execution_equiv_def] >>
-  rpt CASE_TAC >> gvs[result_equiv_def, revert_equiv_def,
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def,
     revert_state_def, set_returndata_def, revert_equiv_def,
     execution_equiv_def, lookup_var_def] >>
   fs[state_equiv_def, execution_equiv_def, lookup_var_def]
@@ -827,7 +836,12 @@ Proof
   rw[step_inst_base_def] >>
   `s1.vs_params = s2.vs_params` by
     fs[state_equiv_def, execution_equiv_def] >>
-  rpt CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
+  CASE_TAC >> gvs[result_equiv_def, revert_equiv_def] >>
   irule update_var_preserves >> simp[]
 QED
 

--- a/venom/proofs/venomExecProofsScript.sml
+++ b/venom/proofs/venomExecProofsScript.sml
@@ -103,7 +103,9 @@ Theorem step_jnz_behavior:
     if cond <> 0w then OK (jump_to if_nonzero s)
     else OK (jump_to if_zero s)
 Proof
-  rw[step_inst_base_def]
+  rpt strip_tac >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >>
+  simp[opcode_case_def]
 QED
 
 (* ==========================================================================
@@ -1326,9 +1328,10 @@ Triviality step_inst_base_operands_none[local]:
 Proof
   rpt strip_tac >>
   Cases_on `inst.inst_opcode` >> gvs[MEM] >>
-  metis_tac[step_inst_base_operands_none_uniform,
-            step_inst_base_operands_none_custom,
-            step_inst_base_operands_none_log, MEM]
+  FIRST
+    [irule step_inst_base_operands_none_uniform >> simp[MEM] >> NO_TAC,
+     irule step_inst_base_operands_none_custom >> simp[MEM] >> NO_TAC,
+     irule step_inst_base_operands_none_log >> simp[]]
 QED
 
 Theorem step_inst_base_nonerr_var_fdom:

--- a/venom/proofs/venomInstProofs1Script.sml
+++ b/venom/proofs/venomInstProofs1Script.sml
@@ -154,7 +154,10 @@ Theorem step_assert_unreachable_identity:
     inst.inst_opcode = ASSERT_UNREACHABLE ==>
     s' = s
 Proof
-  rw[Once step_inst_def, step_inst_base_def] >> gvs[AllCaseEqs()]
+  simp[Once step_inst_def] >>
+  rpt gen_tac >> strip_tac >> gvs[] >>
+  qhdtm_x_assum `step_inst_base` mp_tac >>
+  simp[Once step_inst_base_def] >> gvs[AllCaseEqs()] >> metis_tac[]
 QED
 
 (* ===================================================================== *)

--- a/venom/proofs/venomInstProofs2Script.sml
+++ b/venom/proofs/venomInstProofs2Script.sml
@@ -115,21 +115,23 @@ Theorem step_inst_base_preserves_static_fields:
      s'.vs_logs = s.vs_logs)
 Proof
   rpt gen_tac >> strip_tac >>
-  gvs[step_inst_base_def, AllCaseEqs(),
-      is_terminator_def, is_alloca_op_def,
-      write_effects_def, empty_effects_def,
-      update_var_def, contract_storage_def
-  ] >>
+  RULE_ASSUM_TAC (SIMP_RULE std_ss [Once step_inst_base_def]) >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_terminator_def, is_alloca_op_def,
+      write_effects_def, empty_effects_def] >>
   imp_res_tac exec_pure1_static_preserves >>
   imp_res_tac exec_read0_static_preserves >>
   imp_res_tac exec_read1_static_preserves >>
   imp_res_tac exec_pure2_static_preserves >>
   imp_res_tac exec_ext_call_static_preserves >>
   imp_res_tac exec_pure3_static_preserves >> gvs[] >>
-  gvs[exec_write2_def, AllCaseEqs(),
+  gvs[exec_write2_def, AllCaseEqs(), update_var_def,
+      contract_storage_def,
       mcopy_def, mstore_def, mstore8_def,
       write_memory_with_expansion_def,
-      sstore_def, tstore_def, all_effects_def]
+      sstore_def, tstore_def, all_effects_def] >>
+  drule exec_ext_call_static_preserves >>
+  simp[contract_storage_def]
 QED
 
 Theorem step_inst_base_preserves_storage:

--- a/venom/proofs/venomInstProofs3Script.sml
+++ b/venom/proofs/venomInstProofs3Script.sml
@@ -55,10 +55,10 @@ Theorem step_inst_base_preserves_account_memory_fields:
      s'.vs_memory = s.vs_memory)
 Proof
   rpt gen_tac >> strip_tac >>
-  gvs[step_inst_base_def, AllCaseEqs(),
-      is_terminator_def, is_alloca_op_def,
-      write_effects_def, empty_effects_def,
-      update_var_def] >>
+  RULE_ASSUM_TAC (SIMP_RULE std_ss [Once step_inst_base_def]) >>
+  Cases_on `inst.inst_opcode` >>
+  gvs[is_terminator_def, is_alloca_op_def,
+      write_effects_def, empty_effects_def] >>
   imp_res_tac exec_pure1_static_preserves >>
   imp_res_tac exec_read0_static_preserves >>
   imp_res_tac exec_read1_static_preserves >>
@@ -75,8 +75,9 @@ Proof
       mcopy_def, mstore_def, mstore8_def,
       write_memory_with_expansion_def,
       sstore_def, tstore_def, all_effects_def,
-      update_var_def] >> gvs[] >>
-  Cases_on `result` >> gvs[] >>
+      update_var_def] >> gvs[]
+  >- (drule exec_ext_call_static_preserves >> simp[])
+  >> Cases_on `result` >> gvs[] >>
   Cases_on `y` >> gvs[]
 QED
 

--- a/venom/proofs/venomMemProofsScript.sml
+++ b/venom/proofs/venomMemProofsScript.sml
@@ -673,10 +673,13 @@ Triviality effect_free_direct_not_terminal[local]:
     (!a s'. step_inst_base inst s <> Abort a s') /\
     (!v s'. step_inst_base inst s <> IntRet v s')
 Proof
-  fs[step_inst_base_def] >>
-  rpt gen_tac >> strip_tac >>
-  asm_rewrite_tac[] >>
-  simp_tac(srw_ss())[AllCaseEqs()]
+  rpt gen_tac >> strip_tac >> gvs[] >>
+  ASM_REWRITE_TAC[step_inst_base_def]
+  >- simp[AllCaseEqs()]
+  >- simp[AllCaseEqs()]
+  >- simp[AllCaseEqs()]
+  >- simp[AllCaseEqs()]
+  >- simp[AllCaseEqs()]
 QED
 
 Triviality effect_free_opcode_cases[local]:

--- a/venom/simulation/proofs/analysisSimProofsBaseScript.sml
+++ b/venom/simulation/proofs/analysisSimProofsBaseScript.sml
@@ -27,6 +27,8 @@ Libs
 
 open execEquivParamLib
 
+fun analysis_lift_result_case_tac () = gvs[lift_result_def]
+
 (* ===== Helpers ===== *)
 
 Theorem venom_state_idx_self_update:
@@ -199,8 +201,32 @@ Proof
     first_x_assum (qspecl_then [`0`, `fuel`, `ctx`, `s`] mp_tac) >> simp[])
   >>
   Cases_on `run_insts fuel ctx h s` >>
-  Cases_on `run_insts fuel ctx h' s` >>
-  gvs[lift_result_def]
+  Cases_on `run_insts fuel ctx h' s` >|
+  [analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac (),
+   analysis_lift_result_case_tac (), analysis_lift_result_case_tac ()]
   >>
   rename1 `R_ok v1 v2` >>
   `lift_result R_ok R_term R_term (run_insts fuel ctx (FLAT g1s) v1)
@@ -3270,7 +3296,11 @@ Proof
        phi_prefix_length (h::l) = 0, and by phi_prefix_length_flat_mapi,
        phi_prefix_length (FLAT (MAPi f (h::l))) = 0, so eval_phis on LHS = OK s too. *)
     `phi_prefix_length (FLAT (MAPi f (h::l))) = 0` by (
-      metis_tac[phi_prefix_length_flat_mapi, phi_prefix_length_def]) >>
+      irule EQ_TRANS >>
+      qexists_tac `phi_prefix_length (h::l)` >> conj_tac
+      >- (irule (Q.SPECL [`f`, `h::l`] phi_prefix_length_flat_mapi) >>
+          rpt conj_tac >> FIRST_ASSUM ACCEPT_TAC)
+      >- simp[phi_prefix_length_def]) >>
     simp[phi_prefix_length_zero_eval_phis_ok, eval_phis_def])
 QED
 

--- a/venom/simulation/proofs/analysisSimProofsCompareScript.sml
+++ b/venom/simulation/proofs/analysisSimProofsCompareScript.sml
@@ -1615,7 +1615,11 @@ Proof
     simp[indexedListsTheory.MAPi_def, eval_phis_def])
   >- (
     `phi_prefix_length (FLAT (MAPi f (h::l))) = 0` by (
-      metis_tac[phi_prefix_length_flat_mapi_local, phi_prefix_length_def]) >>
+      irule EQ_TRANS >>
+      qexists_tac `phi_prefix_length (h::l)` >> conj_tac
+      >- (irule (Q.SPECL [`f`, `h::l`] phi_prefix_length_flat_mapi_local) >>
+          rpt conj_tac >> FIRST_ASSUM ACCEPT_TAC)
+      >- simp[phi_prefix_length_def]) >>
     simp[phi_prefix_length_zero_eval_phis_ok_local, eval_phis_def])
 QED
 

--- a/venom/simulation/proofs/analysisSimProofsPrependScript.sml
+++ b/venom/simulation/proofs/analysisSimProofsPrependScript.sml
@@ -614,7 +614,9 @@ Proof
   (* Step 1: R_ok bridge: run_block bb s1 ~ run_block bb s2 *)
   `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1)
     (run_block fuel run_ctx bb s2)` by
-    (irule run_block_preserves_R_helper >> metis_tac[]) >>
+    (irule run_block_preserves_R_helper >>
+     rpt conj_tac >> TRY (first_assum ACCEPT_TAC) >>
+     qexists_tac `fn` >> conj_tac >> first_assum ACCEPT_TAC) >>
   (* Block-level facts for block simulation *)
   `(!idx. SUC idx <= LENGTH bb.bb_instructions ==>
      df_at bottom result bb.bb_label (SUC idx) =
@@ -722,36 +724,70 @@ Proof
     qpat_x_assum `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1) (run_block fuel run_ctx bb s2)` (fn th => ALL_TAC) >>
   qpat_x_assum `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s2) (run_block fuel run_ctx (analysis_block_transform bottom result f bb) s2)` (fn th => ALL_TAC) >>
   qpat_x_assum `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s2) (run_block fuel run_ctx (analysis_block_transform_prepend bottom result prepend f bb) s2)` (fn th => ALL_TAC) >>
-  (* Case split on run_block results for IH *)
-  Cases_on `run_block fuel run_ctx bb s1` >>
-  Cases_on `run_block fuel run_ctx
-    (analysis_block_transform_prepend bottom result prepend f bb) s2` >>
-  gvs[lift_result_def]
-  >- (
-    rename1 `R_ok v1 v2` >>
-    `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
-    simp[lift_result_def] >>
-    imp_res_tac run_block_OK_inst_idx_0 >>
-    `v1.vs_current_bb = v2.vs_current_bb` by metis_tac[vsr_R_ok_fields] >>
-    `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
-     sound (df_at bottom result v1.vs_current_bb 0) v1` by metis_tac[] >>
-    REWRITE_TAC [GSYM function_map_transform_def] >>
-    first_x_assum irule >> simp[] >>
-    rpt conj_tac >> first_assum ACCEPT_TAC)
-  >> (
-    Cases_on `run_block fuel run_ctx bb s2` >> gvs[lift_result_def] >>
-    Cases_on `run_block fuel run_ctx
-      (analysis_block_transform_prepend bottom result prepend f bb) s2` >> gvs[lift_result_def] >>
-    rename1 `R_ok v1 v2` >>
-    `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    `~v2.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    simp[lift_result_def] >>
-    imp_res_tac run_block_OK_inst_idx_0 >>
-    `v1.vs_current_bb = v2.vs_current_bb` by metis_tac[vsr_R_ok_fields] >>
-    `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
-     sound (df_at bottom result v1.vs_current_bb 0) v1` by metis_tac[] >>
-    REWRITE_TAC [GSYM function_map_transform_def] >>
-    first_x_assum irule >> simp[] >>
-    rpt conj_tac >> first_assum ACCEPT_TAC)
+  (* Isolate the composed relation before splitting result constructors. *)
+  qpat_x_assum
+    `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1)
+       (run_block fuel run_ctx
+          (analysis_block_transform_prepend bottom result prepend f bb) s2)`
+    mp_tac >>
+  (Cases_on `run_block fuel run_ctx bb s1` THEN_LT
+   TRYALL (Cases_on `run_block fuel run_ctx
+     (analysis_block_transform_prepend bottom result prepend f bb) s2`)) >>
+  PURE_REWRITE_TAC[lift_result_def] >>
+  simp_tac std_ss [] >> TRY strip_tac >>
+  (ALL_TAC THEN_LT TRYALL
+    (SIMP_TAC bool_ss
+       [venomExecSemanticsTheory.exec_result_case_def,
+        lift_result_def, venomExecSemanticsTheory.exec_result_distinct] >>
+     TRY (first_assum ACCEPT_TAC))) >>
+  (ALL_TAC THEN_LT TRYALL (rename1 `R_ok v1 v2`)) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s1 = OK v1`
+       (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+     qpat_x_assum
+       `run_block fuel run_ctx
+          (analysis_block_transform_prepend bottom result prepend f bb) s2 = OK v2`
+       (fn th => assume_tac th >> PURE_REWRITE_TAC[th]))) >>
+  (ALL_TAC THEN_LT TRYALL (simp[lift_result_def])) >>
+  (ALL_TAC THEN_LT TRYALL (imp_res_tac run_block_OK_inst_idx_0)) >>
+  (ALL_TAC THEN_LT TRYALL
+    (`v1.vs_current_bb = v2.vs_current_bb` by
+       metis_tac[vsr_R_ok_fields])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (`MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
+      sound (df_at bottom result v1.vs_current_bb 0) v1` by metis_tac[])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s2 = Error e`
+       (fn err_th =>
+         qpat_x_assum `~?e. run_block fuel run_ctx bb s2 = Error e`
+           mp_tac >>
+         PURE_REWRITE_TAC[err_th] >> simp[]))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `?e. run_block fuel run_ctx bb s2 = Error e`
+       strip_assume_tac >>
+     qpat_x_assum
+       `lift_result R_ok R_term R_term
+          (run_block fuel run_ctx bb s2) (OK v2)` mp_tac >>
+     qpat_x_assum `run_block fuel run_ctx bb s2 = Error e`
+       (fn err_th => PURE_REWRITE_TAC[err_th]) >>
+     simp[lift_result_def])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s1 = OK v1`
+       (fn th => assume_tac
+         (MATCH_MP
+           (Q.SPECL [`fuel`, `run_ctx`, `bb`, `s1`, `v1`]
+             analysisSimProofsTheory.run_block_OK_not_halted) th)) >>
+     qpat_x_assum
+       `run_block fuel run_ctx
+          (analysis_block_transform_prepend bottom result prepend f bb) s2 = OK v2`
+       (fn th => assume_tac
+         (MATCH_MP
+           (Q.SPECL [`fuel`, `run_ctx`,
+             `analysis_block_transform_prepend bottom result prepend f bb`,
+             `s2`, `v2`] analysisSimProofsTheory.run_block_OK_not_halted) th)) >>
+     simp[])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (REWRITE_TAC [GSYM function_map_transform_def] >>
+     first_x_assum irule >> simp[] >>
+     rpt conj_tac >> first_assum ACCEPT_TAC))
 QED

--- a/venom/simulation/proofs/analysisSimProofsSoundScript.sml
+++ b/venom/simulation/proofs/analysisSimProofsSoundScript.sml
@@ -212,30 +212,54 @@ Proof
     conj_tac >- first_assum ACCEPT_TAC >>
     qexists_tac `run_block fuel run_ctx bb s2` >>
     conj_tac >> first_assum ACCEPT_TAC) >>
-  (* Case split on run_block result *)
-  Cases_on `run_block fuel run_ctx bb s1` >>
-  Cases_on `run_block fuel run_ctx (bt bb) s2` >>
-  gvs[lift_result_def]
-  (* Only OK-OK survives after gvs *)
-  >- (
-    rename1 `R_ok v1 v2` >>
-    `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
-    simp[lift_result_def] >>
-    imp_res_tac run_block_OK_inst_idx_0 >>
-    `v1.vs_current_bb = v2.vs_current_bb` by metis_tac[vsr_R_ok_fields] >>
-    `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
-     sound (df_at bottom result v1.vs_current_bb 0) v1` by metis_tac[] >>
-    REWRITE_TAC [GSYM function_map_transform_def] >>
-    first_x_assum irule >> simp[] >>
-    rpt conj_tac >> first_assum ACCEPT_TAC)
-  (* Non-OK cases: Halt, Abort, IntRet *)
-  >> (
-    Cases_on `run_block fuel run_ctx bb s2` >> gvs[lift_result_def] >>
-    Cases_on `run_block fuel run_ctx (bt bb) s2` >> gvs[lift_result_def])
+  (* Isolate the composed relation before splitting result constructors. *)
+  qpat_x_assum
+    `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1)
+       (run_block fuel run_ctx (bt bb) s2)` mp_tac >>
+  (Cases_on `run_block fuel run_ctx bb s1` THEN_LT
+   TRYALL (Cases_on `run_block fuel run_ctx (bt bb) s2`)) >>
+  PURE_REWRITE_TAC[lift_result_def] >>
+  simp_tac std_ss [] >> TRY strip_tac
+  (* First discharge terminal pairs with goal-only simplification. *)
+  >> (ALL_TAC THEN_LT TRYALL
+       (SIMP_TAC bool_ss
+          [venomExecSemanticsTheory.exec_result_case_def,
+           lift_result_def, venomExecSemanticsTheory.exec_result_distinct] >>
+        TRY (first_assum ACCEPT_TAC)))
+  (* The remaining focused goals are the OK-OK obligations. *)
+  >> (ALL_TAC THEN_LT TRYALL
+       (rename1 `R_ok v1 v2` >>
+        `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
+        `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
+        simp[lift_result_def] >>
+        imp_res_tac run_block_OK_inst_idx_0 >>
+        `v1.vs_current_bb = v2.vs_current_bb` by
+          metis_tac[vsr_R_ok_fields] >>
+        `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
+         sound (df_at bottom result v1.vs_current_bb 0) v1` by
+          metis_tac[] >>
+        REWRITE_TAC [GSYM function_map_transform_def] >>
+        first_x_assum irule >> simp[] >>
+        rpt conj_tac >> first_assum ACCEPT_TAC))
 QED
 
 (* ===== Non-widen variant with state_inv + transfer_sound_wf ===== *)
+
+val sound_inv_OK_tac =
+  rename1 `R_ok v1 v2` >>
+  `~v1.vs_halted` by
+    metis_tac[analysisSimProofsTheory.run_block_OK_not_halted] >>
+  `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
+  simp[lift_result_def] >>
+  imp_res_tac analysisSimProofsTheory.run_block_OK_inst_idx_0 >>
+  `v1.vs_current_bb = v2.vs_current_bb` by
+    metis_tac[vsr_R_ok_fields] >>
+  `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
+   sound (df_at bottom result v1.vs_current_bb 0) v1 /\
+   state_inv v1` by metis_tac[] >>
+  REWRITE_TAC [GSYM function_map_transform_def] >>
+  first_x_assum irule >> simp[] >>
+  rpt conj_tac >> first_assum ACCEPT_TAC;
 
 (* Like df_analysis_pass_correct_sound_proof but:
    - Uses transfer_sound_wf (inst_wf available)
@@ -441,28 +465,42 @@ Proof
     conj_tac >- first_assum ACCEPT_TAC >>
     qexists_tac `run_block fuel run_ctx bb s2` >>
     conj_tac >> first_assum ACCEPT_TAC) >>
-  (* Case split on run_block result *)
-  Cases_on `run_block fuel run_ctx bb s1` >>
-  Cases_on `run_block fuel run_ctx (bt bb) s2` >>
-  gvs[lift_result_def]
-  (* Only OK-OK survives after gvs *)
-  >- (
-    rename1 `R_ok v1 v2` >>
-    `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
-    simp[lift_result_def] >>
-    imp_res_tac run_block_OK_inst_idx_0 >>
-    `v1.vs_current_bb = v2.vs_current_bb` by metis_tac[vsr_R_ok_fields] >>
-    `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
-     sound (df_at bottom result v1.vs_current_bb 0) v1 /\
-     state_inv v1` by metis_tac[] >>
-    REWRITE_TAC [GSYM function_map_transform_def] >>
-    first_x_assum irule >> simp[] >>
-    rpt conj_tac >> first_assum ACCEPT_TAC)
-  (* Non-OK cases: Halt, Abort, IntRet *)
-  >> (
-    Cases_on `run_block fuel run_ctx bb s2` >> gvs[lift_result_def] >>
-    Cases_on `run_block fuel run_ctx (bt bb) s2` >> gvs[lift_result_def])
+  (* Isolate the composed relation before splitting result constructors. *)
+  qpat_x_assum
+    `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1)
+       (run_block fuel run_ctx (bt bb) s2)` mp_tac >>
+  (Cases_on `run_block fuel run_ctx bb s1` THEN_LT
+   TRYALL (Cases_on `run_block fuel run_ctx (bt bb) s2`)) >>
+  PURE_REWRITE_TAC[lift_result_def] >>
+  simp_tac std_ss [] >> TRY strip_tac >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block_entry fuel run_ctx bb s1 = _`
+       (fn th => PURE_REWRITE_TAC[th] >> assume_tac th) >>
+     qpat_x_assum `run_block_entry fuel run_ctx (bt bb) s2 = _`
+       (fn th => PURE_REWRITE_TAC[th] >> assume_tac th) >>
+     SIMP_TAC bool_ss
+       [venomExecSemanticsTheory.exec_result_case_def,
+        lift_result_def, venomExecSemanticsTheory.exec_result_distinct] >>
+     TRY (first_assum ACCEPT_TAC))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `~(?e. run_block_entry fuel run_ctx bb s2 = Error e)`
+       mp_tac >>
+     qpat_x_assum `run_block_entry fuel run_ctx bb s2 = Error _`
+       (fn th => simp[th]))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `?e. run_block_entry fuel run_ctx bb s2 = Error e`
+       strip_assume_tac >>
+     qpat_x_assum
+       `lift_result R_ok R_term R_term
+          (run_block_entry fuel run_ctx bb s2) _` mp_tac >>
+     qpat_x_assum `run_block_entry fuel run_ctx bb s2 = Error _`
+       (fn th =>
+         PURE_REWRITE_TAC[th, lift_result_def] >>
+         simp_tac bool_ss
+           [venomExecSemanticsTheory.exec_result_distinct])))
+  >- sound_inv_OK_tac
+  >- (rpt conj_tac >> first_assum ACCEPT_TAC)
+  >- (rpt conj_tac >> first_assum ACCEPT_TAC)
 QED
 
 
@@ -694,28 +732,41 @@ Proof
     conj_tac >- first_assum ACCEPT_TAC >>
     qexists_tac `run_block fuel run_ctx bb s2` >>
     conj_tac >> first_assum ACCEPT_TAC) >>
-  (* Case split on run_block result *)
-  Cases_on `run_block fuel run_ctx bb s1` >>
-  Cases_on `run_block fuel run_ctx (bt bb) s2` >>
-  gvs[lift_result_def]
-  (* Only OK-OK survives after gvs *)
-  >- (
-    rename1 `R_ok v1 v2` >>
-    `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
-    simp[lift_result_def] >>
-    imp_res_tac run_block_OK_inst_idx_0 >>
-    `v1.vs_current_bb = v2.vs_current_bb` by metis_tac[vsr_R_ok_fields] >>
-    `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
-     sound (df_at bottom result v1.vs_current_bb 0) v1 /\
-     state_inv v1` by metis_tac[] >>
-    REWRITE_TAC [GSYM function_map_transform_def] >>
-    first_x_assum irule >> simp[] >>
-    rpt conj_tac >> first_assum ACCEPT_TAC)
-  (* Non-OK cases: Halt, Abort, IntRet *)
-  >> (
-    Cases_on `run_block fuel run_ctx bb s2` >> gvs[lift_result_def] >>
-    Cases_on `run_block fuel run_ctx (bt bb) s2` >> gvs[lift_result_def])
+  qpat_x_assum
+    `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1)
+       (run_block fuel run_ctx (bt bb) s2)` mp_tac >>
+  (Cases_on `run_block fuel run_ctx bb s1` THEN_LT
+   TRYALL (Cases_on `run_block fuel run_ctx (bt bb) s2`)) >>
+  PURE_REWRITE_TAC[lift_result_def] >>
+  simp_tac std_ss [] >> TRY strip_tac >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block_entry fuel run_ctx bb s1 = _`
+       (fn th => PURE_REWRITE_TAC[th] >> assume_tac th) >>
+     qpat_x_assum `run_block_entry fuel run_ctx (bt bb) s2 = _`
+       (fn th => PURE_REWRITE_TAC[th] >> assume_tac th) >>
+     SIMP_TAC bool_ss
+       [venomExecSemanticsTheory.exec_result_case_def,
+        lift_result_def, venomExecSemanticsTheory.exec_result_distinct] >>
+     TRY (first_assum ACCEPT_TAC))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `~(?e. run_block_entry fuel run_ctx bb s2 = Error e)`
+       mp_tac >>
+     qpat_x_assum `run_block_entry fuel run_ctx bb s2 = Error _`
+       (fn th => simp[th]))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `?e. run_block_entry fuel run_ctx bb s2 = Error e`
+       strip_assume_tac >>
+     qpat_x_assum
+       `lift_result R_ok R_term R_term
+          (run_block_entry fuel run_ctx bb s2) _` mp_tac >>
+     qpat_x_assum `run_block_entry fuel run_ctx bb s2 = Error _`
+       (fn th =>
+         PURE_REWRITE_TAC[th, lift_result_def] >>
+         simp_tac bool_ss
+           [venomExecSemanticsTheory.exec_result_distinct])))
+  >- sound_inv_OK_tac
+  >- (rpt conj_tac >> first_assum ACCEPT_TAC)
+  >- (rpt conj_tac >> first_assum ACCEPT_TAC)
 QED
 
 (* ===== Widening variant with soundness ===== *)

--- a/venom/simulation/proofs/analysisSimProofsWidenScript.sml
+++ b/venom/simulation/proofs/analysisSimProofsWidenScript.sml
@@ -70,6 +70,14 @@ Proof
   rw[df_widen_boundary_def, df_boundary_def, widen_to_df_def]
 QED
 
+Triviality valid_state_rel_R_ok_halted[local]:
+  !R_ok R_term s1 s2.
+    valid_state_rel R_ok R_term /\ R_ok s1 s2 ==>
+    s1.vs_halted = s2.vs_halted
+Proof
+  metis_tac[vsr_R_ok_fields]
+QED
+
 (* Widening variant. Uses widen_to_df bridge to reduce to non-widen case.
  * The caller must establish is_fixpoint for the WIDEN process. *)
 Theorem df_analysis_pass_correct_widen_sound_proof:
@@ -255,26 +263,83 @@ Proof
     conj_tac >- first_assum ACCEPT_TAC >>
     qexists_tac `run_block fuel run_ctx bb s2` >>
     conj_tac >> first_assum ACCEPT_TAC) >>
-  Cases_on `run_block fuel run_ctx bb s1` >>
-  Cases_on `run_block fuel run_ctx (bt bb) s2` >>
-  gvs[lift_result_def]
-  >- (
-    rename1 `R_ok v1 v2` >>
-    `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
-    simp[lift_result_def] >>
-    imp_res_tac run_block_OK_inst_idx_0 >>
-    `v1.vs_current_bb = v2.vs_current_bb` by metis_tac[vsr_R_ok_fields] >>
-    (* Successor soundness: already in df_at form thanks to initial simp *)
-    `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
-     sound (df_at bottom result v1.vs_current_bb 0) v1` by
-      metis_tac[] >>
-    REWRITE_TAC [GSYM function_map_transform_def] >>
-    first_x_assum irule >> simp[] >>
-    rpt conj_tac >> first_assum ACCEPT_TAC)
-  >> (
-    Cases_on `run_block fuel run_ctx bb s2` >> gvs[lift_result_def] >>
-    Cases_on `run_block fuel run_ctx (bt bb) s2` >> gvs[lift_result_def])
+  (* Isolate the composed relation before splitting result constructors. *)
+  qpat_x_assum
+    `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1)
+       (run_block fuel run_ctx (bt bb) s2)` mp_tac >>
+  (Cases_on `run_block fuel run_ctx bb s1` THEN_LT
+   TRYALL (Cases_on `run_block fuel run_ctx (bt bb) s2`)) >>
+  PURE_REWRITE_TAC[lift_result_def] >>
+  simp_tac std_ss [] >> TRY strip_tac
+  (* First discharge terminal pairs with goal-only simplification. *)
+  >> (ALL_TAC THEN_LT TRYALL
+       (SIMP_TAC bool_ss
+          [venomExecSemanticsTheory.exec_result_case_def,
+           lift_result_def, venomExecSemanticsTheory.exec_result_distinct] >>
+        TRY (first_assum ACCEPT_TAC)))
+  (* The remaining focused goals are the OK-OK obligations.  Stage the
+     work across goals so no single TRYALL traverses every large context. *)
+  >> (ALL_TAC THEN_LT TRYALL (rename1 `R_ok v1 v2`))
+  >> (ALL_TAC THEN_LT TRYALL
+       (qpat_x_assum `run_block fuel run_ctx bb s1 = OK v1`
+          (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+        qpat_x_assum `run_block fuel run_ctx (bt bb) s2 = OK v2`
+          (fn th => assume_tac th >> PURE_REWRITE_TAC[th])))
+  >> (ALL_TAC THEN_LT TRYALL
+       (`~v1.vs_halted` by
+          (irule run_block_OK_not_halted >> first_assum ACCEPT_TAC)))
+  >> (ALL_TAC THEN_LT TRYALL
+       (`v1.vs_halted = v2.vs_halted` by
+          (irule valid_state_rel_R_ok_halted >> simp[]) >>
+        `~v2.vs_halted` by
+          (qpat_x_assum `~v1.vs_halted` mp_tac >>
+           qpat_x_assum `v1.vs_halted = v2.vs_halted` mp_tac >> simp[])))
+  >> (ALL_TAC THEN_LT TRYALL (simp[lift_result_def]))
+  >> (ALL_TAC THEN_LT TRYALL (imp_res_tac run_block_OK_inst_idx_0))
+  >> (ALL_TAC THEN_LT TRYALL
+       (`v1.vs_current_bb = v2.vs_current_bb` by
+          metis_tac[vsr_R_ok_fields]))
+  >> (ALL_TAC THEN_LT TRYALL
+       (`MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
+         sound (df_at bottom result v1.vs_current_bb 0) v1` by
+          metis_tac[]))
+  (* Eliminate branches contradicting the earlier no-error split. *)
+  >> (ALL_TAC THEN_LT TRYALL
+       (qpat_x_assum `run_block fuel run_ctx bb s2 = Error e`
+          (fn err_th =>
+            qpat_x_assum `~?e. run_block fuel run_ctx bb s2 = Error e`
+              mp_tac >>
+            PURE_REWRITE_TAC[err_th] >> simp[])))
+  (* Likewise, an asserted block error contradicts an OK lifted result. *)
+  >> (ALL_TAC THEN_LT TRYALL
+       (qpat_x_assum `?e. run_block fuel run_ctx bb s2 = Error e`
+          strip_assume_tac >>
+        qpat_x_assum
+          `lift_result R_ok R_term R_term
+             (run_block fuel run_ctx bb s2) (OK v2)` mp_tac >>
+        qpat_x_assum `run_block fuel run_ctx bb s2 = Error e`
+          (fn err_th => PURE_REWRITE_TAC[err_th]) >>
+        simp[lift_result_def]))
+  (* Only the genuine OK continuation remains. *)
+  >> (ALL_TAC THEN_LT TRYALL
+       (qpat_x_assum `run_block fuel run_ctx bb s1 = OK v1`
+          (fn th => assume_tac
+            (MATCH_MP
+              (Q.SPECL [`fuel`, `run_ctx`, `bb`, `s1`, `v1`]
+                analysisSimProofsTheory.run_block_OK_not_halted) th))))
+  >> (ALL_TAC THEN_LT TRYALL
+       (qspecl_then [`R_ok`, `R_term`, `v1`, `v2`] mp_tac
+          valid_state_rel_R_ok_halted >>
+        impl_tac >- (conj_tac >> first_assum ACCEPT_TAC) >> strip_tac))
+  >> (ALL_TAC THEN_LT TRYALL
+       (`~v2.vs_halted` by
+          (qpat_x_assum `~v1.vs_halted` mp_tac >>
+           qpat_x_assum `v1.vs_halted = v2.vs_halted` mp_tac >> simp[]) >>
+        simp[]))
+  >> (ALL_TAC THEN_LT TRYALL
+       (REWRITE_TAC [GSYM function_map_transform_def] >>
+        first_x_assum irule >> simp[] >>
+        rpt conj_tac >> first_assum ACCEPT_TAC))
 QED
 
 (* ===== Generic function-level correctness, parameterized by block sim =====
@@ -437,26 +502,67 @@ Proof
     conj_tac >- first_assum ACCEPT_TAC >>
     qexists_tac `run_block fuel run_ctx bb s2` >>
     conj_tac >> first_assum ACCEPT_TAC) >>
-  Cases_on `run_block fuel run_ctx bb s1` >>
-  Cases_on `run_block fuel run_ctx (bt bb) s2` >>
-  gvs[lift_result_def]
-  >- (
-    rename1 `R_ok v1 v2` >>
-    `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
-    simp[lift_result_def] >>
-    imp_res_tac run_block_OK_inst_idx_0 >>
-    `v1.vs_current_bb = v2.vs_current_bb` by metis_tac[vsr_R_ok_fields] >>
-    `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
-     sound (df_at bottom result v1.vs_current_bb 0) v1 /\
-     state_inv v1` by
-      metis_tac[] >>
-    REWRITE_TAC [GSYM function_map_transform_def] >>
-    first_x_assum irule >> simp[] >>
-    rpt conj_tac >> first_assum ACCEPT_TAC)
-  >> (
-    Cases_on `run_block fuel run_ctx bb s2` >> gvs[lift_result_def] >>
-    Cases_on `run_block fuel run_ctx (bt bb) s2` >> gvs[lift_result_def])
+  qpat_x_assum
+    `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1)
+       (run_block fuel run_ctx (bt bb) s2)` mp_tac >>
+  (Cases_on `run_block fuel run_ctx bb s1` THEN_LT
+   TRYALL (Cases_on `run_block fuel run_ctx (bt bb) s2`)) >>
+  PURE_REWRITE_TAC[lift_result_def] >>
+  simp_tac std_ss [] >> TRY strip_tac >>
+  (ALL_TAC THEN_LT TRYALL
+    (SIMP_TAC bool_ss
+       [venomExecSemanticsTheory.exec_result_case_def,
+        lift_result_def, venomExecSemanticsTheory.exec_result_distinct] >>
+     TRY (first_assum ACCEPT_TAC))) >>
+  (ALL_TAC THEN_LT TRYALL (rename1 `R_ok v1 v2`)) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s1 = OK v1`
+       (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+     qpat_x_assum `run_block fuel run_ctx (bt bb) s2 = OK v2`
+       (fn th => assume_tac th >> PURE_REWRITE_TAC[th]))) >>
+  (ALL_TAC THEN_LT TRYALL (simp[lift_result_def])) >>
+  (ALL_TAC THEN_LT TRYALL (imp_res_tac run_block_OK_inst_idx_0)) >>
+  (ALL_TAC THEN_LT TRYALL
+    (`v1.vs_current_bb = v2.vs_current_bb` by
+       metis_tac[vsr_R_ok_fields])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (`MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
+      sound (df_at bottom result v1.vs_current_bb 0) v1 /\
+      state_inv v1` by metis_tac[])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s2 = Error e`
+       (fn err_th =>
+         qpat_x_assum `~?e. run_block fuel run_ctx bb s2 = Error e`
+           mp_tac >>
+         PURE_REWRITE_TAC[err_th] >> simp[]))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `?e. run_block fuel run_ctx bb s2 = Error e`
+       strip_assume_tac >>
+     qpat_x_assum
+       `lift_result R_ok R_term R_term
+          (run_block fuel run_ctx bb s2) (OK v2)` mp_tac >>
+     qpat_x_assum `run_block fuel run_ctx bb s2 = Error e`
+       (fn err_th => PURE_REWRITE_TAC[err_th]) >>
+     simp[lift_result_def])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s1 = OK v1`
+       (fn th => assume_tac
+         (MATCH_MP
+           (Q.SPECL [`fuel`, `run_ctx`, `bb`, `s1`, `v1`]
+             analysisSimProofsTheory.run_block_OK_not_halted) th)))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qspecl_then [`R_ok`, `R_term`, `v1`, `v2`] mp_tac
+       valid_state_rel_R_ok_halted >>
+     impl_tac >- (conj_tac >> first_assum ACCEPT_TAC) >> strip_tac)) >>
+  (ALL_TAC THEN_LT TRYALL
+    (`~v2.vs_halted` by
+       (qpat_x_assum `~v1.vs_halted` mp_tac >>
+        qpat_x_assum `v1.vs_halted = v2.vs_halted` mp_tac >> simp[]) >>
+     simp[])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (REWRITE_TAC [GSYM function_map_transform_def] >>
+     first_x_assum irule >> simp[] >>
+     rpt conj_tac >> first_assum ACCEPT_TAC))
 QED
 
 (* Non-widen block-level simulation: like widen_block_sim but for df_analyze.
@@ -600,26 +706,67 @@ Proof
     conj_tac >- first_assum ACCEPT_TAC >>
     qexists_tac `run_block fuel run_ctx bb s2` >>
     conj_tac >> first_assum ACCEPT_TAC) >>
-  Cases_on `run_block fuel run_ctx bb s1` >>
-  Cases_on `run_block fuel run_ctx (bt bb) s2` >>
-  gvs[lift_result_def]
-  >- (
-    rename1 `R_ok v1 v2` >>
-    `~v1.vs_halted` by metis_tac[run_block_OK_not_halted] >>
-    `~v2.vs_halted` by metis_tac[vsr_R_ok_fields] >>
-    simp[lift_result_def] >>
-    imp_res_tac run_block_OK_inst_idx_0 >>
-    `v1.vs_current_bb = v2.vs_current_bb` by metis_tac[vsr_R_ok_fields] >>
-    `MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
-     sound (df_at bottom result v1.vs_current_bb 0) v1 /\
-     state_inv v1` by
-      metis_tac[] >>
-    REWRITE_TAC [GSYM function_map_transform_def] >>
-    first_x_assum irule >> simp[] >>
-    rpt conj_tac >> first_assum ACCEPT_TAC)
-  >> (
-    Cases_on `run_block fuel run_ctx bb s2` >> gvs[lift_result_def] >>
-    Cases_on `run_block fuel run_ctx (bt bb) s2` >> gvs[lift_result_def])
+  qpat_x_assum
+    `lift_result R_ok R_term R_term (run_block fuel run_ctx bb s1)
+       (run_block fuel run_ctx (bt bb) s2)` mp_tac >>
+  (Cases_on `run_block fuel run_ctx bb s1` THEN_LT
+   TRYALL (Cases_on `run_block fuel run_ctx (bt bb) s2`)) >>
+  PURE_REWRITE_TAC[lift_result_def] >>
+  simp_tac std_ss [] >> TRY strip_tac >>
+  (ALL_TAC THEN_LT TRYALL
+    (SIMP_TAC bool_ss
+       [venomExecSemanticsTheory.exec_result_case_def,
+        lift_result_def, venomExecSemanticsTheory.exec_result_distinct] >>
+     TRY (first_assum ACCEPT_TAC))) >>
+  (ALL_TAC THEN_LT TRYALL (rename1 `R_ok v1 v2`)) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s1 = OK v1`
+       (fn th => assume_tac th >> PURE_REWRITE_TAC[th]) >>
+     qpat_x_assum `run_block fuel run_ctx (bt bb) s2 = OK v2`
+       (fn th => assume_tac th >> PURE_REWRITE_TAC[th]))) >>
+  (ALL_TAC THEN_LT TRYALL (simp[lift_result_def])) >>
+  (ALL_TAC THEN_LT TRYALL (imp_res_tac run_block_OK_inst_idx_0)) >>
+  (ALL_TAC THEN_LT TRYALL
+    (`v1.vs_current_bb = v2.vs_current_bb` by
+       metis_tac[vsr_R_ok_fields])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (`MEM v1.vs_current_bb cfg.cfg_dfs_pre /\
+      sound (df_at bottom result v1.vs_current_bb 0) v1 /\
+      state_inv v1` by metis_tac[])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s2 = Error e`
+       (fn err_th =>
+         qpat_x_assum `~?e. run_block fuel run_ctx bb s2 = Error e`
+           mp_tac >>
+         PURE_REWRITE_TAC[err_th] >> simp[]))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `?e. run_block fuel run_ctx bb s2 = Error e`
+       strip_assume_tac >>
+     qpat_x_assum
+       `lift_result R_ok R_term R_term
+          (run_block fuel run_ctx bb s2) (OK v2)` mp_tac >>
+     qpat_x_assum `run_block fuel run_ctx bb s2 = Error e`
+       (fn err_th => PURE_REWRITE_TAC[err_th]) >>
+     simp[lift_result_def])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qpat_x_assum `run_block fuel run_ctx bb s1 = OK v1`
+       (fn th => assume_tac
+         (MATCH_MP
+           (Q.SPECL [`fuel`, `run_ctx`, `bb`, `s1`, `v1`]
+             analysisSimProofsTheory.run_block_OK_not_halted) th)))) >>
+  (ALL_TAC THEN_LT TRYALL
+    (qspecl_then [`R_ok`, `R_term`, `v1`, `v2`] mp_tac
+       valid_state_rel_R_ok_halted >>
+     impl_tac >- (conj_tac >> first_assum ACCEPT_TAC) >> strip_tac)) >>
+  (ALL_TAC THEN_LT TRYALL
+    (`~v2.vs_halted` by
+       (qpat_x_assum `~v1.vs_halted` mp_tac >>
+        qpat_x_assum `v1.vs_halted = v2.vs_halted` mp_tac >> simp[]) >>
+     simp[])) >>
+  (ALL_TAC THEN_LT TRYALL
+    (REWRITE_TAC [GSYM function_map_transform_def] >>
+     first_x_assum irule >> simp[] >>
+     rpt conj_tac >> first_assum ACCEPT_TAC))
 QED
 
 (* Widening + state_inv: uses transfer_sound + analysis_inst_simulates *)

--- a/venom/simulation/proofs/crossBlockSimProofsScript.sml
+++ b/venom/simulation/proofs/crossBlockSimProofsScript.sml
@@ -657,8 +657,9 @@ Proof
   Induct_on `n` >> rpt strip_tac
   >- ( (* n=0: lift_result composition *)
     gvs[resolves_to_def] >>
-    Cases_on `r1` >> Cases_on `r2` >> Cases_on `r3` >>
-    gvs[lift_result_def] >> metis_tac[])
+    irule lift_result_trans_proof >>
+    rpt conj_tac >> TRY (FIRST_ASSUM ACCEPT_TAC) >>
+    qexists_tac `r2` >> simp[])
   >>
   qpat_x_assum `resolves_to _ _ _ _ (SUC _) _ _` mp_tac >>
   simp[Once resolves_to_def] >> strip_tac >> gvs[] >|

--- a/venom/simulation/proofs/execEquivParamBaseScript.sml
+++ b/venom/simulation/proofs/execEquivParamBaseScript.sml
@@ -423,7 +423,11 @@ Theorem vsr_exec_read1:
     lift_result R_ok R_term R_term (exec_read1 f inst s1) (exec_read1 f inst s2)
 Proof
   rw[exec_read1_def] >> vsr_eval_ops_tac () >>
-  rpt (CASE_TAC >> gvs[lift_result_def]) >>
+  CASE_TAC >> gvs[lift_result_def] >>
+  CASE_TAC >> gvs[lift_result_def] >>
+  CASE_TAC >> gvs[lift_result_def] >>
+  CASE_TAC >> gvs[lift_result_def] >>
+  CASE_TAC >> gvs[lift_result_def] >>
   vsr_irule vsr_update_var_R_ok >> simp[]
 QED
 

--- a/venom/simulation/proofs/execEquivParamHelpers2Script.sml
+++ b/venom/simulation/proofs/execEquivParamHelpers2Script.sml
@@ -23,7 +23,8 @@ fun vsr_eval_ops_tac () =
     rw[] >> vsr_irule vsr_eval_operand >> simp[] >> metis_tac[])
 
 fun vsr_eval_rewrite_tac () =
-  imp_res_tac vsr_R_ok_fields >> vsr_eval_ops_tac () >> simp[step_inst_base_def]
+  imp_res_tac vsr_R_ok_fields >> vsr_eval_ops_tac () >>
+  PURE_ONCE_REWRITE_TAC[step_inst_base_def] >> ASM_REWRITE_TAC[] >> simp[]
 
 (* ==========================================================================
    step_inst_base helpers — Part 2

--- a/venom/simulation/proofs/execEquivParamHelpersScript.sml
+++ b/venom/simulation/proofs/execEquivParamHelpersScript.sml
@@ -62,7 +62,7 @@ Theorem vsr_step_inst_pure3:
     (!x. MEM (Var x) inst.inst_operands ==> lookup_var x s1 = lookup_var x s2) ==>
     lift_result R_ok R_term R_term (step_inst_base inst s1) (step_inst_base inst s2)
 Proof
-  rpt strip_tac >> gvs[step_inst_base_def] >>
+  rw[] >> ASM_REWRITE_TAC[step_inst_base_def] >> simp[] >>
   vsr_irule vsr_exec_pure3 >> simp[]
 QED
 
@@ -103,7 +103,7 @@ Theorem vsr_step_inst_extcodehash:
     (!x. MEM (Var x) inst.inst_operands ==> lookup_var x s1 = lookup_var x s2) ==>
     lift_result R_ok R_term R_term (step_inst_base inst s1) (step_inst_base inst s2)
 Proof
-  rpt strip_tac >> gvs[step_inst_base_def] >>
+  rw[] >> ASM_REWRITE_TAC[step_inst_base_def] >> simp[] >>
   vsr_irule vsr_exec_read1 >> simp[] >> rw[] >>
   imp_res_tac vsr_R_ok_fields >> gvs[]
 QED

--- a/venom/simulation/proofs/execEquivParamProofsScript.sml
+++ b/venom/simulation/proofs/execEquivParamProofsScript.sml
@@ -329,7 +329,10 @@ Proof
   rpt gen_tac >> strip_tac >>
   `s1.vs_prev_bb = s2.vs_prev_bb` by (drule vsr_R_ok_prev_bb >> simp[]) >>
   `EVERY (λinst. inst.inst_opcode = PHI ⇒ ∀x. MEM (Var x) inst.inst_operands ⇒ lookup_var x s1 = lookup_var x s2) bb.bb_instructions` by
-    (irule (Q.SPECL [`R_ok`,`R_term`,`fn`] operand_agreement_EVERY) >> metis_tac[]) >>
+    (mp_tac (Q.SPECL [`R_ok`, `R_term`, `fn`, `bb`, `s1`, `s2`]
+       operand_agreement_EVERY) >>
+     impl_tac >- (rpt conj_tac >> first_assum ACCEPT_TAC) >>
+     simp[]) >>
   ONCE_REWRITE_TAC[run_block_def] >> qspec_then `s1` assume_tac eval_phis_ok_or_error_defs >> qspec_then `s2` assume_tac eval_phis_ok_or_error_defs >>
   DISJ_CASES_TAC (Q.SPECL [`s1`,`bb.bb_instructions`] eval_phis_ok_or_error_defs) >-
     (DISJ_CASES_TAC (Q.SPECL [`s2`,`bb.bb_instructions`] eval_phis_ok_or_error_defs) >-

--- a/venom/simulation/proofs/instIdxIndepScript.sml
+++ b/venom/simulation/proofs/instIdxIndepScript.sml
@@ -362,6 +362,14 @@ val opcode_idx_tac =
   EVERY_CASE_TAC >>
   simp(idx_rw @ [venom_state_component_equality]);
 
+(* Isolate the expensive opcode dispatch once for the MUL branch. *)
+Theorem step_inst_base_MUL[local]:
+  !inst s. inst.inst_opcode = MUL ==>
+    step_inst_base inst s = exec_pure2 $* inst s
+Proof
+  simp[step_inst_base_def]
+QED
+
 (* ================================================================
    THE MAIN THEOREM — exported
    ================================================================ *)
@@ -375,7 +383,7 @@ Proof
   simp[is_terminator_def]
   >- opcode_idx_tac  (* ADD *)
   >- opcode_idx_tac  (* SUB *)
-  >- opcode_idx_tac  (* MUL *)
+  >- (asm_simp_tac std_ss [step_inst_base_MUL, exec_pure2_idx])  (* MUL *)
   >- opcode_idx_tac  (* Div *)
   >- opcode_idx_tac  (* SDIV *)
   >- opcode_idx_tac  (* Mod *)

--- a/venom/simulation/proofs/passSimulationProofsScript.sml
+++ b/venom/simulation/proofs/passSimulationProofsScript.sml
@@ -30,6 +30,8 @@ Ancestors
   stateEquivProps execEquivProps stateEquiv venomInst venomExecSemantics
   venomExecProofs venomWf list indexedLists
 
+fun lift_result_case_tac () = gvs[lift_result_def]
+
 Theorem lookup_block_MEM[local]:
   !lbl bbs bb. lookup_block lbl bbs = SOME bb ==> MEM bb bbs
 Proof
@@ -136,8 +138,13 @@ Theorem run_block_same_code_R_ok[local]:
                              (run_block fuel ctx bb s2)
 Proof
   rpt gen_tac >> strip_tac >>
-  mp_tac (Q.SPECL [`R_ok`,`R_term`,`fn`] run_block_preserves_R_helper) >>
-  simp[] >> metis_tac[]
+  mp_tac (Q.SPECL [`R_ok`, `R_term`, `fn`]
+    run_block_preserves_R_helper) >>
+  simp[] >> strip_tac >>
+  qpat_x_assum `(_ ==> !fuel ctx bb s1 s2. _)` mp_tac >>
+  impl_tac >- (rpt conj_tac >> FIRST_ASSUM ACCEPT_TAC) >>
+  disch_then (qspecl_then [`fuel`, `ctx`, `bb`, `s1`, `s2`] mp_tac) >>
+  simp[]
 QED
 
 
@@ -1022,7 +1029,7 @@ Proof
   `MEM (bt bb) fn'.fn_blocks` by
     (simp[Abbr `fn'`, function_map_transform_def, MEM_MAP] >>
      metis_tac[]) >>
-  (* Triangle: per-block + same-code *)
+  (* RBPR triangle: per-block + same-code *)
   `lift_result R_ok R_term R_term (run_block fuel ctx bb s1)
                             (run_block fuel ctx (bt bb) s1)` by metis_tac[] >>
   `lift_result R_ok R_term R_term (run_block fuel ctx (bt bb) s1)
@@ -1034,8 +1041,20 @@ Proof
       qexists_tac `run_block fuel ctx (bt bb) s1` >>
       simp[]) >>
   Cases_on `run_block fuel ctx bb s1` >>
-  Cases_on `run_block fuel ctx (bt bb) s2` >>
-  gvs[lift_result_def]
+  Cases_on `run_block fuel ctx (bt bb) s2` >|
+  [lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac (), lift_result_case_tac (),
+   lift_result_case_tac ()]
   >- (
     (* Both OK, not halted: recurse via IH *)
     `v'.vs_halted <=> v.vs_halted` by metis_tac[] >>
@@ -1187,8 +1206,15 @@ Proof
      MEM bb fn.fn_blocks /\ R_ok s1' s2' ==>
      lift_result R_ok R_term R_term (run_block fuel ctx bb s1')
                               (run_block fuel ctx bb s2')` by
-    (mp_tac (Q.SPECL [`R_ok`,`R_term`,`fn`] run_block_preserves_R_helper) >>
-     simp[] >> metis_tac[]) >>
+    (rpt gen_tac >> strip_tac >>
+     mp_tac (Q.SPECL [`R_ok`, `R_term`, `fn`]
+       run_block_preserves_R_helper) >>
+     simp[] >> strip_tac >>
+     qpat_x_assum `(_ ==> !fuel ctx bb s1 s2. _)` mp_tac >>
+     impl_tac >- (rpt conj_tac >> FIRST_ASSUM ACCEPT_TAC) >>
+     disch_then (qspecl_then [`fuel`, `ctx`, `bb`, `s1'`, `s2'`]
+       mp_tac) >>
+     simp[]) >>
   qsuff_tac
     `!fuel ctx s1 s2.
        R_ok s1 s2 /\ s1.vs_inst_idx = 0 /\ block_inv s1 ==>


### PR DESCRIPTION
Optimizes the proofs to make sure each tactic definitely fits within the 2.5s tactic timeout