### PR TITLE
Canonicalize builtin module identities by resolved path

### DIFF
--- a/frontend/jsonASTLib.sml
+++ b/frontend/jsonASTLib.sml
@@ -319,9 +319,10 @@ fun mk_JInterfaceFunc (name, args, ret_ty, decorators) =
 fun mk_JTL_InterfaceDef (name, funcs) =
   list_mk_comb(JTL_InterfaceDef_tm,
     [fromMLstring name, mk_list(funcs, json_interface_func_ty)])
-fun mk_JImportInfo (alias, src_id, qual_name) =
+fun mk_JImportInfo (alias, src_id, qual_name, resolved_path) =
   list_mk_comb(JImportInfo_tm,
-    [fromMLstring alias, src_id, fromMLstring qual_name])
+    [fromMLstring alias, src_id, fromMLstring qual_name,
+     fromMLstring resolved_path])
 fun mk_JTL_Import infos =
   mk_comb(JTL_Import_tm, mk_list(infos, json_import_info_ty))
 fun mk_JTL_ExportsDecl ann = mk_comb(JTL_ExportsDecl_tm, ann)
@@ -331,10 +332,10 @@ fun mk_JTL_ImplementsDecl ann = mk_comb(JTL_ImplementsDecl_tm, ann)
 fun mk_JModule (src_id, nr_default, tls) =
   list_mk_comb(JModule_tm,
     [src_id, mk_bool nr_default, mk_list(tls, json_toplevel_ty)])
