### PR TITLE
Implement faithful contract creation builtin semantics

### DIFF
--- a/frontend/jsonToVyperExprScript.sml
+++ b/frontend/jsonToVyperExprScript.sml
@@ -356,21 +356,34 @@ Definition make_builtin_call_def:
     else if name = "create_minimal_proxy_to" ∨ name = "create_forwarder_to" then
       let rof = kwarg_bool "revert_on_failure" kwargs T in
       let value_e = kwarg_expr "value" kwargs (Literal (BaseT (UintT 256)) (IntL 0)) in
-      Call ty (CreateTarget CreateMinimalProxy rof) (args ++ [value_e]) NONE
+      let salt_opt = ALOOKUP kwargs "salt" in
+      let salt_es = case salt_opt of NONE => [] | SOME salt_e => [salt_e] in
+      Call ty (CreateTarget CreateMinimalProxy (IS_SOME salt_opt) rof)
+        (TAKE 1 args ++ [value_e] ++ salt_es) NONE
     else if name = "create_copy_of" then
       let rof = kwarg_bool "revert_on_failure" kwargs T in
       let value_e = kwarg_expr "value" kwargs (Literal (BaseT (UintT 256)) (IntL 0)) in
-      Call ty (CreateTarget CreateCopyOf rof) (args ++ [value_e]) NONE
+      let salt_opt = ALOOKUP kwargs "salt" in
+      let salt_es = case salt_opt of NONE => [] | SOME salt_e => [salt_e] in
+      Call ty (CreateTarget CreateCopyOf (IS_SOME salt_opt) rof)
+        (TAKE 1 args ++ [value_e] ++ salt_es) NONE
     else if name = "create_from_blueprint" then
       let rof = kwarg_bool "revert_on_failure" kwargs T in
-      let code_offset = kwarg_num "code_offset" kwargs 3 in
       let raw_args_flag = kwarg_bool "raw_args" kwargs F in
       let value_e = kwarg_expr "value" kwargs (Literal (BaseT (UintT 256)) (IntL 0)) in
-      Call ty (CreateTarget (CreateFromBlueprint code_offset raw_args_flag) rof) (args ++ [value_e]) NONE
+      let salt_opt = ALOOKUP kwargs "salt" in
+      let salt_es = case salt_opt of NONE => [] | SOME salt_e => [salt_e] in
+      let code_offset_e = kwarg_expr "code_offset" kwargs
+        (Literal (BaseT (UintT 256)) (IntL 3)) in
+      Call ty (CreateTarget (CreateFromBlueprint raw_args_flag) (IS_SOME salt_opt) rof)
+        (TAKE 1 args ++ [value_e] ++ salt_es ++ [code_offset_e] ++ DROP 1 args) NONE
     else if name = "raw_create" then
       let rof = kwarg_bool "revert_on_failure" kwargs T in
       let value_e = kwarg_expr "value" kwargs (Literal (BaseT (UintT 256)) (IntL 0)) in
