### PR TITLE
frontend: preserve nominal identity in external call signatures

### DIFF
--- a/frontend/jsonASTLib.sml
+++ b/frontend/jsonASTLib.sml
@@ -183,13 +183,13 @@ fun mk_JE_List (es, ty) = list_mk_comb(JE_List_tm, [mk_list(es, json_expr_ty), t
 fun mk_JE_Call (func, args, kwargs, ty, src_id_opt_tm) =
   list_mk_comb(JE_Call_tm, [func, mk_list(args, json_expr_ty),
                             mk_list(kwargs, json_keyword_ty), ty, src_id_opt_tm])
-fun mk_JE_ExtCall (func_name, arg_types, ret_ty, target, args, keywords) =
-  list_mk_comb(JE_ExtCall_tm, [fromMLstring func_name,
+fun mk_JE_ExtCall (func_name, func_src, arg_types, ret_ty, target, args, keywords) =
+  list_mk_comb(JE_ExtCall_tm, [fromMLstring func_name, func_src,
                                mk_list(arg_types, json_type_ty),
                                ret_ty, target, mk_list(args, json_expr_ty),
                                mk_list(keywords, json_keyword_ty)])
-fun mk_JE_StaticCall (func_name, arg_types, ret_ty, target, args) =
-  list_mk_comb(JE_StaticCall_tm, [fromMLstring func_name,
+fun mk_JE_StaticCall (func_name, func_src, arg_types, ret_ty, target, args) =
+  list_mk_comb(JE_StaticCall_tm, [fromMLstring func_name, func_src,
                                   mk_list(arg_types, json_type_ty),
                                   ret_ty, target, mk_list(args, json_expr_ty)])
 fun mk_JKeyword (arg, v) = list_mk_comb(JKeyword_tm, [fromMLstring arg, v])
@@ -742,9 +742,12 @@ fun d_json_expr () : term decoder = achoose "expr" [
   (* ExtCall - preserve target separately from ordinary arguments. *)
   (* Signature extracted from func.type: argument_types, return_type *)
   check_ast_type "ExtCall" $
-    JSONDecode.map (fn (((func_name, arg_types), (ret_ty, (target, args))), keywords) =>
-      mk_JE_ExtCall(func_name, arg_types, ret_ty, target, args, keywords)) $
-    tuple2 (tuple2 (tuple2 (field "value" $ field "func" $ field "attr" string,
+    JSONDecode.map (fn ((((func_name, func_src), arg_types), (ret_ty, (target, args))), keywords) =>
+      mk_JE_ExtCall(func_name, func_src, arg_types, ret_ty, target, args, keywords)) $
+    tuple2 (tuple2 (tuple2 (tuple2 (field "value" $ field "func" $ field "attr" string,
+                                    orElse (field "value" $ field "func" $ field "type" $
+                                      field "type_decl_node" $ field "source_id" source_ref_tm,
+                                      succeed JMissingSource_tm)),
                             field "value" $ field "func" $ field "type" $
                               orElse (field "argument_types" (array json_type), succeed [])),
                     tuple2 (field "value" $ field "func" $ field "type" $
@@ -755,9 +758,12 @@ fun d_json_expr () : term decoder = achoose "expr" [
 
   (* StaticCall - same structure as ExtCall. *)
   check_ast_type "StaticCall" $
-    JSONDecode.map (fn ((func_name, arg_types), (ret_ty, (target, args))) =>
-      mk_JE_StaticCall(func_name, arg_types, ret_ty, target, args)) $
-    tuple2 (tuple2 (field "value" $ field "func" $ field "attr" string,
+    JSONDecode.map (fn (((func_name, func_src), arg_types), (ret_ty, (target, args))) =>
+      mk_JE_StaticCall(func_name, func_src, arg_types, ret_ty, target, args)) $
+    tuple2 (tuple2 (tuple2 (field "value" $ field "func" $ field "attr" string,
+                            orElse (field "value" $ field "func" $ field "type" $
+                              field "type_decl_node" $ field "source_id" source_ref_tm,
+                              succeed JMissingSource_tm)),
                     field "value" $ field "func" $ field "type" $
                       orElse (field "argument_types" (array json_type), succeed [])),
             tuple2 (field "value" $ field "func" $ field "type" $

--- a/frontend/jsonASTScript.sml
+++ b/frontend/jsonASTScript.sml
@@ -107,9 +107,10 @@ Datatype:
   | JE_Call json_expr (json_expr list) (json_keyword list) json_type json_source_ref
 
   (* External calls preserve target and ordinary arguments separately. *)
-  | JE_ExtCall string (json_type list) json_type json_expr
+  | JE_ExtCall string json_source_ref (json_type list) json_type json_expr
       (json_expr list) (json_keyword list)
-  | JE_StaticCall string (json_type list) json_type json_expr (json_expr list)
+  | JE_StaticCall string json_source_ref (json_type list) json_type json_expr
+      (json_expr list)
 ;
   json_keyword = JKeyword string json_expr             (* arg, value *)
 End

--- a/frontend/jsonToVyperExprScript.sml
+++ b/frontend/jsonToVyperExprScript.sml
@@ -550,6 +550,13 @@ Definition resolve_source_ref_def:
     source_id_to_nsid (expr_main_src_id ctx) src_id)
 End
 
+(* External signature metadata omits source IDs on nested nominal types.  Use
+   the declaring function's module as the current type namespace. *)
+Definition signature_type_ctx_def:
+  signature_type_ctx ctx func_src =
+    (expr_main_src_id ctx, resolve_source_ref ctx func_src, expr_import_map ctx)
+End
+
 (* Bare references to constants and immutables are translated as
    module-qualified top-level names; ordinary names remain local/scoped. *)
 Definition make_name_def:
@@ -772,7 +779,7 @@ Definition translate_expr_def:
   (translate_expr ctx (JE_Call func args kwargs ret_ty src_id_opt) =
     let args' = translate_expr_list ctx args in
     let kwargs' = translate_kwargs ctx kwargs in
-    let rty = translate_type (expr_type_ctx ctx) ret_ty in
+    let rty = translate_type (signature_type_ctx ctx src_id_opt) ret_ty in
     case func of
     | JE_Name name (SOME "interface") _ _ =>
         interface_constructor_result rty args'
@@ -813,7 +820,7 @@ Definition translate_expr_def:
                              SOME src => resolve_source_ref ctx src
                            | NONE => nsid)
                       | _ => nsid in
-                  StructLit rty (mod_nsid, fname) kwargs'
+                  StructLit (StructT (mod_nsid, fname)) (mod_nsid, fname) kwargs'
                 else
                   (* Function call that returns a struct: library.foo() *)
                   Call rty (IntCall (nsid, fname)) args' NONE
@@ -823,18 +830,19 @@ Definition translate_expr_def:
 
   (* ExtCall - mutating external call (is_static = F) *)
   (translate_expr ctx
-      (JE_ExtCall func_name arg_types ret_ty target args keywords) =
+      (JE_ExtCall func_name func_src arg_types ret_ty target args keywords) =
     let value_expr = case find_keyword "value" keywords of
                      | SOME v => translate_expr ctx v
                      | NONE => Literal (BaseT (UintT 256)) (IntL 0) in
-    let ret_ty' = translate_type (expr_type_ctx ctx) ret_ty in
+    let sig_ctx = signature_type_ctx ctx func_src in
+    let ret_ty' = translate_type sig_ctx ret_ty in
     (* Vyper records the full declared parameter list in argument_types, even
        when trailing defaulted parameters are omitted.  ExtCall carries the
        effective ABI signature selected at this call site. *)
     Call ret_ty'
       (ExtCall F
         (func_name,
-         TAKE (LENGTH args) (MAP (translate_type (expr_type_ctx ctx)) arg_types),
+         TAKE (LENGTH args) (MAP (translate_type sig_ctx) arg_types),
          ret_ty'))
       (translate_expr ctx target :: value_expr :: translate_expr_list ctx args)
       (OPTION_MAP (translate_expr ctx)
@@ -842,13 +850,14 @@ Definition translate_expr_def:
 
   (* StaticCall - read-only external call (is_static = T) *)
   (translate_expr ctx
-      (JE_StaticCall func_name arg_types ret_ty target args) =
-    let ret_ty' = translate_type (expr_type_ctx ctx) ret_ty in
+      (JE_StaticCall func_name func_src arg_types ret_ty target args) =
+    let sig_ctx = signature_type_ctx ctx func_src in
+    let ret_ty' = translate_type sig_ctx ret_ty in
     (* See ExtCall above: retain only the effective ABI argument types. *)
     Call ret_ty'
       (ExtCall T
         (func_name,
-         TAKE (LENGTH args) (MAP (translate_type (expr_type_ctx ctx)) arg_types),
+         TAKE (LENGTH args) (MAP (translate_type sig_ctx) arg_types),
          ret_ty'))
       (translate_expr ctx target :: translate_expr_list ctx args)
       NONE) /\


### PR DESCRIPTION
Retain the declaring function's source reference when decoding extcall and staticcall nodes. Use that module context when translating argument and return types so unqualified imported structs and flags receive their canonical nominal identity.

Also canonicalize imported struct constructor result types, including structs passed as external call arguments.

This fixes imported struct returns, imported struct arguments, and imported flag returns in interface calls: Fixes #452.