-fun mk_JImportedModule (src_id_tm, path, nr_default, body) =
+fun mk_JImportedModule (src_id_tm, path, resolved_path, nr_default, body) =
   list_mk_comb(JImportedModule_tm,
-    [src_id_tm, fromMLstring path, mk_bool nr_default,
-     mk_list(body, json_toplevel_ty)])
+    [src_id_tm, fromMLstring path, fromMLstring resolved_path,
+     mk_bool nr_default, mk_list(body, json_toplevel_ty)])
 fun mk_JAnnotatedAST (main_ast, imports) =
   list_mk_comb(JAnnotatedAST_tm,
     [main_ast,
@@ -1177,18 +1178,20 @@ val json_toplevel : term decoder = achoose "toplevel" [
     JSONDecode.map mk_JTL_Import $
     field "import_infos" $ array $
       JSONDecode.map mk_JImportInfo $
-      tuple3 (field "alias" string,
+      tuple4 (field "alias" string,
               field "source_id" inttm,
-              field "qualified_module_name" string),
+              field "qualified_module_name" string,
+              field "resolved_path" string),
 
   (* ImportFrom - from X import Y statement *)
   check_ast_type "ImportFrom" $
     JSONDecode.map mk_JTL_Import $
     field "import_infos" $ array $
       JSONDecode.map mk_JImportInfo $
-      tuple3 (field "alias" string,
+      tuple4 (field "alias" string,
               field "source_id" inttm,
-              field "qualified_module_name" string),
+              field "qualified_module_name" string,
+              field "resolved_path" string),
 
   (* ExportsDecl - exports declaration *)
   check_ast_type "ExportsDecl" $
@@ -1228,11 +1231,12 @@ val json_module : term decoder =
 (* Decoder for imported modules from the imports array *)
 
 val json_imported_module : term decoder =
-  JSONDecode.map (fn (src_id, path, nr, body) =>
-    mk_JImportedModule(src_id, path, nr, body)) $
-  tuple4 (field "source_id" inttm,
-          field "path" string,
-          nonreentrancy_by_default,
+  JSONDecode.map (fn ((src_id, path, resolved_path, nr), body) =>
+    mk_JImportedModule(src_id, path, resolved_path, nr, body)) $
+  tuple2 (tuple4 (field "source_id" inttm,
+                  field "path" string,
+                  field "resolved_path" string,
+                  nonreentrancy_by_default),
           field "body" (array json_toplevel))
 
 (* Parse raw Vyper `-f annotated_ast` output. *)

--- a/frontend/jsonASTScript.sml
+++ b/frontend/jsonASTScript.sml
@@ -173,7 +173,8 @@ End
 
 Datatype:
   json_import_info
-  = JImportInfo string int string                      (* alias, source_id, qualified_module_name *)
+  = JImportInfo string int string string
+    (* alias, source_id, qualified_module_name, resolved_path *)
 End
 
 (* ===== Interface Function Signature ===== *)
@@ -217,8 +218,8 @@ End
 
 Datatype:
   json_imported_module
-  = JImportedModule int string bool (json_toplevel list)
-    (* source_id, path, nonreentrancy_by_default, body *)
+  = JImportedModule int string string bool (json_toplevel list)
+    (* source_id, path, resolved_path, nonreentrancy_by_default, body *)
 End
 
 (* ===== Annotated AST ===== *)

--- a/frontend/jsonToVyperExprScript.sml
+++ b/frontend/jsonToVyperExprScript.sml
@@ -560,7 +560,25 @@ End
 Definition resolve_source_ref_def:
   (resolve_source_ref ctx JMissingSource = expr_current_nsid ctx) /\
   (resolve_source_ref ctx (JExplicitSource src_id) =
-    source_id_to_nsid (expr_main_src_id ctx) src_id)
+    if src_id = -2 then expr_current_nsid ctx
+    else source_id_to_nsid (expr_main_src_id ctx) src_id)
+End
+
+(* Module syntax carries the import alias that disambiguates Vyper's shared
+   builtin source ID.  Prefer that canonical alias mapping to raw metadata. *)
+Definition resolve_module_alias_def:
+  resolve_module_alias ctx alias fallback =
+    case ALOOKUP (expr_import_map ctx) alias of
+    | SOME src_id => SOME src_id
+    | NONE => resolve_source_ref ctx fallback
+End
+
+Definition resolve_func_module_ref_def:
+  resolve_func_module_ref ctx
+      (JE_Attribute (JE_Name alias (SOME "module") src _)
+        _ _ _ _ _ _) fallback =
+    resolve_module_alias ctx alias src ∧
+  resolve_func_module_ref ctx _ fallback = resolve_source_ref ctx fallback
 End
 
 (* Bare references to constants and immutables are translated as
@@ -695,7 +713,7 @@ Definition translate_expr_def:
       TopLevelName (lookup_toplevel_type ctx nsid ty) nsid
     (* Module variable access (lib1.x): use its canonical declaration type. *)
     else if tc = SOME "module" then
-      let nsid = (resolve_source_ref ctx src_id_opt, attr) in
+      let nsid = (resolve_module_alias ctx obj src_id_opt, attr) in
       TopLevelName (lookup_toplevel_type ctx nsid ty) nsid
     else if attr = "balance" /\ base_type_name = SOME "address" then Builtin (BaseT (UintT 256)) (Acc Balance) [make_name ctx base_ty obj]
     else if attr = "address" /\ base_type_name = SOME "address" then Builtin (BaseT AddressT) (Acc Address) [make_name ctx base_ty obj]
@@ -811,7 +829,7 @@ Definition translate_expr_def:
     (* Module struct constructor, interface constructor, or module function call *)
     | _ => if is_interface_constructor func then
              interface_constructor_result rty args'
-           else let nsid = resolve_source_ref ctx src_id_opt;
+           else let nsid = resolve_func_module_ref ctx func src_id_opt;
                fname = extract_func_name func in
            (case ret_ty of
               JT_Struct src_id_opt sname =>

--- a/frontend/jsonToVyperScript.sml
+++ b/frontend/jsonToVyperScript.sml
@@ -4,6 +4,88 @@ Ancestors
 Libs
   intLib
 
+(* Vyper assigns the shared source ID -2 to builtin modules.  Canonicalize
+   colliding source IDs by matching the exact resolved paths emitted on import
+   metadata and imported module ASTs. *)
+Definition max_nonnegative_source_id_def:
+  max_nonnegative_source_id [] = 0 ∧
+  max_nonnegative_source_id (JImportedModule src_id _ _ _ _ :: rest) =
+    MAX (Num src_id) (max_nonnegative_source_id rest)
+End
+
+Definition source_id_occurrences_def:
+  source_id_occurrences src_id [] = 0 ∧
+  source_id_occurrences src_id (JImportedModule sid _ _ _ _ :: rest) =
+    (if src_id = sid then 1 else 0) + source_id_occurrences src_id rest
+End
+
+Definition build_module_identity_map_aux_def:
+  build_module_identity_map_aux all_imports next [] = [] ∧
+  build_module_identity_map_aux all_imports next
+      (JImportedModule src_id _ resolved_path _ _ :: rest) =
+    let canonical_id =
+      if source_id_occurrences src_id all_imports = 1 then src_id else &next in
+    (resolved_path,canonical_id) ::
+      build_module_identity_map_aux all_imports (next + 1) rest
+End
+
+Definition build_module_identity_map_def:
+  build_module_identity_map main_src_id imports =
+    build_module_identity_map_aux imports
+      (MAX (Num main_src_id) (max_nonnegative_source_id imports) + 1) imports
+End
+
+Definition lookup_module_identity_def:
+  lookup_module_identity resolved_path [] = NONE ∧
+  lookup_module_identity resolved_path ((path,src_id)::rest) =
+    if resolved_path = path then SOME src_id
+    else lookup_module_identity resolved_path rest
+End
+
+Definition canonicalize_import_infos_def:
+  canonicalize_import_infos identities [] = [] ∧
+  canonicalize_import_infos identities
+      (JImportInfo alias src_id qualified_name resolved_path :: rest) =
+    let canonical_id =
+      case lookup_module_identity resolved_path identities of
+      | SOME sid => sid
+      | NONE => src_id in
+    JImportInfo alias canonical_id qualified_name resolved_path ::
+      canonicalize_import_infos identities rest
+End
+
+Definition canonicalize_import_toplevels_def:
+  canonicalize_import_toplevels identities [] = [] ∧
+  canonicalize_import_toplevels identities (JTL_Import infos :: rest) =
+    JTL_Import (canonicalize_import_infos identities infos) ::
+      canonicalize_import_toplevels identities rest ∧
+  canonicalize_import_toplevels identities (top :: rest) =
+    top :: canonicalize_import_toplevels identities rest
+End
+
+Definition canonicalize_imported_modules_def:
+  canonicalize_imported_modules identities [] = [] ∧
+  canonicalize_imported_modules identities
+      (JImportedModule src_id path resolved_path nr_default body :: rest) =
+    let canonical_id =
+      case lookup_module_identity resolved_path identities of
+      | SOME sid => sid
+      | NONE => src_id in
+    JImportedModule canonical_id path resolved_path nr_default
+      (canonicalize_import_toplevels identities body) ::
+    canonicalize_imported_modules identities rest
+End
+
+Definition canonicalize_annotated_ast_imports_def:
+  canonicalize_annotated_ast_imports
+      (JAnnotatedAST (JModule main_src_id nr_default body) imports) =
+    let identities = build_module_identity_map main_src_id imports in
+    JAnnotatedAST
+      (JModule main_src_id nr_default
+        (canonicalize_import_toplevels identities body))
+      (canonicalize_imported_modules identities imports)
+End
+
 Definition collect_consts_and_immutables_def:
   collect_consts_and_immutables [] = [] ∧
   collect_consts_and_immutables (t :: rest) =
@@ -17,7 +99,7 @@ End
 (* Names of constants/immutables are translated as top-level names. *)
 Definition build_import_map_def:
   build_import_map [] = [] ∧
-  build_import_map (JImportInfo alias src_id _ :: rest) =
+  build_import_map (JImportInfo alias src_id _ _ :: rest) =
     (alias, source_id_to_module_id src_id) :: build_import_map rest
 End
 
@@ -39,7 +121,7 @@ End
 (* Extract source_ids that a module depends on from its body *)
 Definition get_module_deps_def:
   get_module_deps body =
-    MAP (λinfo. case info of JImportInfo _ src_id _ => src_id) (collect_imports body)
+    MAP (λinfo. case info of JImportInfo _ src_id _ _ => src_id) (collect_imports body)
 End
 
 
@@ -48,7 +130,7 @@ End
    Returns T if sorted, F otherwise. *)
 Definition imports_topsorted_def:
   imports_topsorted seen [] = T ∧
-  imports_topsorted seen (JImportedModule src_id _ _ body :: rest) =
+  imports_topsorted seen (JImportedModule src_id _ _ _ body :: rest) =
     let deps = get_module_deps body in
     if EVERY (λd. MEM d seen) deps
     then imports_topsorted (src_id :: seen) rest
@@ -119,14 +201,14 @@ End
 (* Find module body by raw source_id in imports list *)
 Definition find_module_body_def:
   find_module_body src_id [] = [] ∧
-  find_module_body src_id (JImportedModule sid _ _ body :: rest) =
+  find_module_body src_id (JImportedModule sid _ _ _ body :: rest) =
     if src_id = sid then body else find_module_body src_id rest
 End
 
 (* Find module body by offset source_id (num) in imports list *)
 Definition find_module_body_nsid_def:
   find_module_body_nsid nsid [] = [] ∧
-  find_module_body_nsid nsid (JImportedModule sid _ _ body :: rest) =
+  find_module_body_nsid nsid (JImportedModule sid _ _ _ body :: rest) =
     if nsid = source_id_to_module_id sid then body
     else find_module_body_nsid nsid rest
 End
@@ -153,7 +235,7 @@ End
 (* Build a map from source_id to import_map for all imported modules *)
 Definition build_all_import_maps_def:
   build_all_import_maps [] = [] ∧
-  build_all_import_maps (JImportedModule src_id _ _ body :: rest) =
+  build_all_import_maps (JImportedModule src_id _ _ _ body :: rest) =
     let nsid = source_id_to_module_id src_id in
     (nsid, build_import_map (collect_imports body)) ::
     build_all_import_maps rest
@@ -196,7 +278,7 @@ End
 
 Definition build_all_inline_interface_maps_def:
   build_all_inline_interface_maps [] = [] ∧
-  build_all_inline_interface_maps (JImportedModule src_id _ _ body :: rest) =
+  build_all_inline_interface_maps (JImportedModule src_id _ _ _ body :: rest) =
     let nsid = source_id_to_module_id src_id in
     (nsid, collect_inline_interfaces body) :: build_all_inline_interface_maps rest
 End
@@ -299,7 +381,7 @@ End
 
 Definition build_import_compact_indexes_def:
   build_import_compact_indexes [] = [] ∧
-  build_import_compact_indexes (JImportedModule src_id _ _ body :: rest) =
+  build_import_compact_indexes (JImportedModule src_id _ _ _ body :: rest) =
     module_compact_index (source_id_to_module_id src_id) body ::
     build_import_compact_indexes rest
 End
@@ -364,7 +446,7 @@ End
 Definition collect_imported_nominal_decls_def:
   collect_imported_nominal_decls [] = [] ∧
   collect_imported_nominal_decls
-      (JImportedModule src_id _ _ body :: rest) =
+      (JImportedModule src_id _ _ _ body :: rest) =
     collect_nominal_decls (SOME (source_id_to_module_id src_id)) body ++
     collect_imported_nominal_decls rest
 End
@@ -389,7 +471,7 @@ End
    well as its source instead of classifying every import from that source. *)
 Definition collect_interface_refs_def:
   collect_interface_refs [] = [] ∧
-  collect_interface_refs (JImportedModule src_id path _ _ :: rest) =
+  collect_interface_refs (JImportedModule src_id path _ _ _ :: rest) =
     if is_interface_path path
     then (source_id_to_module_id src_id, interface_path_name path) ::
       collect_interface_refs rest
@@ -412,7 +494,7 @@ End
 Definition collect_interface_alias_infos_def:
   collect_interface_alias_infos interface_refs nsid [] = [] ∧
   collect_interface_alias_infos interface_refs nsid
-      (JImportInfo alias src_id qualified_name :: rest) =
+      (JImportInfo alias src_id qualified_name _ :: rest) =
     if is_interface_import interface_refs src_id qualified_name
     then ((nsid, alias), InterfaceKind) ::
       collect_interface_alias_infos interface_refs nsid rest
@@ -431,7 +513,7 @@ End
 Definition collect_imported_interface_aliases_def:
   collect_imported_interface_aliases interface_refs [] = [] ∧
   collect_imported_interface_aliases interface_refs
-      (JImportedModule src_id _ _ body :: rest) =
+      (JImportedModule src_id _ _ _ body :: rest) =
     collect_interface_aliases interface_refs
       (SOME (source_id_to_module_id src_id)) body ++
     collect_imported_interface_aliases interface_refs rest
@@ -528,7 +610,7 @@ End
 Definition imported_decl_types_valid_def:
   imported_decl_types_valid nominal_index all_import_maps main_src_id [] = T ∧
   imported_decl_types_valid nominal_index all_import_maps main_src_id
-      (JImportedModule src_id _ _ body :: rest) =
+      (JImportedModule src_id _ _ _ body :: rest) =
     (let nsid = source_id_to_module_id src_id in
      let import_map = build_import_map (collect_imports body) in
      let type_ctx = (main_src_id, SOME nsid, import_map) in
@@ -559,7 +641,7 @@ End
 Definition collect_imported_toplevel_types_def:
   collect_imported_toplevel_types nominal_index all_import_maps main_src_id [] = [] ∧
   collect_imported_toplevel_types nominal_index all_import_maps main_src_id
-      (JImportedModule src_id _ _ body :: rest) =
+      (JImportedModule src_id _ _ _ body :: rest) =
     let nsid = source_id_to_module_id src_id in
     let import_map = build_import_map (collect_imports body) in
     let type_ctx = (main_src_id, SOME nsid, import_map) in
@@ -599,7 +681,7 @@ End
 
 Definition translate_imported_module_def:
   translate_imported_module nominal_index all_import_maps all_toplevel_types
-      main_src_id (JImportedModule src_id path nr_default body) =
+      main_src_id (JImportedModule src_id path _ nr_default body) =
     let nsid = source_id_to_module_id src_id in
     let import_map = build_import_map (collect_imports body) in
     let expr_ctx =
@@ -658,8 +740,8 @@ End
    - exports: func_name -> source_id
    - import_map: alias -> source_id (for storage layout key transformation)
    Returns NONE if imports are not topologically sorted. *)
-Definition translate_annotated_ast_def:
-  translate_annotated_ast
+Definition translate_annotated_ast_canonical_def:
+  translate_annotated_ast_canonical
       (JAnnotatedAST (JModule main_src_id nr_default toplevels) imports) =
     if ¬imports_topsorted [] imports then NONE else
     let main = JModule main_src_id nr_default toplevels in
@@ -680,6 +762,11 @@ Definition translate_annotated_ast_def:
         all_toplevel_types main_src_id imports in
     let exports = extract_exports_with_indexes all_import_maps all_inline_maps exports_map main_index in
     SOME (sources, exports, import_map)
+End
+
+Definition translate_annotated_ast_def:
+  translate_annotated_ast ast =
+    translate_annotated_ast_canonical (canonicalize_annotated_ast_imports ast)
 End
 
 (* Annotate all sources with storage slots from json_storage_layout.


### PR DESCRIPTION
Vyper assigns the shared source ID -2 to builtin modules, so translating source IDs directly can collapse distinct builtin interfaces into one module namespace.

Preserve resolved paths in the decoded import metadata and imported module ASTs, and use them to assign fresh identities when source IDs collide. Canonicalize import maps before translation and resolve module expressions through their aliases so builtin references use the corresponding canonical module identity.

Fixes #454 