-      Call ty (CreateTarget RawCreate rof) (args ++ [value_e]) NONE
+      let salt_opt = ALOOKUP kwargs "salt" in
+      let salt_es = case salt_opt of NONE => [] | SOME salt_e => [salt_e] in
+      Call ty (CreateTarget RawCreate (IS_SOME salt_opt) rof)
+        (TAKE 1 args ++ [value_e] ++ DROP 1 args ++ salt_es) NONE
     else if name = "abs" then Builtin ty Abs args
     else if name = "as_wei_value" then
       (case args of

--- a/lowering/defs/exprLoweringScript.sml
+++ b/lowering/defs/exprLoweringScript.sml
@@ -2136,7 +2136,7 @@ Definition compile_call_def:
   compile_call cfn cenv ret_ty ty SelfDestructTarget args default_ret st =
     (let (_, st') = emit_inst INVALID [] [] st in
      (StackValue ret_ty (Lit 0w), st')) ∧
-  compile_call cfn cenv ret_ty ty (CreateTarget ck rof) args default_ret st =
+  compile_call cfn cenv ret_ty ty (CreateTarget ck has_salt rof) args default_ret st =
     (let (_, st') = emit_inst INVALID [] [] st in
      (StackValue ret_ty (Lit 0w), st'))
 End

--- a/semantics/prop/vyperEvalExprPreservesScopesDomScript.sml
+++ b/semantics/prop/vyperEvalExprPreservesScopesDomScript.sml
@@ -1,6 +1,6 @@
 Theory vyperEvalExprPreservesScopesDom
 Ancestors
-  vyperMisc vyperContext vyperState vyperInterpreter vyperLookup
+  vyperMisc vyperContext vyperState vyperCreate vyperInterpreter vyperLookup
   vyperScopePreservation vyperStatePreservation
 
 (* ========================================================================
@@ -407,18 +407,18 @@ QED
 
 (* CreateTarget *)
 Theorem case_CreateTarget_dom[local]:
-  ∀cx ty kind rof es v0.
+  ∀cx ty kind has_salt rof es v0.
     (∀st res st'. eval_exprs cx es st = (res,st') ⇒ MAP FDOM st.scopes = MAP FDOM st'.scopes) ⇒
     ∀st res st'.
-      eval_expr cx (Call ty (CreateTarget kind rof) es v0) st = (res,st') ⇒
+      eval_expr cx (Call ty (CreateTarget kind has_salt rof) es v0) st = (res,st') ⇒
       MAP FDOM st.scopes = MAP FDOM st'.scopes
 Proof
   rpt strip_tac >> qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
-  simp[evaluate_def, bind_def, ignore_bind_def, AllCaseEqs(), return_def, raise_def,
-       check_def, type_check_def, assert_def, lift_option_def, lift_option_type_def,
-       get_accounts_def, update_accounts_def, option_CASE_rator, COND_RATOR] >>
-  strip_tac >> gvs[AllCaseEqs(), return_def, raise_def] >>
-  imp_res_tac transfer_value_scopes >> gvs[]
+  simp[Once evaluate_def, bind_def] >>
+  Cases_on `eval_exprs cx es st` >> Cases_on `q` >> simp[] >>
+  strip_tac >>
+  first_x_assum drule >> strip_tac >>
+  drule eval_create_preserves_non_accounts >> strip_tac >> gvs[]
 QED
 
 (* Goal 17: ExtCall (exact evaluate_ind shape) *)

--- a/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
+++ b/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
@@ -1,6 +1,6 @@
 Theory vyperEvalPreservesImmutablesDom
 Ancestors
-  vyperMisc vyperAST vyperValue vyperContext vyperState vyperStorageBackend vyperInterpreter
+  vyperMisc vyperAST vyperValue vyperContext vyperState vyperStorageBackend vyperCreate vyperInterpreter
   vyperLookup vyperScopePreservation vyperStatePreservation
   vyperAssignTarget vyperEvalExprPreservesScopesDom
   vyperImmutablesPreservation
@@ -2033,41 +2033,19 @@ Proof
   rpt gen_tac \\
   strip_tac \\
   conj_tac
-  >- (qspecl_then
+  >- (match_mp_tac (Q.SPECL
         [`cx`, `src_id_opt`, `fn`, `es`,
          `ih_check_s`, `ih_mod_s`, `ih_fun_s`, `ih_len_s`, `ih_args_s`,
          `xrec`, `srec`, `ts`, `smod`, `tup`, `sfun`, `xlen`, `slen`,
          `vs`, `sevl`, `needed_dflts`, `cxd`, `prev`, `INL dflt_vs`, `sdfl`]
-        mp_tac intcall_default_frame_imm_dom_from_generated_ih \\
+        intcall_default_frame_imm_dom_from_generated_ih) \\
+      conj_tac >- FIRST_ASSUM ACCEPT_TAC \\
+      qpat_x_assum
+        `∀s0 x0 t0 s1 ts0 t1 s2 tup0 t2 mut0 stup0 nr0 stup20
+            args0 sstup0 dflts0 sstup20 ret0 body0 s3 x1 t3 s4 vs0 t4
+            needed_dflts0 cxd0. _` kall_tac \\
       simp[] \\
-      disch_then irule \\
-      simp[] \\
-      conj_tac
-      >- (rpt strip_tac \\
-          qpat_assum `∀s0 x0 t0 s1 ts0 t1 s2 tup0 t2 mut0 stup0 nr0 stup20
-                         args0 sstup0 dflts0 sstup20 ret0 body0 s3 x1 t3 s4
-                         vs0 t4 needed_dflts0 cxd0.
-                         _ ⇒ ∀st0 res0 st1.
-                           eval_exprs cxd0 needed_dflts0 st0 = (res0,st1) ⇒
-                           preserves_immutables_dom cxd0 st0 st1`
-            (qspecl_then
-              [`s0`, `()`, `t0`, `s1`, `ts0`, `t1`, `s2`, `tup0`, `t2`,
-               `FST tup0`, `SND tup0`, `FST (SND tup0)`, `SND (SND tup0)`,
-               `FST (SND (SND tup0))`, `SND (SND (SND tup0))`,
-               `FST (SND (SND (SND tup0)))`, `SND (SND (SND (SND tup0)))`,
-               `FST (SND (SND (SND (SND tup0))))`,
-               `SND (SND (SND (SND (SND tup0))))`, `s3`, `()`, `t3`,
-               `s4`, `vs0`, `t4`,
-               `DROP
-                  (LENGTH (FST (SND (SND (SND tup0)))) −
-                   (LENGTH (FST (SND (SND tup0))) − LENGTH es))
-                  (FST (SND (SND (SND tup0))))`,
-               `cx with stk updated_by CONS (src_id_opt,fn)`] mp_tac) \\
-          simp[] \\
-          disch_then irule \\
-          simp[] \\
-          gvs[type_check_def, assert_def] \\
-          decide_tac) \\
+      gvs[type_check_def, assert_def] \\
       qhdtm_x_assum`type_check`mp_tac >>
       simp_tac(srw_ss())[type_check_def, assert_def] >>
       strip_tac >> rpt BasicProvers.VAR_EQ_TAC >>
@@ -3397,15 +3375,11 @@ Proof
       irule preserves_immutables_dom_eq >> gvs[])
   (* CreateTarget *)
   >- (qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
-      simp[Once evaluate_def, bind_def, ignore_bind_def, AllCaseEqs(), return_def, raise_def,
-           check_def, type_check_def, assert_def, lift_option_def, lift_option_type_def,
-           get_accounts_def, update_accounts_def, option_CASE_rator, COND_RATOR] >>
-      rpt strip_tac >> gvs[AllCaseEqs(), return_def, raise_def] >>
+      simp[Once evaluate_def, bind_def] >>
+      Cases_on `eval_exprs cx es st` >> Cases_on `q` >> simp[] >>
+      strip_tac >>
       first_x_assum drule >> strip_tac >>
-      TRY (gvs[] >> NO_TAC) >>
-      TRY (imp_res_tac transfer_value_immutables >>
-           irule preserves_immutables_dom_trans >> first_assum (irule_at Any) >>
-           irule preserves_immutables_dom_eq >> gvs[] >> NO_TAC) >>
+      drule eval_create_preserves_non_accounts >> strip_tac >>
       irule preserves_immutables_dom_trans >> first_assum (irule_at Any) >>
       irule preserves_immutables_dom_eq >> gvs[])
   >- gvs[evaluate_def, return_def, preserves_immutables_dom_refl]

--- a/semantics/prop/vyperEvalPreservesScopesScript.sml
+++ b/semantics/prop/vyperEvalPreservesScopesScript.sml
@@ -1,7 +1,7 @@
 Theory vyperEvalPreservesScopes
 Ancestors
   vyperTypeInvariants
-  vyperState vyperInterpreter vyperLookup
+  vyperState vyperCreate vyperInterpreter vyperLookup
   vyperEvalExprPreservesScopesDom vyperScopePreservation
   vyperMisc vyperImmutablesPreservation vyperStatePreservation
 
@@ -2090,17 +2090,13 @@ Proof
   (* CreateTarget *)
   conj_tac >- (
     rpt gen_tac >> strip_tac >> rpt gen_tac >> strip_tac >>
-    gvs[Once evaluate_def, bind_apply, ignore_bind_apply, AllCaseEqs(),
-         return_def, COND_RATOR] >>
-    imp_res_tac check_state >>
-    imp_res_tac type_check_state >>
-    imp_res_tac lift_option_type_state >>
-    imp_res_tac get_accounts_state >>
-    imp_res_tac transfer_value_scopes >>
-    imp_res_tac transfer_value_immutables >>
-    imp_res_tac update_accounts_scopes >>
-    imp_res_tac update_accounts_immutables >> gvs[] >>
-    first_x_assum drule >> rw[] >>
+    qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+    simp[Once evaluate_def, bind_def] >>
+    Cases_on `eval_exprs cx es st` >> Cases_on `q` >> simp[] >>
+    strip_tac >>
+    first_x_assum drule >> strip_tac >>
+    drule eval_create_preserves_non_accounts >> strip_tac >>
+    irule preserves_tv_trans >> first_assum (irule_at Any) >>
     gvs[preserves_tv_def]) >>
   (* eval_exprs [] *)
   conj_tac >- rw[evaluate_def, return_def] >>

--- a/semantics/prop/vyperExprNoControlScript.sml
+++ b/semantics/prop/vyperExprNoControlScript.sml
@@ -1,7 +1,7 @@
 Theory vyperExprNoControl
 
 Ancestors
-  vyperInterpreter vyperAST vyperState vyperMisc
+  vyperCreate vyperInterpreter vyperAST vyperState vyperMisc
 Libs
   pairLib
 
@@ -479,7 +479,15 @@ val mono = [bind_def, ignore_bind_def, return_def, raise_def,
             get_scopes_def, get_accounts_def, get_transient_storage_def,
             update_accounts_def, update_transient_def];
 
-val helpers = [check_no_control, type_check_no_control,
+Theorem eval_create_no_control[local]:
+  eval_create cx kind has_salt rof arg_tys vs st = (INR ex, st') ==>
+  no_control_exc ex
+Proof
+  strip_tac >> drule eval_create_exception_is_error >> simp[no_control_exc_def]
+QED
+
+val helpers = [eval_create_no_control,
+               check_no_control, type_check_no_control,
                lift_option_no_control, lift_option_type_no_control,
                lift_sum_no_control, lift_sum_runtime_no_control,
                get_Value_no_control, read_storage_slot_no_control,

--- a/semantics/prop/vyperTypeBuiltinsScript.sml
+++ b/semantics/prop/vyperTypeBuiltinsScript.sml
@@ -1279,7 +1279,7 @@ Theorem well_typed_builtin_app_length:
   well_typed_builtin_app ty blt ts ==> builtin_args_length_ok blt (LENGTH ts)
 Proof
   simp[oneline well_typed_builtin_app_def] >>
-  CASE_TAC >> rw[builtin_args_length_ok_def] >>
+  Cases_on `blt` >> rw[builtin_args_length_ok_def] >>
   pop_assum mp_tac >> CASE_TAC >> rw[]
 QED
 

--- a/semantics/prop/vyperTypeEvalSoundnessScript.sml
+++ b/semantics/prop/vyperTypeEvalSoundnessScript.sml
@@ -207,7 +207,7 @@ QED
 
 Theorem create_call_evaluation_safe_args[local]:
   call_evaluation_safe cx
-    (int_calls_expr (Call loc (CreateTarget kind rof) es extra)) ==>
+    (int_calls_expr (Call loc (CreateTarget kind has_salt rof) es extra)) ==>
   call_evaluation_safe cx (int_calls_exprs es)
 Proof
   simp[int_calls_expr_def]
@@ -9904,7 +9904,7 @@ Resume eval_all_type_sound_mutual[Expr_Call_CreateTarget]:
   >- (
     strip_tac >>
     drule create_call_evaluation_safe_args >> strip_tac >>
-    qpat_x_assum `well_typed_expr env (Call _ (CreateTarget _ _) _ _)` mp_tac >>
+    qpat_x_assum `well_typed_expr env (Call _ (CreateTarget _ _ _) _ _)` mp_tac >>
     rewrite_tac[Once well_typed_expr_def] >> strip_tac >>
     qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
     simp_tac(srw_ss())[Once evaluate_def, bind_def, ignore_bind_def,
@@ -9917,12 +9917,11 @@ Resume eval_all_type_sound_mutual[Expr_Call_CreateTarget]:
     Cases_on `args_res` >> gvs[no_type_error_result_def]
     >- (
       rename1 `exprs_runtime_typed env es vs` >>
-      drule_all create_args_runtime_typed_dest >> strip_tac >> gvs[] >>
       strip_tac >>
-      qspecl_then [`env`, `cx`, `es`, `vs`, `args_st`, `amount`, `target_addr`,
-                   `res`, `st'`, `kind`, `rof`]
+      qspecl_then [`env`, `cx`, `es`, `vs`, `args_st`, `res`, `st'`,
+                   `kind`, `has_salt`, `rof`]
         mp_tac create_tail_result_sound_simp >>
-      simp[type_check_def, assert_def, runtime_consistent_def]) >>
+      simp[runtime_consistent_def]) >>
     strip_tac >> gvs[]) >>
   rpt strip_tac >> gvs[Once well_typed_expr_def]
 QED

--- a/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
+++ b/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
@@ -2,7 +2,7 @@
 
 Theory vyperTypeEvalStoragePreservation
 Ancestors
-  pair vyperInterpreter vyperState vyperStorageBackend vyperStorageLayoutSafety
+  pair vyperCreate vyperInterpreter vyperState vyperStorageBackend vyperStorageLayoutSafety
   vyperTypeSystem vyperTypeEnv vyperTypeInvariants vyperTypeValues vyperTypeCallGraph
   vyperEvalMisc vyperStatePreservation vyperScopePreservation
   vyperTypeCallStackSoundness vyperValue
@@ -2635,72 +2635,25 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_CreateTarget]:
     strip_tac >>
     `call_evaluation_safe cx (int_calls_exprs es)` by
       (qpat_x_assum `call_evaluation_safe cx
-          (int_calls_expr (Call _ (CreateTarget _ _) es _))` mp_tac >>
+          (int_calls_expr (Call _ (CreateTarget _ _ _) es _))` mp_tac >>
        simp[int_calls_expr_def]) >>
-    qpat_x_assum `well_typed_expr env (Call _ (CreateTarget _ _) _ _)` mp_tac >>
+    qpat_x_assum `well_typed_expr env
+        (Call _ (CreateTarget _ _ _) es _)` mp_tac >>
     rewrite_tac[Once well_typed_expr_def] >> strip_tac >>
     qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
-    simp_tac(srw_ss())[Once evaluate_def, bind_def, ignore_bind_def,
-                         type_check_def, check_def, assert_def,
-                         return_def, raise_def, lift_option_type_def,
-                         get_accounts_def] >>
-    simp[] >>
+    simp[Once evaluate_def, bind_def] >>
     Cases_on `eval_exprs cx es st` >>
     rename1 `eval_exprs cx es st = (args_res,args_st)` >>
     first_x_assum drule_all >> strip_tac >>
-    Cases_on `args_res` >> gvs[]
-    >- (
-      Cases_on `x = []` >> gvs[type_check_def, assert_def, return_def, raise_def]
-      >- (rpt strip_tac >> gvs[]) >>
-      Cases_on `dest_NumV (LAST x)` >> gvs[return_def, raise_def]
-      >- (rpt strip_tac >> gvs[]) >>
-      Cases_on `dest_AddressV (HD x)` >> gvs[return_def, raise_def]
-      >- (rpt strip_tac >> gvs[]) >>
-      rename [`dest_NumV (LAST x) = SOME amount`,
-              `dest_AddressV (HD x) = SOME target_addr`] >>
-      Cases_on `amount <= (lookup_account cx.txn.target args_st.accounts).balance` >>
-      gvs[bind_apply, ignore_bind_apply, assert_def, return_def, raise_def] >>
-      Cases_on `~vfmExecution$account_already_created
-          (lookup_account
-             (vfmContext$address_for_create cx.txn.target
-                (lookup_account cx.txn.target args_st.accounts).nonce)
-             args_st.accounts)` >>
-      gvs[bind_apply, ignore_bind_apply, assert_def, return_def, raise_def] >>
-      Cases_on `amount > 0`
-      >- (
-        Cases_on `transfer_value cx.txn.target
-            (vfmContext$address_for_create cx.txn.target
-               (lookup_account cx.txn.target args_st.accounts).nonce)
-            amount args_st` >>
-        rename1 `transfer_value cx.txn.target
-            (vfmContext$address_for_create cx.txn.target
-               (lookup_account cx.txn.target args_st.accounts).nonce)
-            amount args_st = (transfer_res,transfer_st)` >>
-        drule_all transfer_value_preserves_contract_storage_well_formed >>
-        Cases_on `transfer_res` >>
-        gvs[bind_apply, ignore_bind_apply, return_def, raise_def]
-        >- (
-          strip_tac >>
-          Cases_on `update_accounts
-              (vfmExecution$increment_nonce cx.txn.target) transfer_st` >>
-          rename1 `update_accounts
-              (vfmExecution$increment_nonce cx.txn.target) transfer_st =
-              (nonce_res,nonce_st)` >>
-          drule_all increment_nonce_preserves_contract_storage_well_formed >>
-          Cases_on `nonce_res` >>
-          gvs[bind_apply, ignore_bind_apply, return_def, raise_def] >>
-          rpt strip_tac >> gvs[]) >>
-        rpt strip_tac >> gvs[]) >>
-      Cases_on `update_accounts
-          (vfmExecution$increment_nonce cx.txn.target) args_st` >>
-      rename1 `update_accounts
-          (vfmExecution$increment_nonce cx.txn.target) args_st =
-          (nonce_res,nonce_st)` >>
-      drule_all increment_nonce_preserves_contract_storage_well_formed >>
-      Cases_on `nonce_res` >>
-      gvs[bind_apply, ignore_bind_apply, return_def, raise_def] >>
-      rpt strip_tac >> gvs[]) >>
-    rpt strip_tac >> gvs[]) >>
+    Cases_on `args_res` >> gvs[] >> strip_tac >>
+    imp_res_tac eval_create_preserves_non_accounts >>
+    imp_res_tac eval_create_preserves_storage >>
+    irule contract_storage_well_formed_storage_frame >>
+    qexists_tac `args_st` >> simp[] >>
+    Cases_on `b` >>
+    simp[vyperStorageBackendTheory.get_storage_def] >>
+    qpat_x_assum `!address. _` (qspec_then `cx.txn.target` mp_tac) >>
+    simp[vfmStateTheory.lookup_account_def]) >>
   rpt strip_tac >> gvs[Once well_typed_expr_def]
 QED
 

--- a/semantics/prop/vyperTypeExtCallSoundnessScript.sml
+++ b/semantics/prop/vyperTypeExtCallSoundnessScript.sml
@@ -9,7 +9,7 @@ Theory vyperTypeExtCallSoundness
 Ancestors
   list rich_list pred_set prim_rec arithmetic finite_map option pair sum
   vyperAST vyperValue vyperValueOperation vyperMisc vyperABI
-  vyperInterpreter vyperState vyperContext vyperStorage vyperTyping
+  vyperCreate vyperInterpreter vyperState vyperContext vyperStorage vyperTyping
   vyperEncodeDecode vyperArith vyperTypeSystem vyperTypeInvariants vyperTypeValues
   vyperTypeEnv vyperTypeEnvExtension vyperTypeEnvPreservation vyperTypeScopePop
   vyperTypeABI vyperTypeBindArguments vyperTypeExprResult
@@ -1669,162 +1669,287 @@ Proof
       toplevel_value_typed_def, value_has_type_def]
 QED
 
-Theorem create_tail_sound:
-  !env cx es vs st kind rof ty.
-    runtime_consistent env cx st /\
-    exprs_runtime_typed env es vs /\
-    LENGTH es >= 2 /\
-    HD (MAP expr_type es) = BaseT AddressT /\
-    LAST (MAP expr_type es) = BaseT (UintT 256) ==>
-    runtime_consistent env cx
-      (SND ((do
-               type_check (vs <> []) "create no args";
-               amount <- lift_option_type (dest_NumV (LAST vs)) "create value";
-               target_addr <- lift_option_type (dest_AddressV (HD vs)) "create target";
-               accounts <- get_accounts;
-               self_acct <<- lookup_account cx.txn.target accounts;
-               check (amount <= self_acct.balance) "create insufficient balance";
-               new_addr <<- vfmContext$address_for_create cx.txn.target self_acct.nonce;
-               existing <<- lookup_account new_addr accounts;
-               check (~vfmExecution$account_already_created existing) "address collision";
-               (if amount > 0 then transfer_value cx.txn.target new_addr amount else return ());
-               update_accounts (vfmExecution$increment_nonce cx.txn.target);
-               if rof then return (Value (AddressV new_addr))
-               else return (Value (AddressV new_addr))
-             od) st)) /\
-    (!s. FST ((do
-                 type_check (vs <> []) "create no args";
-                 amount <- lift_option_type (dest_NumV (LAST vs)) "create value";
-                 target_addr <- lift_option_type (dest_AddressV (HD vs)) "create target";
-                 accounts <- get_accounts;
-                 self_acct <<- lookup_account cx.txn.target accounts;
-                 check (amount <= self_acct.balance) "create insufficient balance";
-                 new_addr <<- vfmContext$address_for_create cx.txn.target self_acct.nonce;
-                 existing <<- lookup_account new_addr accounts;
-                 check (~vfmExecution$account_already_created existing) "address collision";
-                 (if amount > 0 then transfer_value cx.txn.target new_addr amount else return ());
-                 update_accounts (vfmExecution$increment_nonce cx.txn.target);
-                 if rof then return (Value (AddressV new_addr))
-                 else return (Value (AddressV new_addr))
-               od) st) <> INR (Error (TypeError s)))
+(* ===== Shared creation helper soundness ===== *)
+
+Theorem LIST_REL_source_value_compose[local]:
+  !tys tvs.
+    LIST_REL (\ty tv. evaluate_type tenv ty = SOME tv) tys tvs ==>
+    !vs. LIST_REL value_has_type tvs vs ==>
+      LIST_REL
+        (\ty v. ?tv. evaluate_type tenv ty = SOME tv /\ value_has_type tv v)
+        tys vs
+Proof
+  Induct >> Cases_on `tvs` >> simp[] >> rpt strip_tac >>
+  Cases_on `vs` >> gvs[] >> metis_tac[]
+QED
+
+Theorem LIST_REL_APPEND_SINGLETON[local]:
+  LIST_REL R (xs ++ [x]) ys ==>
+  ?y ys'. ys = ys' ++ [y] /\ LIST_REL R xs ys' /\ R x y
+Proof
+  simp[GSYM SNOC_APPEND, LIST_REL_SNOC]
+QED
+
+Theorem exprs_runtime_typed_LIST_REL_source_value[local]:
+  exprs_runtime_typed env es vs ==>
+  LIST_REL
+    (\ty v. ?tv. evaluate_type env.type_defs ty = SOME tv /\
+                   value_has_type tv v)
+    (MAP expr_type es) vs
+Proof
+  rw[exprs_runtime_typed_def, values_have_types_LIST_REL_extcall] >>
+  drule LIST_REL_evaluate_expr_types >> strip_tac >>
+  drule_all LIST_REL_source_value_compose >> simp[]
+QED
+
+Theorem source_value_LIST_REL_runtime_types[local]:
+  !tys vs.
+    LIST_REL
+      (\ty v. ?tv. evaluate_type tenv ty = SOME tv /\ value_has_type tv v)
+      tys vs ==>
+    ?tvs.
+      LIST_REL (\ty tv. evaluate_type tenv ty = SOME tv) tys tvs /\
+      values_have_types tvs vs
+Proof
+  Induct_on `tys` >> Cases_on `vs` >>
+  simp[values_have_types_LIST_REL_extcall, PULL_EXISTS] >>
+  rpt strip_tac >> first_x_assum drule >> strip_tac >>
+  qexists_tac `tvs` >> gvs[values_have_types_LIST_REL_extcall]
+QED
+
+Theorem value_has_type_Address_dest[local]:
+  value_has_type (BaseTV AddressT) v ==>
+  ?a. dest_AddressV v = SOME a
+Proof
+  strip_tac >> Cases_on `v` >> gvs[value_has_type_def, dest_AddressV_def]
+QED
+
+Theorem value_has_type_Uint256_dest[local]:
+  value_has_type (BaseTV (UintT 256)) v ==>
+  ?n. dest_NumV v = SOME n
+Proof
+  strip_tac >> Cases_on `v` >> gvs[value_has_type_def, dest_NumV_def] >>
+  rename1 `0 <= i` >>
+  `~(i < 0:int)` by intLib.ARITH_TAC >>
+  qexists_tac `Num i` >> simp[]
+QED
+
+Theorem value_has_type_Bytes_dest[local]:
+  value_has_type (BaseTV (BytesT bd)) v ==>
+  ?bs. dest_BytesV v = SOME bs
+Proof
+  strip_tac >> Cases_on `v` >> gvs[value_has_type_def, dest_BytesV_def]
+QED
+
+Theorem value_has_type_Bytes32_dest[local]:
+  value_has_type (BaseTV (BytesT (Fixed 32))) v ==>
+  ?bs. dest_BytesV v = SOME bs /\ LENGTH bs = 32
+Proof
+  strip_tac >> Cases_on `v` >> gvs[value_has_type_def, dest_BytesV_def]
+QED
+
+Theorem create_args_runtime_typed_decode:
+  create_arg_types_ok kind has_salt tys /\
+  LIST_REL
+    (\ty v. ?tv. evaluate_type tenv ty = SOME tv /\ value_has_type tv v)
+    tys vs ==>
+  ?ops ctor_tys.
+    dest_create_args kind has_salt vs = SOME ops /\
+    create_arg_ctor_types kind has_salt tys = SOME ctor_tys /\
+    LIST_REL
+      (\ty v. ?tv. evaluate_type tenv ty = SOME tv /\ value_has_type tv v)
+      ctor_tys ops.co_ctor_args
 Proof
   rpt strip_tac >>
-  drule_all create_args_runtime_typed_dest >> strip_tac >> gvs[] >>
-  rw[bind_def, ignore_bind_def, type_check_def, check_def, assert_def,
-     raise_def, return_def, lift_option_type_def, get_accounts_def,
-     update_accounts_def]
-  >- (Cases_on `transfer_value cx.txn.target
-          (vfmContext$address_for_create cx.txn.target
-             (lookup_account cx.txn.target st.accounts).nonce) amount st` >>
-      gvs[return_def] >> Cases_on `q` >> gvs[] >>
-      qspecl_then [`env`, `cx`, `cx.txn.target`,
-                   `vfmContext$address_for_create cx.txn.target
-                      (lookup_account cx.txn.target st.accounts).nonce`,
-                   `amount`, `st`] mp_tac transfer_value_runtime_consistent >>
-      simp[] >> strip_tac >>
-      qspecl_then [`env`, `cx`, `r`, `cx.txn.target`] mp_tac
-        runtime_consistent_increment_nonce >> simp[update_accounts_def, return_def])
-  >- (qspecl_then [`env`, `cx`, `st`, `cx.txn.target`] mp_tac
-        runtime_consistent_increment_nonce >> simp[update_accounts_def, return_def])
-  >- (qpat_x_assum `FST _ = INR (Error (TypeError s))` mp_tac >>
-      rw[bind_def, ignore_bind_def, type_check_def, check_def, assert_def,
-         raise_def, return_def, lift_option_type_def, get_accounts_def,
-         update_accounts_def] >>
-      Cases_on `amount > 0` >> gvs[return_def] >>
-      Cases_on `transfer_value cx.txn.target
-          (vfmContext$address_for_create cx.txn.target
-             (lookup_account cx.txn.target st.accounts).nonce) amount st` >>
-      gvs[return_def] >> Cases_on `q` >> gvs[] >>
-      qspecl_then [`cx.txn.target`,
-                   `vfmContext$address_for_create cx.txn.target
-                      (lookup_account cx.txn.target st.accounts).nonce`,
-                   `amount`, `st`, `s`] mp_tac transfer_value_no_type_error >> simp[])
+  Cases_on `kind` >> Cases_on `has_salt` >>
+  gvs[create_arg_types_ok_def, dest_create_args_def,
+      create_arg_ctor_types_def, make_create_operands_def,
+      dest_optional_num_def, dest_optional_salt_def, dest_create_salt_def,
+      evaluate_type_def, value_has_type_def, AllCaseEqs()] >>
+  TRY (imp_res_tac value_has_type_Address_dest) >>
+  TRY (imp_res_tac value_has_type_Uint256_dest) >>
+  TRY (imp_res_tac value_has_type_Bytes32_dest) >>
+  TRY (imp_res_tac value_has_type_Bytes_dest) >>
+  gvs[dest_create_args_def, create_arg_ctor_types_def,
+      make_create_operands_def, dest_optional_num_def,
+      dest_optional_salt_def, dest_create_salt_def, AllCaseEqs()] >>
+  imp_res_tac LIST_REL_APPEND_SINGLETON >>
+  gvs[evaluate_type_def] >>
+  qpat_x_assum `value_has_type (BaseTV (BytesT (Fixed 32))) y`
+    (strip_assume_tac o MATCH_MP value_has_type_Bytes32_dest) >>
+  TRY (imp_res_tac value_has_type_Bytes_dest) >>
+  gvs[dest_create_args_def, create_arg_ctor_types_def,
+      make_create_operands_def, dest_optional_num_def,
+      dest_optional_salt_def, dest_create_salt_def,
+      evaluate_type_def, value_has_type_def, GSYM SNOC_APPEND,
+      AllCaseEqs()]
+QED
+
+Theorem encode_create_ctor_args_total:
+  LIST_REL
+    (\ty v. ?tv. evaluate_type tenv ty = SOME tv /\ value_has_type tv v)
+    tys vs ==>
+  ?bytes. encode_create_ctor_args tenv tys vs = SOME bytes
+Proof
+  strip_tac >> drule source_value_LIST_REL_runtime_types >> strip_tac >>
+  drule_all (cj 2 vyper_to_abi_total) >> strip_tac >>
+  simp[encode_create_ctor_args_def]
+QED
+
+Theorem build_create_code_total:
+  create_arg_types_ok kind has_salt tys /\
+  dest_create_args kind has_salt vs = SOME ops /\
+  create_arg_ctor_types kind has_salt tys = SOME ctor_tys /\
+  LIST_REL
+    (\ty v. ?tv. evaluate_type tenv ty = SOME tv /\ value_has_type tv v)
+    ctor_tys ops.co_ctor_args ==>
+  ?code_info. build_create_code tenv kind ops accounts ctor_tys = SOME code_info
+Proof
+  rpt strip_tac >>
+  drule encode_create_ctor_args_total >> strip_tac >>
+  Cases_on `kind` >> Cases_on `has_salt` >>
+  gvs[create_arg_types_ok_def, dest_create_args_def,
+      create_arg_ctor_types_def, make_create_operands_def,
+      dest_optional_num_def, dest_optional_salt_def, dest_create_salt_def,
+      build_create_code_def, encode_create_ctor_args_def,
+      evaluate_type_def, value_has_type_def, AllCaseEqs(), LET_THM] >>
+  Cases_on `b` >>
+  gvs[build_create_code_def, encode_create_ctor_args_def,
+      evaluate_type_def, value_has_type_def, AllCaseEqs(), LET_THM] >>
+  Cases_on `v` >> gvs[value_has_type_def]
+QED
+
+Theorem build_create_code_runtime_code_bound:
+  accounts_well_typed accounts /\
+  build_create_code tenv kind ops accounts ctor_tys = SOME code_info ==>
+  !code. code_info.cc_runtime_code = SOME code ==>
+         LENGTH code <= max_code_size
+Proof
+  rpt strip_tac >>
+  Cases_on `kind` >>
+  gvs[build_create_code_def, AllCaseEqs(), LET_THM,
+      accounts_well_typed_def, account_well_typed_def,
+      vfmConstantsTheory.max_code_size_def] >>
+  first_x_assum (qspec_then `a` mp_tac) >> simp[]
+QED
+
+Theorem install_created_code_accounts_well_typed:
+  accounts_well_typed accounts /\
+  (!code. runtime_code = SOME code ==> LENGTH code <= max_code_size) ==>
+  accounts_well_typed
+    (install_created_code address runtime_code accounts)
+Proof
+  Cases_on `runtime_code` >>
+  gvs[install_created_code_def, accounts_well_typed_def,
+      account_well_typed_def, vfmConstantsTheory.max_code_size_def,
+      vfmStateTheory.lookup_account_def, vfmStateTheory.update_account_def,
+      combinTheory.APPLY_UPDATE_THM] >>
+  rpt strip_tac >> Cases_on `addr = address` >> gvs[]
+QED
+
+Theorem lookup_account_increment_nonce_balance[simp]:
+  (lookup_account a (vfmExecution$increment_nonce b accounts)).balance =
+  (lookup_account a accounts).balance
+Proof
+  simp[vfmExecutionTheory.increment_nonce_def,
+       vfmStateTheory.lookup_account_def, vfmStateTheory.update_account_def,
+       combinTheory.APPLY_UPDATE_THM] >>
+  Cases_on `a = b` >> simp[]
+QED
+
+Theorem proceed_create_accounts_well_typed:
+  accounts_well_typed accounts /\
+  amount <= (lookup_account sender accounts).balance /\
+  (lookup_account address accounts).balance + amount < 2 ** 256 /\
+  (!code. runtime_code = SOME code ==> LENGTH code <= max_code_size) ==>
+  accounts_well_typed
+    (proceed_create_accounts sender address amount runtime_code accounts)
+Proof
+  rpt strip_tac >>
+  simp[proceed_create_accounts_def] >>
+  irule install_created_code_accounts_well_typed >>
+  simp[] >>
+  irule vfm_transfer_value_accounts_well_typed >>
+  simp[accounts_well_typed_increment_nonce] >>
+  qpat_x_assum `(lookup_account address accounts).balance + amount < 2 ** 256`
+    mp_tac >> simp[ADD_COMM]
+QED
+
+Theorem eval_create_accounts_well_typed:
+  accounts_well_typed st.accounts /\
+  dest_create_args kind has_salt vs = SOME ops /\
+  create_arg_ctor_types kind has_salt arg_tys = SOME ctor_tys /\
+  build_create_code (get_tenv cx) kind ops st.accounts ctor_tys = SOME code_info /\
+  eval_create cx kind has_salt rof arg_tys vs st = (res, st') ==>
+  accounts_well_typed st'.accounts
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_create _ _ _ _ _ _ _ = _` mp_tac >>
+  simp[eval_create_def, bind_def, ignore_bind_def, lift_option_type_def,
+       get_accounts_def, update_accounts_def, check_def, assert_def,
+       create_soft_failure_def, return_def, raise_def] >>
+  rpt (IF_CASES_TAC >>
+       gvs[bind_def, ignore_bind_def, update_accounts_def,
+           check_def, assert_def, create_soft_failure_def,
+           return_def, raise_def]) >>
+  rpt strip_tac >> rpt BasicProvers.VAR_EQ_TAC >>
+  simp[update_accounts_def] >>
+  FIRST
+    [FIRST_ASSUM ACCEPT_TAC,
+     irule accounts_well_typed_increment_nonce >> FIRST_ASSUM ACCEPT_TAC,
+     irule proceed_create_accounts_well_typed >>
+     simp[] >>
+     rpt strip_tac >>
+     imp_res_tac build_create_code_runtime_code_bound]
 QED
 
 Theorem create_tail_result_sound_simp:
-  !env cx es vs st amount target_addr res st' kind rof.
+  !env cx es vs st res st' kind has_salt rof.
     runtime_consistent env cx st /\
     exprs_runtime_typed env es vs /\
-    LENGTH es >= 2 /\
-    HD (MAP expr_type es) = BaseT AddressT /\
-    LAST (MAP expr_type es) = BaseT (UintT 256) /\
-    dest_AddressV (HD vs) = SOME target_addr /\
-    dest_NumV (LAST vs) = SOME amount /\
-    ((case type_check (vs <> []) "create no args" st of
-        (INL x,s'') =>
-          (case return amount s'' of
-             (INL amount',s'') =>
-               (case return target_addr s'' of
-                  (INL target_addr',s'') =>
-                    do
-                      x <- check (amount' <= (lookup_account cx.txn.target s''.accounts).balance)
-                        "create insufficient balance";
-                      x <- check
-                        (~vfmExecution$account_already_created
-                           (lookup_account
-                              (vfmContext$address_for_create cx.txn.target
-                                 (lookup_account cx.txn.target s''.accounts).nonce)
-                              s''.accounts)) "address collision";
-                      x <- if amount' > 0 then
-                             transfer_value cx.txn.target
-                               (vfmContext$address_for_create cx.txn.target
-                                  (lookup_account cx.txn.target s''.accounts).nonce) amount'
-                           else return ();
-                      x <- update_accounts (vfmExecution$increment_nonce cx.txn.target);
-                      return (Value (AddressV
-                        (vfmContext$address_for_create cx.txn.target
-                           (lookup_account cx.txn.target s''.accounts).nonce)))
-                    od s''
-                | (INR e,s'') => (INR e,s''))
-           | (INR e,s'') => (INR e,s''))
-      | (INR e,s'') => (INR e,s'')) = (res,st')) ==>
-    state_well_typed st' /\ env_consistent env cx st' /\ accounts_well_typed st'.accounts /\
+    create_arg_types_ok kind has_salt (MAP expr_type es) /\
+    eval_create cx kind has_salt rof (MAP expr_type es) vs st = (res,st') ==>
+    state_well_typed st' /\ env_consistent env cx st' /\
+    accounts_well_typed st'.accounts /\
     (!msg. res <> INR (Error (TypeError msg))) /\
     (case res of
-     | INL tv => expr_result_typed env (Call (BaseT AddressT) (CreateTarget kind rof) es NONE) tv
+     | INL tv => expr_result_typed env
+         (Call (BaseT AddressT) (CreateTarget kind has_salt rof) es NONE) tv
      | INR _ => T)
 Proof
   rpt gen_tac >> strip_tac >>
-  qspecl_then [`env`, `cx`, `es`, `vs`, `st`, `kind`, `rof`, `BaseT AddressT`]
-    mp_tac create_tail_sound >>
-  impl_tac >- simp[] >>
-  strip_tac >>
-  gvs[] >>
+  `get_tenv cx = env.type_defs` by metis_tac[runtime_consistent_get_tenv] >>
+  drule exprs_runtime_typed_LIST_REL_source_value >> strip_tac >>
+  drule_all create_args_runtime_typed_decode >> strip_tac >>
+  `?code_info.
+      build_create_code (get_tenv cx) kind ops st.accounts ctor_tys =
+        SOME code_info` by (
+    qpat_x_assum `get_tenv cx = env.type_defs` (fn th => rewrite_tac[th]) >>
+    irule build_create_code_total >> metis_tac[]) >>
+  pop_assum strip_assume_tac >>
+  `accounts_well_typed st'.accounts` by (
+    irule eval_create_accounts_well_typed >>
+    metis_tac[runtime_consistent_def]) >>
+  drule eval_create_preserves_non_accounts >> strip_tac >>
   `runtime_consistent env cx st'` by (
-    qpat_x_assum `(case type_check _ _ _ of _ => _) = _` mp_tac >>
-    qpat_x_assum `runtime_consistent _ _ (SND _)` mp_tac >>
-    rw[bind_def, ignore_bind_def, type_check_def, check_def, assert_def,
-       raise_def, return_def,
-       lift_option_type_def, get_accounts_def, update_accounts_def] >>
-    gvs[]) >>
-  `!msg. res <> INR (Error (TypeError msg))` by (
-    gen_tac >>
-    qpat_x_assum `(case type_check _ _ _ of _ => _) = _` mp_tac >>
-    qpat_x_assum `!s. FST _ <> INR (Error (TypeError s))` (qspec_then `msg` mp_tac) >>
-    rw[bind_def, ignore_bind_def, type_check_def, check_def, assert_def,
-       raise_def, return_def,
-       lift_option_type_def, get_accounts_def, update_accounts_def] >>
-    gvs[]) >>
+    gvs[runtime_consistent_def, state_well_typed_def, env_consistent_def,
+        env_scopes_consistent_def, env_immutables_consistent_def] >>
+    rpt conj_tac >> FIRST_ASSUM ACCEPT_TAC) >>
   gvs[runtime_consistent_def] >>
-  qpat_x_assum `(case type_check _ _ _ of _ => _) = _` mp_tac >>
-  rw[bind_def, ignore_bind_def, type_check_def, check_def, assert_def,
-     raise_def, return_def, lift_option_type_def, get_accounts_def,
-     update_accounts_def,
-     no_type_error_result_def, expr_result_typed_def, expr_runtime_typed_def,
-     expr_type_def, toplevel_value_typed_def, value_has_type_def,
-     evaluate_type_def, is_HashMapRef_def] >>
-  qpat_x_assum `(case type_check _ _ _ of _ => _) = _` mp_tac >>
-  gvs[bind_def, ignore_bind_def, type_check_def, check_def, assert_def,
-      raise_def, return_def,
-      lift_option_type_def, get_accounts_def, update_accounts_def,
-      runtime_consistent_def, toplevel_value_typed_def, value_has_type_def] >>
-  TRY (Cases_on `transfer_value cx.txn.target
-          (vfmContext$address_for_create cx.txn.target
-             (lookup_account cx.txn.target st.accounts).nonce) amount st` >>
-       Cases_on `q` >> gvs[return_def]) >>
-  strip_tac >> gvs[toplevel_value_typed_def, value_has_type_def,
-                   expr_result_typed_def, expr_runtime_typed_def,
-                   expr_type_def, is_HashMapRef_def]
+  qpat_x_assum `eval_create _ _ _ _ _ _ _ = _` mp_tac >>
+  simp[eval_create_def, bind_def, ignore_bind_def, lift_option_type_def,
+       get_accounts_def, update_accounts_def, check_def, assert_def,
+       create_soft_failure_def, return_def, raise_def] >>
+  rpt (IF_CASES_TAC >>
+       gvs[bind_def, ignore_bind_def, update_accounts_def,
+           check_def, assert_def, create_soft_failure_def,
+           return_def, raise_def, expr_result_typed_def,
+           expr_runtime_typed_def, expr_type_def, evaluate_type_def,
+           toplevel_value_typed_def, value_has_type_def, is_HashMapRef_def]) >>
+  rpt strip_tac >> rpt BasicProvers.VAR_EQ_TAC >>
+  gvs[expr_result_typed_def, expr_runtime_typed_def, expr_type_def,
+      evaluate_type_def, toplevel_value_typed_def, value_has_type_def,
+      is_HashMapRef_def]
 QED
 
 Theorem raw_revert_tail_sound:

--- a/semantics/vyperCreateScript.sml
+++ b/semantics/vyperCreateScript.sml
@@ -495,5 +495,3 @@ Proof
   rpt (IF_CASES_TAC >>
        gvs[bind_def, update_accounts_def, return_def, raise_def, assert_def])
 QED
-
-val _ = export_theory();

--- a/semantics/vyperCreateScript.sml
+++ b/semantics/vyperCreateScript.sml
@@ -1,0 +1,499 @@
+(*
+ * High-level semantics for Vyper contract-creation builtins.
+ *
+ * TOP-LEVEL:
+ *   dest_create_args       — decode evaluated operands by kind/layout
+ *   create_arg_ctor_types  — recover constructor-argument types
+ *   minimal_proxy_initcode — EIP-1167 initcode (54 bytes)
+ *   create_address         — CREATE/CREATE2 address selection
+ *   eval_create            — shared interpreter/CPS creation semantics
+ *)
+
+Theory vyperCreate
+Ancestors
+  arithmetic byte combin integer list option pair rich_list words
+  contractABI vfmConstants vfmState vfmContext
+  vfmExecution[ignore_grammar] vyperAST vyperABI vyperMisc vyperValue
+  vyperContext vyperState
+Libs
+  cv_transLib wordsLib monadsyntax
+
+Datatype:
+  create_code_source
+  = AddressCodeSource address
+  | BytecodeCodeSource (byte list)
+End
+
+Datatype:
+  create_operands = <|
+    co_code_src: create_code_source
+  ; co_ctor_args: value list
+  ; co_value: num
+  ; co_code_offset: num option
+  ; co_salt: bytes32 option
+  |>
+End
+
+(* ===== Operand decoding ===== *)
+
+Definition dest_create_salt_def:
+  dest_create_salt v =
+    case dest_BytesV v of
+    | SOME bs => if LENGTH bs = 32 then SOME (word_of_bytes_be bs : bytes32)
+                 else NONE
+    | NONE => NONE
+End
+
+val () = cv_auto_trans dest_create_salt_def;
+
+Definition dest_optional_num_def:
+  dest_optional_num NONE = SOME NONE /\
+  dest_optional_num (SOME v) = OPTION_MAP SOME (dest_NumV v)
+End
+
+val () = cv_auto_trans dest_optional_num_def;
+
+Definition dest_optional_salt_def:
+  dest_optional_salt NONE = SOME NONE /\
+  dest_optional_salt (SOME v) = OPTION_MAP SOME (dest_create_salt v)
+End
+
+val () = cv_auto_trans dest_optional_salt_def;
+
+Definition make_create_operands_def:
+  make_create_operands address_src src_v value_v offset_v salt_v ctor_args =
+    case (if address_src then OPTION_MAP AddressCodeSource (dest_AddressV src_v)
+          else OPTION_MAP BytecodeCodeSource (dest_BytesV src_v)) of
+    | NONE => NONE
+    | SOME src =>
+        case dest_NumV value_v of
+        | NONE => NONE
+        | SOME amount =>
+            case dest_optional_num offset_v of
+            | NONE => NONE
+            | SOME offset =>
+                case dest_optional_salt salt_v of
+                | NONE => NONE
+                | SOME salt => SOME <|
+                    co_code_src := src;
+                    co_ctor_args := ctor_args;
+                    co_value := amount;
+                    co_code_offset := offset;
+                    co_salt := salt
+                  |>
+End
+
+val () = cv_auto_trans make_create_operands_def;
+
+Definition dest_create_args_def:
+  dest_create_args kind has_salt vs =
+    case kind of
+    | CreateMinimalProxy =>
+        if has_salt then
+          (case vs of [target; value; salt] =>
+             make_create_operands T target value NONE (SOME salt) []
+           | _ => NONE)
+        else
+          (case vs of [target; value] =>
+             make_create_operands T target value NONE NONE []
+           | _ => NONE)
+    | CreateCopyOf =>
+        if has_salt then
+          (case vs of [target; value; salt] =>
+             make_create_operands T target value NONE (SOME salt) []
+           | _ => NONE)
+        else
+          (case vs of [target; value] =>
+             make_create_operands T target value NONE NONE []
+           | _ => NONE)
+    | CreateFromBlueprint raw_args =>
+        if has_salt then
+          (case vs of target::value::salt::code_offset::ctor_args =>
+             make_create_operands T target value (SOME code_offset)
+               (SOME salt) ctor_args
+           | _ => NONE)
+        else
+          (case vs of target::value::code_offset::ctor_args =>
+             make_create_operands T target value (SOME code_offset) NONE ctor_args
+           | _ => NONE)
+    | RawCreate =>
+        (case vs of
+         | bytecode::value::rest =>
+             if has_salt then
+               if NULL rest then NONE
+               else make_create_operands F bytecode value NONE
+                 (SOME (LAST rest)) (FRONT rest)
+             else make_create_operands F bytecode value NONE NONE rest
+         | _ => NONE)
+End
+
+val dest_create_args_pre_def =
+  cv_auto_trans_pre "dest_create_args_pre" dest_create_args_def;
+
+Theorem dest_create_args_pre[cv_pre]:
+  !kind has_salt vs. dest_create_args_pre kind has_salt vs
+Proof
+  rw[dest_create_args_pre_def]
+QED
+
+(* Recover only the constructor-argument suffix/middle from the static types. *)
+Definition create_arg_ctor_types_def:
+  create_arg_ctor_types kind has_salt tys =
+    case kind of
+    | CreateMinimalProxy =>
+        if has_salt then
+          (case tys of [_; _; _] => SOME [] | _ => NONE)
+        else (case tys of [_; _] => SOME [] | _ => NONE)
+    | CreateCopyOf =>
+        if has_salt then
+          (case tys of [_; _; _] => SOME [] | _ => NONE)
+        else (case tys of [_; _] => SOME [] | _ => NONE)
+    | CreateFromBlueprint raw_args =>
+        if has_salt then
+          (case tys of _::_::_::_::ctor_tys => SOME ctor_tys | _ => NONE)
+        else (case tys of _::_::_::ctor_tys => SOME ctor_tys | _ => NONE)
+    | RawCreate =>
+        (case tys of
+         | _::_::rest =>
+             if has_salt then
+               if NULL rest then NONE else SOME (FRONT rest)
+             else SOME rest
+         | _ => NONE)
+End
+
+val create_arg_ctor_types_pre_def =
+  cv_auto_trans_pre "create_arg_ctor_types_pre" create_arg_ctor_types_def;
+
+Theorem create_arg_ctor_types_pre[cv_pre]:
+  !kind has_salt tys. create_arg_ctor_types_pre kind has_salt tys
+Proof
+  rw[create_arg_ctor_types_pre_def]
+QED
+
+(* ===== Initcode construction ===== *)
+
+Definition minimal_proxy_loader_def:
+  minimal_proxy_loader : byte list =
+    [0x60w; 0x2dw; 0x3dw; 0x81w; 0x60w; 0x09w; 0x3dw; 0x39w; 0xf3w]
+End
+
+Definition minimal_proxy_forwarder_pre_def:
+  minimal_proxy_forwarder_pre : byte list =
+    [0x36w; 0x3dw; 0x3dw; 0x37w; 0x3dw;
+     0x3dw; 0x3dw; 0x36w; 0x3dw; 0x73w]
+End
+
+Definition minimal_proxy_forwarder_post_def:
+  minimal_proxy_forwarder_post : byte list =
+    [0x5aw; 0xf4w; 0x3dw; 0x82w; 0x80w;
+     0x3ew; 0x90w; 0x3dw; 0x91w; 0x60w;
+     0x2bw; 0x57w; 0xfdw; 0x5bw; 0xf3w]
+End
+
+Definition minimal_proxy_runtime_def:
+  minimal_proxy_runtime (target : address) =
+    minimal_proxy_forwarder_pre ++ word_to_bytes target T ++
+    minimal_proxy_forwarder_post
+End
+
+Definition minimal_proxy_initcode_def:
+  minimal_proxy_initcode (target : address) =
+    minimal_proxy_loader ++ minimal_proxy_runtime target
+End
+
+Definition create_copy_initcode_def:
+  create_copy_initcode code =
+    [0x62w] ++
+    DROP 29 (word_to_bytes_be ((n2w (LENGTH code)) : bytes32)) ++
+    [0x3dw; 0x81w; 0x60w; 0x0bw; 0x3dw; 0x39w; 0xf3w] ++ code
+End
+
+Definition blueprint_initcode_def:
+  blueprint_initcode code_offset code args_enc =
+    DROP code_offset code ++ args_enc
+End
+
+Definition raw_create_initcode_def:
+  raw_create_initcode bytecode args_enc = bytecode ++ args_enc
+End
+
+Definition blueprint_code_ok_def:
+  blueprint_code_ok code_offset code =
+    (0i < w2i ((n2w (LENGTH code) - n2w code_offset) : bytes32))
+End
+
+Definition encode_create_ctor_args_def:
+  encode_create_ctor_args tenv tys vs =
+    case vyper_to_abi_list tenv tys vs of
+    | NONE => NONE
+    | SOME avs =>
+        SOME (contractABI$enc
+          (contractABI$Tuple (vyper_to_abi_types tenv tys))
+          (contractABI$ListV avs))
+End
+
+Definition create_address_def:
+  create_address self nonce salt_opt initcode =
+    case salt_opt of
+    | NONE => vfmContext$address_for_create self nonce
+    | SOME salt => vfmExecution$address_for_create2 self salt initcode
+End
+
+val () = cv_auto_trans minimal_proxy_loader_def;
+val () = cv_auto_trans minimal_proxy_forwarder_pre_def;
+val () = cv_auto_trans minimal_proxy_forwarder_post_def;
+val () = cv_auto_trans minimal_proxy_runtime_def;
+val () = cv_auto_trans minimal_proxy_initcode_def;
+val () = cv_auto_trans create_copy_initcode_def;
+val () = cv_auto_trans blueprint_initcode_def;
+val () = cv_auto_trans raw_create_initcode_def;
+val () = cv_auto_trans blueprint_code_ok_def;
+val () = cv_auto_trans encode_create_ctor_args_def;
+val () = cv_auto_trans create_address_def;
+
+Theorem LENGTH_minimal_proxy_runtime[simp]:
+  LENGTH (minimal_proxy_runtime target) = 45
+Proof
+  simp[minimal_proxy_runtime_def, minimal_proxy_forwarder_pre_def,
+       minimal_proxy_forwarder_post_def]
+QED
+
+Theorem LENGTH_minimal_proxy_initcode[simp]:
+  LENGTH (minimal_proxy_initcode target) = 54
+Proof
+  simp[minimal_proxy_initcode_def, minimal_proxy_loader_def]
+QED
+
+(* ===== Kind-specific code and account effects ===== *)
+
+Datatype:
+  create_code = <|
+    cc_initcode: byte list
+  ; cc_runtime_code: byte list option
+  ; cc_source_ok: bool
+  |>
+End
+
+Definition build_create_code_def:
+  build_create_code tenv CreateMinimalProxy ops accounts ctor_tys =
+    (case ops.co_code_src of
+     | AddressCodeSource target => SOME <|
+         cc_initcode := minimal_proxy_initcode target;
+         cc_runtime_code := SOME (minimal_proxy_runtime target);
+         cc_source_ok := T
+       |>
+     | _ => NONE) /\
+  build_create_code tenv CreateCopyOf ops accounts ctor_tys =
+    (case ops.co_code_src of
+     | AddressCodeSource target =>
+         let code = (lookup_account target accounts).code in
+           SOME <| cc_initcode := create_copy_initcode code;
+                   cc_runtime_code := SOME code;
+                   cc_source_ok := (code <> []) |>
+     | _ => NONE) /\
+  build_create_code tenv (CreateFromBlueprint raw_args) ops accounts ctor_tys =
+    (case (ops.co_code_src, ops.co_code_offset) of
+     | (AddressCodeSource target, SOME code_offset) =>
+         let code = (lookup_account target accounts).code in
+         let args_enc_opt =
+           if raw_args then
+             case ops.co_ctor_args of [BytesV bs] => SOME bs | _ => NONE
+           else encode_create_ctor_args tenv ctor_tys ops.co_ctor_args
+         in
+           (case args_enc_opt of
+            | NONE => NONE
+            | SOME args_enc => SOME <|
+                cc_initcode := blueprint_initcode code_offset code args_enc;
+                cc_runtime_code := NONE;
+                cc_source_ok := blueprint_code_ok code_offset code
+              |>)
+     | _ => NONE) /\
+  build_create_code tenv RawCreate ops accounts ctor_tys =
+    (case ops.co_code_src of
+     | BytecodeCodeSource bytecode =>
+         (case encode_create_ctor_args tenv ctor_tys ops.co_ctor_args of
+          | NONE => NONE
+          | SOME args_enc => SOME <|
+              cc_initcode := raw_create_initcode bytecode args_enc;
+              cc_runtime_code := NONE;
+              cc_source_ok := T
+            |>)
+     | _ => NONE)
+End
+
+val () = cv_auto_trans build_create_code_def;
+
+Definition install_created_code_def:
+  install_created_code address NONE accounts = accounts /\
+  install_created_code address (SOME code) accounts =
+    update_account address ((lookup_account address accounts) with code := code)
+      accounts
+End
+
+val () = cv_auto_trans install_created_code_def;
+
+Definition proceed_create_accounts_def:
+  proceed_create_accounts sender address amount runtime_code accounts =
+    let accounts1 = vfmExecution$increment_nonce sender accounts in
+    let accounts2 =
+      (vfmExecution$transfer_value sender address amount o
+       vfmExecution$increment_nonce address) accounts1 in
+      install_created_code address runtime_code accounts2
+End
+
+val () = cv_auto_trans proceed_create_accounts_def;
+
+Theorem install_created_code_storage[simp]:
+  (lookup_account a (install_created_code address runtime_code accounts)).storage =
+  (lookup_account a accounts).storage
+Proof
+  Cases_on `runtime_code` >>
+  simp[install_created_code_def, vfmStateTheory.lookup_account_def,
+       vfmStateTheory.update_account_def, combinTheory.APPLY_UPDATE_THM] >>
+  IF_CASES_TAC >> gvs[]
+QED
+
+Theorem increment_nonce_storage[simp]:
+  (lookup_account a (vfmExecution$increment_nonce address accounts)).storage =
+  (lookup_account a accounts).storage
+Proof
+  simp[vfmExecutionTheory.increment_nonce_def,
+       vfmStateTheory.lookup_account_def, vfmStateTheory.update_account_def,
+       combinTheory.APPLY_UPDATE_THM] >>
+  Cases_on `a = address` >> gvs[combinTheory.APPLY_UPDATE_THM]
+QED
+
+Theorem proceed_create_accounts_storage[simp]:
+  (lookup_account a
+    (proceed_create_accounts sender address amount runtime_code accounts)).storage =
+  (lookup_account a accounts).storage
+Proof
+  Cases_on `runtime_code` >>
+  simp[proceed_create_accounts_def, install_created_code_def,
+       vfmExecutionTheory.transfer_value_def,
+       vfmExecutionTheory.increment_nonce_def,
+       vfmStateTheory.lookup_account_def, vfmStateTheory.update_account_def,
+       combinTheory.APPLY_UPDATE_THM] >>
+  Cases_on `amount = 0` >> Cases_on `sender = address` >>
+  Cases_on `a = address` >> Cases_on `a = sender` >>
+  gvs[combinTheory.APPLY_UPDATE_THM]
+QED
+
+Definition create_soft_failure_def:
+  create_soft_failure rof msg =
+    if rof then raise (Error (RuntimeError msg))
+    else return (Value (AddressV 0w))
+End
+
+val () = create_soft_failure_def
+  |> SRULE [FUN_EQ_THM, return_def, raise_def, COND_RATOR]
+  |> cv_auto_trans;
+
+(* Shared by the recursive interpreter and the CPS machine.  All operands have
+   already been evaluated before this helper is entered. *)
+Definition eval_create_def:
+  eval_create cx kind has_salt rof arg_tys vs = do
+    ops <- lift_option_type (dest_create_args kind has_salt vs)
+      "create operand shape";
+    ctor_tys <- lift_option_type (create_arg_ctor_types kind has_salt arg_tys)
+      "create argument type shape";
+    accounts <- get_accounts;
+    code_info <- lift_option_type
+      (build_create_code (get_tenv cx) kind ops accounts ctor_tys)
+      "create operands";
+    (* copy-of/blueprint ASSERTs are emitted before CREATE and always revert. *)
+    check code_info.cc_source_ok "create source has no deployable code";
+    self_acct <<- lookup_account cx.txn.target accounts;
+    new_addr <<- create_address cx.txn.target self_acct.nonce ops.co_salt
+      code_info.cc_initcode;
+    check (LENGTH code_info.cc_initcode <= 2 * max_code_size)
+      "create initcode too large";
+    if self_acct.balance < ops.co_value \/
+       SUC self_acct.nonce >= 2 ** 64
+    then create_soft_failure rof "create insufficient balance or nonce limit"
+    else do
+      existing <<- lookup_account new_addr accounts;
+      if vfmExecution$account_already_created existing then do
+        update_accounts (vfmExecution$increment_nonce cx.txn.target);
+        create_soft_failure rof "create address collision"
+      od else do
+        check (existing.balance + ops.co_value < 2 ** 256)
+          "create recipient balance overflow";
+        update_accounts (proceed_create_accounts cx.txn.target new_addr
+          ops.co_value code_info.cc_runtime_code);
+        return (Value (AddressV new_addr))
+      od
+    od
+  od
+End
+
+val () = eval_create_def
+  |> SRULE [FUN_EQ_THM, bind_def, ignore_bind_def, lift_option_type_def,
+            option_CASE_rator, LET_RATOR, COND_RATOR, check_def, assert_def]
+  |> cv_auto_trans;
+
+Theorem eval_create_preserves_non_accounts:
+  eval_create cx kind has_salt rof arg_tys vs st = (res, st') ==>
+  st'.scopes = st.scopes /\ st'.immutables = st.immutables /\
+  st'.logs = st.logs /\ st'.tStorage = st.tStorage
+Proof
+  strip_tac >>
+  Cases_on `dest_create_args kind has_salt vs`
+  >- gvs[eval_create_def, bind_def, lift_option_type_def, return_def, raise_def] >>
+  rename1 `dest_create_args kind has_salt vs = SOME ops` >>
+  Cases_on `create_arg_ctor_types kind has_salt arg_tys`
+  >- gvs[eval_create_def, bind_def, lift_option_type_def, return_def, raise_def] >>
+  rename1 `create_arg_ctor_types kind has_salt arg_tys = SOME ctor_tys` >>
+  Cases_on `build_create_code (get_tenv cx) kind ops st.accounts ctor_tys` >>
+  gvs[eval_create_def, bind_def, ignore_bind_def, lift_option_type_def,
+      get_accounts_def, update_accounts_def, check_def, assert_def,
+      create_soft_failure_def, return_def, raise_def, AllCaseEqs()] >>
+  qpat_x_assum `(if _ then _ else _) _ = _` mp_tac >>
+  rpt (IF_CASES_TAC >>
+       gvs[bind_def, update_accounts_def, return_def, raise_def, assert_def]) >>
+  rpt strip_tac >> gvs[]
+QED
+
+Theorem eval_create_preserves_storage:
+  eval_create cx kind has_salt rof arg_tys vs st = (res, st') ==>
+  (lookup_account address st'.accounts).storage =
+  (lookup_account address st.accounts).storage
+Proof
+  strip_tac >>
+  Cases_on `dest_create_args kind has_salt vs`
+  >- gvs[eval_create_def, bind_def, lift_option_type_def, return_def, raise_def] >>
+  rename1 `dest_create_args kind has_salt vs = SOME ops` >>
+  Cases_on `create_arg_ctor_types kind has_salt arg_tys`
+  >- gvs[eval_create_def, bind_def, lift_option_type_def, return_def, raise_def] >>
+  rename1 `create_arg_ctor_types kind has_salt arg_tys = SOME ctor_tys` >>
+  Cases_on `build_create_code (get_tenv cx) kind ops st.accounts ctor_tys` >>
+  gvs[eval_create_def, bind_def, ignore_bind_def, lift_option_type_def,
+      get_accounts_def, update_accounts_def, check_def, assert_def,
+      create_soft_failure_def, return_def, raise_def, AllCaseEqs()] >>
+  qpat_x_assum `(if _ then _ else _) _ = _` mp_tac >>
+  rpt (IF_CASES_TAC >>
+       gvs[bind_def, update_accounts_def, return_def, raise_def, assert_def]) >>
+  rpt strip_tac >> gvs[]
+QED
+
+Theorem eval_create_exception_is_error:
+  eval_create cx kind has_salt rof arg_tys vs st = (INR ex, st') ==>
+  ?err. ex = Error err
+Proof
+  strip_tac >>
+  Cases_on `dest_create_args kind has_salt vs`
+  >- gvs[eval_create_def, bind_def, lift_option_type_def, return_def, raise_def] >>
+  rename1 `dest_create_args kind has_salt vs = SOME ops` >>
+  Cases_on `create_arg_ctor_types kind has_salt arg_tys`
+  >- gvs[eval_create_def, bind_def, lift_option_type_def, return_def, raise_def] >>
+  rename1 `create_arg_ctor_types kind has_salt arg_tys = SOME ctor_tys` >>
+  Cases_on `build_create_code (get_tenv cx) kind ops st.accounts ctor_tys` >>
+  gvs[eval_create_def, bind_def, ignore_bind_def, lift_option_type_def,
+      get_accounts_def, update_accounts_def, check_def, assert_def,
+      create_soft_failure_def, return_def, raise_def, AllCaseEqs()] >>
+  qpat_x_assum `(if _ then _ else _) _ = _` mp_tac >>
+  rpt (IF_CASES_TAC >>
+       gvs[bind_def, update_accounts_def, return_def, raise_def, assert_def])
+QED
+
+val _ = export_theory();

--- a/semantics/vyperInterpreterScript.sml
+++ b/semantics/vyperInterpreterScript.sml
@@ -4,6 +4,7 @@ Ancestors
   rich_list cv cv_std vfmState vfmContext vfmCompute[ignore_grammar]
   vfmExecution[ignore_grammar] vyperAST vyperABI
   vyperMisc vyperValue vyperValueOperation vyperStorage vyperContext vyperState
+  vyperCreate
 Libs
   cv_transLib wordsLib monadsyntax
 
@@ -1354,40 +1355,12 @@ Definition evaluate_def:
        unless in same transaction as creation. We model the simple case. *)
     return $ Value NoneV
   od ∧
-  (* create_*(target, *ctor_args, value=0, ...)
-     At the semantic level, we model CREATE as an oracle: given initcode + value,
-     it returns a new address. We use Verifereum's run_create infrastructure.
-     args = [target_or_bytecode; ctor_arg1; ...; ctor_argN; value]
-     For simplicity, we model all create variants identically:
-     the initcode construction differences are codegen-level concerns. *)
-  eval_expr cx (Call ty (CreateTarget kind rof) es _) = do
+  (* Creation operands use the kind-specific runtime layouts documented on
+     CreateTarget.  eval_exprs preserves their evaluation order and the shared
+     helper performs decoding, initcode/address derivation and account effects. *)
+  eval_expr cx (Call ty (CreateTarget kind has_salt rof) es _) = do
     vs <- eval_exprs cx es;
-    type_check (vs ≠ []) "create no args";
-    (* Last arg is value *)
-    amount <- lift_option_type (dest_NumV (LAST vs)) "create value";
-    (* For now, model create as an opaque operation that transfers value
-       and returns a fresh address. The actual initcode construction
-       (minimal proxy bytecode, extcodecopy, blueprint extraction)
-       happens at the codegen/Venom level. *)
-    target_addr <- lift_option_type (dest_AddressV (HD vs)) "create target";
-    accounts <- get_accounts;
-    self_acct <<- lookup_account cx.txn.target accounts;
-    check (amount ≤ self_acct.balance) "create insufficient balance";
-    (* Use Verifereum's address_for_create with sender's nonce *)
-    new_addr <<- vfmContext$address_for_create cx.txn.target self_acct.nonce;
-    (* Check for address collision (EIP-684) *)
-    existing <<- lookup_account new_addr accounts;
-    check (¬vfmExecution$account_already_created existing) "address collision";
-    (* Transfer value from self to new contract *)
-    if amount > 0 then
-      transfer_value cx.txn.target new_addr amount
-    else return ();
-    (* Increment sender nonce *)
-    update_accounts (vfmExecution$increment_nonce cx.txn.target);
-    if rof then
-      return $ Value $ AddressV new_addr
-    else
-      return $ Value $ AddressV new_addr
+    eval_create cx kind has_salt rof (MAP expr_type es) vs
   od ∧
   eval_exprs cx [] = return [] ∧
   eval_exprs cx (e::es) = do

--- a/semantics/vyperSmallStepScript.sml
+++ b/semantics/vyperSmallStepScript.sml
@@ -1,7 +1,7 @@
 Theory vyperSmallStep
 Ancestors
   arithmetic combin pair list While
-  vyperMisc vyperValue vyperContext vyperState vyperInterpreter vyperABI
+  vyperMisc vyperValue vyperContext vyperState vyperCreate vyperInterpreter vyperABI
 Libs
   cv_transLib
 
@@ -64,7 +64,7 @@ Datatype:
   | RawLogK eval_continuation
   | RawRevertK eval_continuation
   | SelfDestructK eval_continuation
-  | CreateK type create_kind bool eval_continuation
+  | CreateK (type list) create_kind bool bool eval_continuation
   | IntCallK (num |-> type_args) (num option # identifier) ((identifier # type) list) (expr list) type (stmt list) bool function_mutability eval_continuation
   | IntCallK1 (num |-> type_args) (num option # identifier) ((identifier # type) list) (value list) (scope list) type (stmt list) bool function_mutability eval_continuation
   | IntCallK2 (scope list) type_value bool bool eval_continuation
@@ -182,8 +182,8 @@ Definition eval_expr_cps_def:
     eval_exprs_cps cx10 es st (RawRevertK k) ∧
   eval_expr_cps cx10 (Call _ SelfDestructTarget es _) st k =
     eval_exprs_cps cx10 es st (SelfDestructK k) ∧
-  eval_expr_cps cx10 (Call ty (CreateTarget kind rof) es _) st k =
-    eval_exprs_cps cx10 es st (CreateK ty kind rof k) ∧
+  eval_expr_cps cx10 (Call ty (CreateTarget kind has_salt rof) es _) st k =
+    eval_exprs_cps cx10 es st (CreateK (MAP expr_type es) kind has_salt rof k) ∧
   eval_expr_cps cx10 (Call _ (IntCall (ns, fn)) es _) st k =
     (case do
       type_check (no_recursion (ns, fn) cx10.stk) "recursion";
@@ -398,7 +398,7 @@ Definition apply_exc_def:
   apply_exc cx ex st (RawLogK k) = AK cx (ApplyExc ex) st k ∧
   apply_exc cx ex st (RawRevertK k) = AK cx (ApplyExc ex) st k ∧
   apply_exc cx ex st (SelfDestructK k) = AK cx (ApplyExc ex) st k ∧
-  apply_exc cx ex st (CreateK _ _ _ k) = AK cx (ApplyExc ex) st k ∧
+  apply_exc cx ex st (CreateK _ _ _ _ k) = AK cx (ApplyExc ex) st k ∧
   apply_exc cx ex st (IntCallK _ _ _ _ _ _ _ _ k) = AK cx (ApplyExc ex) st k ∧
   apply_exc cx ex st (IntCallK1 _ _ _ _ prev _ _ _ _ k) =
     liftk (cx with stk updated_by TL) (K (ApplyExc ex)) (set_scopes prev st) k ∧
@@ -742,24 +742,9 @@ Definition apply_vals_def:
     od st
     of (INR ex, st) => AK cx (ApplyExc ex) st k
      | (INL tv, st) => AK cx (ApplyTv tv) st k) ∧
-  apply_vals cx vs st (CreateK ty kind rof k) =
-    (case do
-      type_check (vs ≠ []) "create no args";
-      amount <- lift_option_type (dest_NumV (LAST vs)) "create value";
-      target_addr <- lift_option_type (dest_AddressV (HD vs)) "create target";
-      accounts <- get_accounts;
-      self_acct <<- lookup_account cx.txn.target accounts;
-      check (amount ≤ self_acct.balance) "create insufficient balance";
-      new_addr <<- vfmContext$address_for_create cx.txn.target self_acct.nonce;
-      existing <<- lookup_account new_addr accounts;
-      check (¬vfmExecution$account_already_created existing) "address collision";
-      if amount > 0 then
-        transfer_value cx.txn.target new_addr amount
-      else return ();
-      update_accounts (vfmExecution$increment_nonce cx.txn.target);
-      return $ Value $ AddressV new_addr
-    od st
-    of (INR ex, st) => AK cx (ApplyExc ex) st k
+  apply_vals cx vs st (CreateK arg_tys kind has_salt rof k) =
+    (case eval_create cx kind has_salt rof arg_tys vs st of
+       (INR ex, st) => AK cx (ApplyExc ex) st k
      | (INL tv, st) => AK cx (ApplyTv tv) st k) ∧
   apply_vals cx vs st DoneK = AK cx (ApplyVals vs) st DoneK ∧
   apply_vals cx vs st _ =

--- a/semantics/vyperTypeSystemScript.sml
+++ b/semantics/vyperTypeSystemScript.sml
@@ -483,6 +483,26 @@ End
 
 (* ===== Expressions, places, and targets ===== *)
 
+(* Positional type contract for creation builtin operands. *)
+Definition create_arg_types_ok_def:
+  create_arg_types_ok CreateMinimalProxy has_salt tys =
+    (tys = [BaseT AddressT; BaseT (UintT 256)] ++
+       if has_salt then [BaseT (BytesT (Fixed 32))] else []) /\
+  create_arg_types_ok CreateCopyOf has_salt tys =
+    (tys = [BaseT AddressT; BaseT (UintT 256)] ++
+       if has_salt then [BaseT (BytesT (Fixed 32))] else []) /\
+  create_arg_types_ok (CreateFromBlueprint raw_args) has_salt tys =
+    (?ctor_tys.
+       tys = [BaseT AddressT; BaseT (UintT 256)] ++
+         (if has_salt then [BaseT (BytesT (Fixed 32))] else []) ++
+         [BaseT (UintT 256)] ++ ctor_tys /\
+       (raw_args ==> ?bd. ctor_tys = [BaseT (BytesT bd)])) /\
+  create_arg_types_ok RawCreate has_salt tys =
+    (?bd ctor_tys.
+       tys = [BaseT (BytesT bd); BaseT (UintT 256)] ++ ctor_tys ++
+         if has_salt then [BaseT (BytesT (Fixed 32))] else [])
+End
+
 Definition well_typed_expr_def:
   well_typed_expr env (Name ty id) =
     (FLOOKUP env.var_types (string_to_num id) = SOME ty) /\
@@ -554,9 +574,9 @@ Definition well_typed_expr_def:
   well_typed_expr env (Call ty SelfDestructTarget args drv) =
     (well_typed_exprs env args /\ drv = NONE /\ ty = NoneT /\ LENGTH args = 1 /\
      HD (MAP expr_type args) = BaseT AddressT) /\
-  well_typed_expr env (Call ty (CreateTarget kind rof) args drv) =
-    (well_typed_exprs env args /\ drv = NONE /\ ty = BaseT AddressT /\ LENGTH args >= 2 /\
-     HD (MAP expr_type args) = BaseT AddressT /\ LAST (MAP expr_type args) = BaseT (UintT 256)) /\
+  well_typed_expr env (Call ty (CreateTarget kind has_salt rof) args drv) =
+    (well_typed_exprs env args /\ drv = NONE /\ ty = BaseT AddressT /\
+     create_arg_types_ok kind has_salt (MAP expr_type args)) /\
 
   type_place_expr env (TopLevelName ty (src_id_opt, id)) =
     (case FLOOKUP env.toplevel_vtypes (src_id_opt, string_to_num id) of

--- a/syntax/vyperASTScript.sml
+++ b/syntax/vyperASTScript.sml
@@ -185,7 +185,7 @@ Datatype:
   create_kind
   = CreateMinimalProxy  (* create_minimal_proxy_to(target) *)
   | CreateCopyOf        (* create_copy_of(target) *)
-  | CreateFromBlueprint num bool (* code_offset, raw_args *)
+  | CreateFromBlueprint bool (* raw_args; code_offset is an evaluated operand *)
                         (* create_from_blueprint(target, *args) *)
   | RawCreate           (* raw_create(bytecode, *args) *)
 End
@@ -213,10 +213,12 @@ Datatype:
   (* selfdestruct(to) — terminus
      args = [to_addr] *)
   | SelfDestructTarget
-  (* create_*(target, *ctor_args, value=0, salt=NONE, revert_on_failure=T)
-     args = [target_or_bytecode; ctor_arg1; ...; value]
-     salt: NONE = CREATE, SOME s = CREATE2 with salt s *)
-  | CreateTarget create_kind bool (* revert_on_failure *)
+  (* Creation operands are stored in their runtime evaluation order:
+     - minimal proxy/copy: [target; value] ++ [salt]?
+     - blueprint: [target; value] ++ [salt]? ++ [code_offset] ++ ctor_args
+     - raw_create: [bytecode; value] ++ ctor_args ++ [salt]?
+     The first bool records salt presence; the second is revert_on_failure. *)
+  | CreateTarget create_kind bool (* has_salt *) bool (* revert_on_failure *)
 End
 
 Datatype:

--- a/syntax/vyperASTSyntax.sig
+++ b/syntax/vyperASTSyntax.sig
@@ -344,8 +344,8 @@ signature vyperASTSyntax = sig
   val SelfDestructTarget_tm : term
   val is_SelfDestructTarget : term -> bool
   val CreateTarget_tm : term
-  val mk_CreateTarget_tm : term * term -> term
-  val dest_CreateTarget_tm : term -> term * term
+  val mk_CreateTarget_tm : term * term * term -> term
+  val dest_CreateTarget_tm : term -> term * term * term
   val is_CreateTarget : term -> bool
 
   val AssertBare_tm : term
@@ -499,8 +499,8 @@ signature vyperASTSyntax = sig
   val CreateMinimalProxy_tm : term val is_CreateMinimalProxy : term -> bool
   val CreateCopyOf_tm : term val is_CreateCopyOf : term -> bool
   val CreateFromBlueprint_tm : term
-  val mk_CreateFromBlueprint_tm : term * term -> term
-  val dest_CreateFromBlueprint_tm : term -> term * term
+  val mk_CreateFromBlueprint_tm : term -> term
+  val dest_CreateFromBlueprint_tm : term -> term
   val is_CreateFromBlueprint : term -> bool
   val RawCreate_tm : term val is_RawCreate : term -> bool
 
@@ -627,7 +627,7 @@ signature vyperASTSyntax = sig
     | VRawLog
     | VRawRevert
     | VSelfDestructTarget
-    | VCreateTarget of term * term
+    | VCreateTarget of term * term * term
   val view_call_target : term -> call_target_view
 
   datatype toplevel_view =

--- a/syntax/vyperASTSyntax.sml
+++ b/syntax/vyperASTSyntax.sml
@@ -240,7 +240,7 @@ val (PowMod256_tm, is_PowMod256) = syntax0 "PowMod256"
 
 val (CreateMinimalProxy_tm, is_CreateMinimalProxy) = syntax0 "CreateMinimalProxy"
 val (CreateCopyOf_tm, is_CreateCopyOf) = syntax0 "CreateCopyOf"
-val (CreateFromBlueprint_tm, mk_CreateFromBlueprint_tm, dest_CreateFromBlueprint_tm, is_CreateFromBlueprint) = syntax_fns2 "vyperAST" "CreateFromBlueprint"
+val (CreateFromBlueprint_tm, mk_CreateFromBlueprint_tm, dest_CreateFromBlueprint_tm, is_CreateFromBlueprint) = syntax_fns1 "vyperAST" "CreateFromBlueprint"
 val (RawCreate_tm, is_RawCreate) = syntax0 "RawCreate"
 
 val (Empty_tm, is_Empty) = syntax0 "Empty"
@@ -412,7 +412,7 @@ val (RawLog_tm, is_RawLog) = syntax0 "RawLog"
 val (RawRevert_tm, is_RawRevert) = syntax0 "RawRevert"
 val (SelfDestructTarget_tm, is_SelfDestructTarget) = syntax0 "SelfDestructTarget"
 val (CreateTarget_tm, mk_CreateTarget_tm, dest_CreateTarget_tm, is_CreateTarget) =
-  syntax_fns2 "vyperAST" "CreateTarget"
+  syntax_fns3 "vyperAST" "CreateTarget"
 
 val (AssertBare_tm, is_AssertBare) = syntax0 "AssertBare"
 val (AssertUnreachable_tm, is_AssertUnreachable) = syntax0 "AssertUnreachable"
@@ -603,7 +603,7 @@ datatype call_target_view =
   | VRawLog
   | VRawRevert
   | VSelfDestructTarget
-  | VCreateTarget of term * term
+  | VCreateTarget of term * term * term
 
 fun view_call_target tm =
   if is_IntCall tm then VIntCall (dest_IntCall_tm tm)

--- a/syntax/vyperASTSyntaxTestScript.sml
+++ b/syntax/vyperASTSyntaxTestScript.sml
@@ -181,11 +181,24 @@ val call_target_samples =
   , vyperASTSyntax.RawRevert_tm
   , vyperASTSyntax.SelfDestructTarget_tm
   , vyperASTSyntax.mk_CreateTarget_tm
-      (vyperASTSyntax.CreateMinimalProxy_tm, boolSyntax.T)
+      (vyperASTSyntax.CreateMinimalProxy_tm, boolSyntax.F, boolSyntax.T)
   ];
 val _ = List.app
   (fn tm => ignore (vyperASTSyntax.view_call_target tm))
   call_target_samples;
+val _ =
+  case vyperASTSyntax.view_call_target (List.last call_target_samples) of
+    vyperASTSyntax.VCreateTarget (kind, has_salt, rof) =>
+      if same_term kind vyperASTSyntax.CreateMinimalProxy_tm andalso
+         same_term has_salt boolSyntax.F andalso same_term rof boolSyntax.T
+      then () else raise Fail "CreateTarget field order"
+  | _ => raise Fail "CreateTarget view";
+val _ =
+  if same_term
+       (vyperASTSyntax.dest_CreateFromBlueprint_tm
+          (vyperASTSyntax.mk_CreateFromBlueprint_tm boolSyntax.T))
+       boolSyntax.T
+  then () else raise Fail "CreateFromBlueprint raw_args";
 val _ =
   if vyperASTSyntax.is_raw_call_flags flags then
     let val decoded = vyperASTSyntax.dest_raw_call_flags flags in

--- a/tests/vyperTestLib.sml
+++ b/tests/vyperTestLib.sml
@@ -316,27 +316,32 @@ val excluded_test_names = [
   "test_checkable_raw_call",
   "test_nonreentrant_decorator_for_default",
 
-  (* raw_create semantics: first arg is bytecode, not address.
-     The CreateTarget handler assumes HD args is an address for all
-     create kinds, but raw_create passes bytecode as first arg.
-     TODO: fix CreateTarget to handle RawCreate differently *)
-  "test_raw_create*",
+  (* RawCreate now preserves bytecode, constructor args, value, and salt.
+     Its eval-order and CREATE2 salt tests are enabled. Running initcode and
+     installing the resulting runtime code remains out of scope (#379), so
+     tests that inspect or call the deployed contract remain excluded. *)
+  "test_raw_create",
+  "test_raw_create_change_*",
+  "test_raw_create_dynamic_arg",
+  "test_raw_create_double_eval",
+  "test_raw_create_memory_overlap",
+  "test_raw_create_revert_value_kws*",
   "test_bubble_revert_data_raw_create",
 
   (* create_from_blueprint / create_copy_of / create_minimal_proxy_to tests:
-     opaque create model doesn't run initcode or load sources for created
-     contracts, so calls to created contracts fail.
-     TODO: run initcode for create builtins *)
+     opaque create model doesn't run blueprint/raw initcode or register newly
+     created contracts as callable, so calls to created contracts fail.
+     TODO(#379): run initcode and register created contracts. *)
   "test_create_from_blueprint*",
   "test_blueprint_evals_once_side_effects",
   "test_bubble_revert_data_blueprint",
-  (* create_copy_of / create_minimal_proxy_to tests: opaque create
-     model computes addresses via address_for_create but doesn't run
-     actual initcode, so created addresses and contract state don't
-     match the real EVM. TODO: run initcode for create builtins *)
+  (* Proxy/copy semantics install statically derivable runtime code, and the
+     salted proxy CREATE2 address tests are enabled. Registration as a
+     callable Vyper contract and constructor effects remain out of scope
+     (#379), so tests that call or inspect created contract state stay out. *)
   "test_create_copy_of*",
-  "test_create_copy_salt_eval_order_regression",
-  "test_create_minimal_proxy_to*",
+  "test_create_minimal_proxy_to_call",
+  "test_create_minimal_proxy_to_create",
   "test_minimal_proxy_exception",
   (* Tests using shift() builtin which is not yet translated.
      TODO: add shift builtin support *)


### PR DESCRIPTION
## Summary

- Add shared semantics for `create_minimal_proxy_to`, `create_copy_of`, `create_from_blueprint`, and `raw_create`.
- Construct kind-specific initcode, including EIP-1167 minimal proxies and ABI-encoded constructor arguments.
- Support CREATE and CREATE2 address derivation, salt handling, value transfer, nonce updates, collision checks, code-size limits, and failure behavior.
- Reuse the creation semantics in both recursive and CPS interpreters.
- Strengthen creation operand typing and update preservation/type-soundness proofs.
- Re-enable supported creation tests, including CREATE2 address and evaluation-order coverage.
- Closes #435 

## Limitations

Blueprint and raw initcode execution, constructor effects, and registration of created contracts as callable Vyper contracts remain out of scope.
