### PR TITLE
Add concrete Vyper event encoding semantics

### DIFF
--- a/frontend/jsonASTLib.sml
+++ b/frontend/jsonASTLib.sml
@@ -911,7 +911,10 @@ fun d_json_stmt () : term decoder = achoose "stmt" [
   check_ast_type "Log" $
     field "value" $
     check_ast_type "Call" $
-    JSONDecode.map (fn ((name, src_id_opt), args) => mk_JS_Log(mk_nsid(src_id_opt, name), args)) $
+    JSONDecode.map
+      (fn ((name, src_id_opt), (keywords, args)) =>
+        mk_JS_Log(mk_nsid(src_id_opt, name),
+                  if List.null keywords then args else keywords)) $
     tuple2 (field "func" $ achoose "log func" [
               (* Same-module event: log MyEvent(...) *)
               check_ast_type "Name" $
@@ -924,10 +927,9 @@ fun d_json_stmt () : term decoder = achoose "stmt" [
                       orElse (field "value" $ field "type" $
                                 field "type_decl_node" $ field "source_id" source_ref_tm,
                               succeed JMissingSource_tm))],
-            achoose "log args" [
-              field "keywords" (array (field "value" json_expr)),
-              field "args" (array json_expr)
-            ]),
+            tuple2
+              (field "keywords" (array (field "value" json_expr)),
+               field "args" (array json_expr))),
 
   (* If *)
   check_ast_type "If" $

--- a/lowering/defs/compileEnvScript.sml
+++ b/lowering/defs/compileEnvScript.sml
@@ -793,28 +793,7 @@ Definition log_non_indexed_types_def:
 End
 
 Definition log_entry_equiv_def:
-  log_entry_equiv cenv (addr:address) ((event_nsid, args) : log) (ev : event) ⇔
-    let event_name = nsid_to_string event_nsid in
-    case cenv.ce_event_info event_name of
-      NONE => F
-    | SOME (event_hash, arg_types, indexed_flags) =>
-        let idx_vals = indexed_values indexed_flags args in
-        let idx_bs = indexed_topic_flags indexed_flags (MAP is_bytestring_type arg_types) in
-        let nidx_vals = log_non_indexed_values indexed_flags args in
-        let nidx_types = log_non_indexed_types indexed_flags arg_types in
-          LENGTH indexed_flags = LENGTH args ∧
-          LENGTH arg_types = LENGTH args ∧
-          ev.logger = addr ∧
-          (* First topic is the event selector hash. Static indexed args match
-             val_to_w256; indexed bytes/string args match keccak256(raw bytes). *)
-          (∃topic_tail.
-             ev.topics = n2w event_hash :: topic_tail ∧
-             log_indexed_topics_equiv idx_bs idx_vals topic_tail) ∧
-          (* Non-indexed args are ABI-encoded into LOG data. *)
-          (?abi_vals.
-             vyper_to_abi_list cenv.ce_type_env nidx_types nidx_vals = SOME abi_vals ∧
-             ev.data = enc (Tuple (vyper_to_abi_types cenv.ce_type_env nidx_types))
-                           (ListV abi_vals))
+  log_entry_equiv _ _ (source_event : log) (ev : event) ⇔ source_event = ev
 End
 
 (* Logs relation: pairwise equivalence *)

--- a/lowering/defs/compileEnvScript.sml
+++ b/lowering/defs/compileEnvScript.sml
@@ -724,17 +724,13 @@ Definition is_bytestring_type_def:
 End
 
 (* ===== Log Equivalence ===== *)
-(* Single log entry equivalence.
-   Interpreter log: (nsid, value list) where nsid = (num option, string).
-   Venom event: <| logger; topics : bytes32 list; data : byte list |>.
-   The lowering (compile_stmt Log) computes:
-   - event_hash from ce_event_info → first topic
-   - indexed static args → ABI word topics
-   - indexed bytes/string args → keccak256(raw bytes) topics
-   - non-indexed args → ABI-encoded data buffer
-   logger = contract address (cc_address).
-
-   The relation uses ce_event_info to determine which args are indexed. *)
+(* Both the source interpreter and Venom state carry concrete EVM events:
+   <| logger; topics : bytes32 list; data : byte list |>.
+   Event declarations are encoded by the source semantics when Log executes,
+   using the same signature hash, indexed-topic encoding, and ABI data encoding
+   as compile_stmt. Consequently the authoritative state relation below is
+   concrete event equality. The extraction helpers in this section characterize
+   the shared encoder and remain useful to lowering compatibility proofs. *)
 (* Extract indexed values from args based on flags *)
 Definition indexed_values_def:
   indexed_values [] [] = ([] : value list) ∧

--- a/lowering/defs/compileVyperScript.sml
+++ b/lowering/defs/compileVyperScript.sml
@@ -182,6 +182,17 @@ Proof
   Cases_on `lookup_event_metadata_in tenv ename tops` >> simp[]
 QED
 
+Theorem build_event_info_empty_lookup_event_metadata:
+  ALOOKUP sources target = SOME mods ⇒
+  ALOOKUP mods NONE = SOME tops ⇒
+  event_decl_unique ename tops ⇒
+  build_event_info tenv tops (K NONE) ename =
+  lookup_event_metadata tenv sources target (NONE, ename)
+Proof
+  simp[lookup_event_metadata_def,
+       build_event_info_empty_lookup_event_metadata_in]
+QED
+
 (* ===== Nonreentrant Keys ===== *)
 
 Definition assign_nkeys_def:

--- a/lowering/defs/compileVyperScript.sml
+++ b/lowering/defs/compileVyperScript.sml
@@ -26,6 +26,7 @@ Ancestors
   selectorDispatch
   jumptableUtils
   vyperContext
+  vyperEvent
   compileEnv
   vyperAST
   byte
@@ -130,15 +131,8 @@ End
 
 (* ===== Event Info ===== *)
 
-Definition event_hash_def:
-  event_hash tenv ename (arg_types : type list) =
-    let abi_types = vyper_to_abi_types tenv arg_types in
-    let sig_str = function_signature ename abi_types in
-    let hash_bytes = Keccak_256_w64 (MAP (n2w o ORD) sig_str) in
-    num_of_bytes (be_bytes 32 [] hash_bytes)
-End
-
-(* is_bytestring_type is in compileEnvTheory *)
+(* event_hash is shared with the source semantics in vyperEventTheory.
+   is_bytestring_type is in compileEnvTheory. *)
 
 Definition build_event_info_def:
   build_event_info tenv ([] : toplevel list) eim = eim ∧

--- a/lowering/defs/compileVyperScript.sml
+++ b/lowering/defs/compileVyperScript.sml
@@ -147,6 +147,41 @@ Definition build_event_info_def:
     | _ => build_event_info tenv rest eim
 End
 
+Theorem build_event_info_lookup_event_metadata_in:
+  ∀tops.
+    event_decl_unique ename tops ⇒
+    ∀eim.
+      build_event_info tenv tops eim ename =
+      case lookup_event_metadata_in tenv ename tops of
+      | NONE => eim ename
+      | SOME metadata => SOME metadata
+Proof
+  Induct_on `tops` >>
+  simp[build_event_info_def, lookup_event_metadata_in_def] >>
+  Cases_on `h` >>
+  gvs[build_event_info_def, lookup_event_metadata_in_def,
+      event_decl_unique_def] >>
+  Cases_on `s = ename` >> gvs[] >>
+  Cases_on `lookup_event_metadata_in tenv ename tops`
+  >- simp[] >>
+  drule lookup_event_metadata_in_some >>
+  strip_tac >>
+  strip_tac >>
+  qpat_x_assum `∀args args'. _`
+    (qspecl_then [`l`, `args`] mp_tac) >>
+  simp[]
+QED
+
+Theorem build_event_info_empty_lookup_event_metadata_in:
+  event_decl_unique ename tops ⇒
+  build_event_info tenv tops (K NONE) ename =
+  lookup_event_metadata_in tenv ename tops
+Proof
+  strip_tac >>
+  drule build_event_info_lookup_event_metadata_in >>
+  Cases_on `lookup_event_metadata_in tenv ename tops` >> simp[]
+QED
+
 (* ===== Nonreentrant Keys ===== *)
 
 Definition assign_nkeys_def:

--- a/lowering/e2eCorrectnessScript.sml
+++ b/lowering/e2eCorrectnessScript.sml
@@ -528,8 +528,8 @@ Proof
   irule LIST_REL_mono >>
   qexists_tac `log_entry_equiv cenv cx.txn.target` >>
   conj_tac >-
-   (rpt gen_tac >> PairCases_on `x` >>
-    simp[log_entry_equiv_encode_vyper_event, log_entry_corresponds_def]) >>
+   (rpt gen_tac >>
+    simp[log_entry_equiv_concrete_event, log_entry_corresponds_def]) >>
   simp[]
 QED
 

--- a/lowering/e2eCorrectnessScript.sml
+++ b/lowering/e2eCorrectnessScript.sml
@@ -529,7 +529,7 @@ Proof
   qexists_tac `log_entry_equiv cenv cx.txn.target` >>
   conj_tac >-
    (rpt gen_tac >> PairCases_on `x` >>
-    simp[log_entry_equiv_def, log_entry_corresponds_def]) >>
+    simp[log_entry_equiv_encode_vyper_event, log_entry_corresponds_def]) >>
   simp[]
 QED
 

--- a/lowering/e2eDefsScript.sml
+++ b/lowering/e2eDefsScript.sml
@@ -43,23 +43,11 @@ End
 
 (* ===== Log Correspondence ===== *)
 
-(* Single log entry correspondence. Relates a Vyper log (nsid, values)
-   to an EVM event, given:
-   - event_info: maps event name to SOME (hash, arg_types, indexed_flags)
-   - tenv: type environment for ABI encoding
-   - addr: contract address (logger)
-
-   EVM event structure:
-   - ev.logger = contract address
-   - ev.topics = event hash followed by indexed topics
-   - ev.data = ABI-encode of non-indexed values as tuple
-
-   Static indexed args are encoded as val_to_w256. Indexed bytes/string
-   args are encoded as keccak256(raw bytes), matching compileEnv$logs_rel. *)
+(* Source execution now records the concrete EVM event directly. The metadata
+   parameters remain temporarily for compatibility with the e2e API. *)
 Definition log_entry_corresponds_def:
-  log_entry_corresponds event_info tenv (addr : address)
-    ((eid, vals) : log) (ev : event) <=>
-    encode_vyper_event event_info tenv addr (nsid_to_string eid) vals = SOME ev
+  log_entry_corresponds _ _ _ (source_event : log) (ev : event) <=>
+    source_event = ev
 End
 
 (* Compatibility lemmas between the executable semantics encoder and the
@@ -155,6 +143,8 @@ Proof
 QED
 
 
+(* OBSOLETE after source logs became concrete events. Preserved until the
+   surrounding legacy compatibility package is removed deliberately.
 Theorem log_entry_equiv_encode_vyper_event:
   log_entry_equiv cenv addr (eid, vals) ev <=>
   encode_vyper_event cenv.ce_event_info cenv.ce_type_env addr
@@ -191,6 +181,20 @@ QED
 Theorem log_entry_corresponds_encode:
   log_entry_corresponds event_info tenv addr (eid, vals) ev <=>
   encode_vyper_event event_info tenv addr (nsid_to_string eid) vals = SOME ev
+Proof
+  simp[log_entry_corresponds_def]
+QED
+*)
+
+Theorem log_entry_equiv_concrete_event:
+  log_entry_equiv cenv addr source_event ev <=> source_event = ev
+Proof
+  simp[log_entry_equiv_def]
+QED
+
+Theorem log_entry_corresponds_concrete_event:
+  log_entry_corresponds event_info tenv addr source_event ev <=>
+  source_event = ev
 Proof
   simp[log_entry_corresponds_def]
 QED

--- a/lowering/e2eDefsScript.sml
+++ b/lowering/e2eDefsScript.sml
@@ -62,6 +62,131 @@ Definition log_entry_corresponds_def:
     encode_vyper_event event_info tenv addr (nsid_to_string eid) vals = SOME ev
 End
 
+(* Compatibility lemmas between the executable semantics encoder and the
+   pre-existing relational log specification in compileEnv. *)
+Theorem event_value_to_word_eq_val_to_w256:
+  event_value_to_word v = val_to_w256 v
+Proof
+  Cases_on `v` >>
+  simp[event_value_to_word_def, valueEncodingTheory.val_to_w256_def]
+QED
+
+Theorem encode_event_topic_eq_log_topic_equiv:
+  encode_event_topic is_bytestring v = SOME topic <=>
+  log_topic_equiv is_bytestring v topic
+Proof
+  Cases_on `is_bytestring` >> Cases_on `v` >>
+  simp[encode_event_topic_def, log_topic_equiv_def,
+       log_bytestring_topic_def, event_value_to_word_eq_val_to_w256,
+       byteTheory.word_of_bytes_be_def] >>
+  metis_tac[]
+QED
+
+Theorem encode_indexed_event_topics_characterization:
+  encode_indexed_event_topics flags tys vals = SOME topics <=>
+  LENGTH flags = LENGTH tys /\
+  LENGTH flags = LENGTH vals /\
+  log_indexed_topics_equiv
+    (indexed_topic_flags flags (MAP is_bytestring_type tys))
+    (indexed_values flags vals) topics
+Proof
+  `!ty. is_event_bytestring_type ty = is_bytestring_type ty` by
+    (gen_tac >> Cases_on `ty` >> simp[is_event_bytestring_type_def,
+                                      is_bytestring_type_def] >>
+     Cases_on `b` >> simp[is_event_bytestring_type_def,
+                          is_bytestring_type_def] >>
+     Cases_on `b'` >> simp[is_event_bytestring_type_def,
+                           is_bytestring_type_def]) >>
+  qid_spec_tac `topics` >> qid_spec_tac `vals` >> qid_spec_tac `tys` >>
+  Induct_on `flags`
+  >- (Cases_on `tys` >> Cases_on `vals` >> Cases_on `topics` >>
+      simp[encode_indexed_event_topics_def, indexed_topic_flags_def,
+           indexed_values_def, log_indexed_topics_equiv_def])
+  >> qx_gen_tac `flag` >> qx_gen_tac `tys` >>
+  qx_gen_tac `vals` >> qx_gen_tac `topics` >>
+  Cases_on `tys` >> Cases_on `vals` >> Cases_on `flag` >>
+  Cases_on `topics` >>
+  gvs[encode_indexed_event_topics_def, indexed_topic_flags_def,
+      indexed_values_def, log_indexed_topics_equiv_def,
+      is_event_bytestring_type_def, is_bytestring_type_def,
+      encode_event_topic_eq_log_topic_equiv, AllCaseEqs()] >>
+  metis_tac[]
+QED
+
+Theorem non_indexed_event_args_characterization:
+  non_indexed_event_args flags tys vals = SOME typed_vals <=>
+  LENGTH flags = LENGTH tys /\
+  LENGTH flags = LENGTH vals /\
+  MAP FST typed_vals = log_non_indexed_types flags tys /\
+  MAP SND typed_vals = log_non_indexed_values flags vals
+Proof
+  qid_spec_tac `typed_vals` >> qid_spec_tac `vals` >>
+  qid_spec_tac `tys` >> Induct_on `flags`
+  >- (Cases_on `tys` >> Cases_on `vals` >> Cases_on `typed_vals` >>
+      simp[non_indexed_event_args_def, log_non_indexed_types_def,
+           log_non_indexed_values_def])
+  >> qx_gen_tac `flag` >> qx_gen_tac `tys` >>
+  qx_gen_tac `vals` >> qx_gen_tac `typed_vals` >>
+  Cases_on `tys` >> Cases_on `vals` >> Cases_on `flag` >>
+  Cases_on `typed_vals` >>
+  gvs[non_indexed_event_args_def, log_non_indexed_types_def,
+      log_non_indexed_values_def, AllCaseEqs()] >>
+  PairCases_on `h''` >> gvs[] >>
+  simp[AC CONJ_ASSOC CONJ_COMM]
+QED
+Theorem non_indexed_event_args_exists:
+  LENGTH flags = LENGTH tys /\
+  LENGTH flags = LENGTH vals ==>
+  ?typed_vals.
+    non_indexed_event_args flags tys vals = SOME typed_vals /\
+    MAP FST typed_vals = log_non_indexed_types flags tys /\
+    MAP SND typed_vals = log_non_indexed_values flags vals
+Proof
+  qid_spec_tac `vals` >> qid_spec_tac `tys` >> Induct_on `flags`
+  >- (Cases_on `tys` >> Cases_on `vals` >>
+      simp[non_indexed_event_args_def, log_non_indexed_types_def,
+           log_non_indexed_values_def])
+  >> qx_gen_tac `flag` >> qx_gen_tac `tys` >> qx_gen_tac `vals` >>
+  Cases_on `tys` >> Cases_on `vals` >> Cases_on `flag` >>
+  gvs[non_indexed_event_args_def, log_non_indexed_types_def,
+      log_non_indexed_values_def] >>
+  strip_tac >> first_x_assum drule >> disch_then drule >> strip_tac >>
+  qexists `(h,h')::typed_vals` >> simp[]
+QED
+
+
+Theorem log_entry_equiv_encode_vyper_event:
+  log_entry_equiv cenv addr (eid, vals) ev <=>
+  encode_vyper_event cenv.ce_event_info cenv.ce_type_env addr
+    (nsid_to_string eid) vals = SOME ev
+Proof
+  Cases_on `cenv.ce_event_info (nsid_to_string eid)`
+  >- simp[log_entry_equiv_def, encode_vyper_event_def]
+  >> PairCases_on `x` >>
+  simp[log_entry_equiv_def, encode_vyper_event_def] >>
+  eq_tac
+  >- (strip_tac >>
+      `encode_indexed_event_topics x2 x1 vals = SOME topic_tail` by
+        (simp[encode_indexed_event_topics_characterization] >> metis_tac[]) >>
+      `?typed_vals.
+         non_indexed_event_args x2 x1 vals = SOME typed_vals /\
+         MAP FST typed_vals = log_non_indexed_types x2 x1 /\
+         MAP SND typed_vals = log_non_indexed_values x2 vals` by
+        (irule non_indexed_event_args_exists >> metis_tac[]) >>
+      Cases_on `ev` >> gvs[vfmTypesTheory.event_component_equality])
+  >> Cases_on `encode_indexed_event_topics x2 x1 vals`
+  >- simp[]
+  >> Cases_on `non_indexed_event_args x2 x1 vals`
+  >- simp[]
+  >> Cases_on `vyper_to_abi_list cenv.ce_type_env (MAP FST x') (MAP SND x')`
+  >- simp[]
+  >> simp[] >> strip_tac >>
+  gvs[encode_indexed_event_topics_characterization,
+      non_indexed_event_args_characterization,
+      vfmTypesTheory.event_component_equality] >>
+  qexists `x` >> simp[]
+QED
+
 Theorem log_entry_corresponds_encode:
   log_entry_corresponds event_info tenv addr (eid, vals) ev <=>
   encode_vyper_event event_info tenv addr (nsid_to_string eid) vals = SOME ev

--- a/lowering/e2eDefsScript.sml
+++ b/lowering/e2eDefsScript.sml
@@ -163,7 +163,8 @@ Proof
   Cases_on `cenv.ce_event_info (nsid_to_string eid)`
   >- simp[log_entry_equiv_def, encode_vyper_event_def]
   >> PairCases_on `x` >>
-  simp[log_entry_equiv_def, encode_vyper_event_def] >>
+  simp[log_entry_equiv_def, encode_vyper_event_def,
+       encode_vyper_event_metadata_def] >>
   eq_tac
   >- (strip_tac >>
       `encode_indexed_event_topics x2 x1 vals = SOME topic_tail` by

--- a/lowering/e2eDefsScript.sml
+++ b/lowering/e2eDefsScript.sml
@@ -21,6 +21,7 @@ Theory e2eDefs
 Ancestors
   vfmExecution
   vyperABI
+  vyperEvent
   vyperInterpreter
   compileEnv
   selectorDispatch
@@ -58,25 +59,15 @@ End
 Definition log_entry_corresponds_def:
   log_entry_corresponds event_info tenv (addr : address)
     ((eid, vals) : log) (ev : event) <=>
-    let event_name = nsid_to_string eid in
-    case event_info event_name of
-      NONE => F
-    | SOME (event_hash, arg_types, indexed_flags) =>
-        let idx_vals = indexed_values indexed_flags vals in
-        let idx_bs = indexed_topic_flags indexed_flags (MAP is_bytestring_type arg_types) in
-        let nidx_vals = log_non_indexed_values indexed_flags vals in
-        let nidx_types = log_non_indexed_types indexed_flags arg_types in
-          LENGTH indexed_flags = LENGTH vals /\
-          LENGTH arg_types = LENGTH vals /\
-          ev.logger = addr /\
-          (?topic_tail.
-             ev.topics = n2w event_hash :: topic_tail /\
-             log_indexed_topics_equiv idx_bs idx_vals topic_tail) /\
-          (?abi_vals.
-             vyper_to_abi_list tenv nidx_types nidx_vals = SOME abi_vals /\
-             ev.data = enc (Tuple (vyper_to_abi_types tenv nidx_types))
-                           (ListV abi_vals))
+    encode_vyper_event event_info tenv addr (nsid_to_string eid) vals = SOME ev
 End
+
+Theorem log_entry_corresponds_encode:
+  log_entry_corresponds event_info tenv addr (eid, vals) ev <=>
+  encode_vyper_event event_info tenv addr (nsid_to_string eid) vals = SOME ev
+Proof
+  simp[log_entry_corresponds_def]
+QED
 
 (* Vyper logs correspond to EVM events (ordered, same-length).
    event_info maps event name -> SOME (hash, arg_types, indexed_flags)

--- a/semantics/prop/vyperCallScript.sml
+++ b/semantics/prop/vyperCallScript.sml
@@ -71,6 +71,38 @@ Proof
   strip_tac >> res_tac
 QED
 
+(* ===== Log Lifecycle Boundaries (issue #439) ===== *)
+
+Theorem initial_state_logs[simp]:
+  (initial_state am scopes).logs = am.logs
+Proof
+  simp[initial_state_def]
+QED
+
+Theorem clear_machine_logs_logs[simp]:
+  (clear_machine_logs am).logs = []
+Proof
+  simp[clear_machine_logs_def]
+QED
+
+Theorem clear_machine_logs_preserves_machine:
+  (clear_machine_logs am).sources = am.sources ∧
+  (clear_machine_logs am).exports = am.exports ∧
+  (clear_machine_logs am).immutables = am.immutables ∧
+  (clear_machine_logs am).accounts = am.accounts ∧
+  (clear_machine_logs am).layouts = am.layouts ∧
+  (clear_machine_logs am).tStorage = am.tStorage
+Proof
+  simp[clear_machine_logs_def]
+QED
+
+Theorem call_external_transaction_clears_input_logs:
+  call_external_transaction (am with logs := logs) tx =
+  call_external_transaction am tx
+Proof
+  simp[call_external_transaction_def, clear_machine_logs_def]
+QED
+
 (* ===== Error Rollback Properties (issue #180) ===== *)
 
 Theorem call_external_function_error_rollback:
@@ -87,6 +119,14 @@ Theorem call_external_error_rollback:
   am' = am
 Proof
   simp[Once call_external_def] >> strip_tac >> gvs[AllCaseEqs()] >> imp_res_tac call_external_function_error_rollback
+QED
+
+Theorem call_external_transaction_error_logs_empty:
+  call_external_transaction am tx = (INR e, am') ⇒ am'.logs = []
+Proof
+  rw[call_external_transaction_def] >>
+  drule call_external_error_rollback >>
+  simp[]
 QED
 
 Theorem call_external_error_no_state_change:

--- a/semantics/prop/vyperCallScript.sml
+++ b/semantics/prop/vyperCallScript.sml
@@ -27,9 +27,9 @@ Definition extcall_call_def:
     case run_ext_call cx.txn.target target_addr calldata value_opt
                       accounts tStorage (vyper_to_tx_params cx.txn) of
     | NONE => NONE
-    | SOME (success, returnData, accounts', tStorage') =>
+    | SOME (success, returnData, accounts', tStorage', emitted_logs) =>
       if ¬success then NONE
-      else SOME (returnData, accounts', tStorage')
+      else SOME (returnData, accounts', tStorage', emitted_logs)
 End
 
 Definition extcall_result_def:
@@ -38,11 +38,11 @@ Definition extcall_result_def:
     case extcall_call cx is_static (func_name, arg_types, ret_type) vs
                       accounts tStorage of
     | NONE => NONE
-    | SOME (returnData, accounts', tStorage') =>
+    | SOME (returnData, accounts', tStorage', emitted_logs) =>
       case evaluate_abi_decode_return (get_tenv cx) ret_type returnData of
       | INR _ => NONE
       | INL ret_val =>
-        SOME (ret_val, accounts', tStorage')
+        SOME (ret_val, accounts', tStorage', emitted_logs)
 End
 
 Theorem eval_expr_intcall_drv:

--- a/semantics/prop/vyperCallScript.sml
+++ b/semantics/prop/vyperCallScript.sml
@@ -73,6 +73,36 @@ QED
 
 (* ===== Log Lifecycle Boundaries (issue #439) ===== *)
 
+Theorem push_log_logs[simp]:
+  push_log ev st = (INL (), st with logs := st.logs ++ [ev])
+Proof
+  simp[push_log_def, vyperStateTheory.return_def]
+QED
+
+Theorem append_logs_logs[simp]:
+  append_logs events st = (INL (), st with logs := st.logs ++ events)
+Proof
+  simp[append_logs_def, vyperStateTheory.return_def]
+QED
+
+Theorem extract_call_result_success_logs:
+  final_state.contexts = [(ctxt, rollback)] ⇒
+  extract_call_result orig_accounts orig_tStorage (INR NONE, final_state) =
+    SOME (T, ctxt.returnData, final_state.rollback.accounts,
+          final_state.rollback.tStorage, ctxt.logs)
+Proof
+  simp[extract_call_result_def]
+QED
+
+Theorem extract_call_result_reverted_logs:
+  final_state.contexts = [(ctxt, rollback)] ⇒
+  extract_call_result orig_accounts orig_tStorage
+    (INR (SOME Reverted), final_state) =
+    SOME (F, ctxt.returnData, orig_accounts, orig_tStorage, [])
+Proof
+  simp[extract_call_result_def]
+QED
+
 Theorem initial_state_logs[simp]:
   (initial_state am scopes).logs = am.logs
 Proof

--- a/semantics/prop/vyperEvalExprPreservesScopesDomScript.sml
+++ b/semantics/prop/vyperEvalExprPreservesScopesDomScript.sml
@@ -619,7 +619,11 @@ Resume eval_mutual_preserves_scopes_dom[ExtCall]:
     \\ imp_res_tac check_scopes >> imp_res_tac type_check_scopes
     \\ imp_res_tac update_accounts_scopes
     \\ imp_res_tac update_transient_scopes
+    \\ imp_res_tac append_logs_scopes
     \\ imp_res_tac lift_option_scopes >> imp_res_tac lift_option_type_scopes
+    \\ strip_tac
+    \\ gvs[append_logs_def, return_def, check_def, type_check_def, assert_def]
+    \\ first_x_assum drule
     \\ first_x_assum drule
     \\ gvs[get_accounts_def, get_transient_storage_def, return_def,
            check_def, assert_def,
@@ -636,6 +640,7 @@ Resume eval_mutual_preserves_scopes_dom[ExtCall]:
     \\ rw[] \\ imp_res_tac check_scopes >> imp_res_tac type_check_scopes
     \\ imp_res_tac update_accounts_scopes
     \\ imp_res_tac update_transient_scopes
+    \\ imp_res_tac append_logs_scopes
     \\ imp_res_tac lift_option_scopes >> imp_res_tac lift_option_type_scopes
     \\ imp_res_tac lift_sum_scopes >> imp_res_tac lift_sum_runtime_scopes
     \\ gvs[get_accounts_def, get_transient_storage_def, return_def,
@@ -648,10 +653,12 @@ Resume eval_mutual_preserves_scopes_dom[ExtCall]:
   \\ rw[return_def] \\ imp_res_tac check_scopes >> imp_res_tac type_check_scopes
   \\ imp_res_tac update_accounts_scopes
   \\ imp_res_tac update_transient_scopes
+  \\ imp_res_tac append_logs_scopes
   \\ imp_res_tac lift_option_scopes >> imp_res_tac lift_option_type_scopes
   \\ imp_res_tac lift_sum_scopes >> imp_res_tac lift_sum_runtime_scopes
   \\ gvs[get_accounts_def, get_transient_storage_def, return_def,
          COND_RATOR, CaseEq"bool", bind_def, CaseEq"sum", CaseEq"prod"]
+  \\ imp_res_tac lift_sum_runtime_scopes
   \\ imp_res_tac check_scopes >> imp_res_tac type_check_scopes
   \\ imp_res_tac lift_option_scopes >> imp_res_tac lift_option_type_scopes
   \\ gvs[assert_def]

--- a/semantics/prop/vyperEvalExprPreservesScopesDomScript.sml
+++ b/semantics/prop/vyperEvalExprPreservesScopesDomScript.sml
@@ -356,8 +356,8 @@ Proof
        check_def, type_check_def, assert_def, lift_option_def, lift_option_type_def,
        get_accounts_def, get_transient_storage_def, option_CASE_rator] >>
   strip_tac >> gvs[AllCaseEqs(), return_def, raise_def] >>
-  pairarg_tac >> gvs[update_accounts_def, update_transient_def, bind_def,
-       ignore_bind_def, return_def, raise_def, AllCaseEqs(), assert_def,
+  pairarg_tac >> gvs[update_accounts_def, update_transient_def, append_logs_def,
+       bind_def, ignore_bind_def, return_def, raise_def, AllCaseEqs(), assert_def,
        COND_RATOR, CaseEq"bool"]
 QED
 

--- a/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
+++ b/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
@@ -1682,7 +1682,7 @@ QED
 
 (* Helper: inner pipeline after run_ext_call result destructuring *)
 Theorem extcall_inner_pipeline_imm_dom[local]:
-  ∀cx drv tenv ret_type success returnData accounts' tStorage' s res s'.
+  ∀cx drv tenv ret_type success returnData accounts' tStorage' emitted_logs s res s'.
     (success ∧ returnData = [] ∧ IS_SOME drv ⇒
        ∀st res st'. eval_expr cx (THE drv) st = (res,st') ⇒
          preserves_immutables_dom cx st st') ⇒
@@ -1690,6 +1690,7 @@ Theorem extcall_inner_pipeline_imm_dom[local]:
       x <- check success "ExtCall reverted";
       x <- update_accounts (K accounts');
       x <- update_transient (K tStorage');
+      x <- append_logs emitted_logs;
       if returnData = [] ∧ IS_SOME drv then eval_expr cx (THE drv)
       else
         do
@@ -1701,7 +1702,7 @@ Theorem extcall_inner_pipeline_imm_dom[local]:
     preserves_immutables_dom cx s s'
 Proof
   rw[bind_def, ignore_bind_def, check_def, type_check_def, assert_def,
-     update_accounts_def, update_transient_def, return_def,
+     update_accounts_def, update_transient_def, append_logs_def, return_def,
      raise_def, lift_sum_def, lift_sum_runtime_def]
   \\ rpt strip_tac \\ gvs[AllCaseEqs(), preserves_immutables_dom_refl]
   \\ TRY (irule preserves_immutables_dom_eq
@@ -1719,12 +1720,12 @@ QED
 Theorem extcall_pipeline_preserves_imm_dom[local]:
   ∀cx drv func_name arg_types ret_type target_addr value_opt arg_vals
      caller txParams s res s'.
-    (∀ts calldata accounts tStorage success returnData accounts' tStorage'.
+    (∀ts calldata accounts tStorage success returnData accounts' tStorage' emitted_logs.
        get_self_code cx = SOME ts ⇒
        build_ext_calldata (type_env ts) func_name arg_types arg_vals =
          SOME calldata ⇒
        run_ext_call caller target_addr calldata value_opt accounts tStorage
-         txParams = SOME (success, returnData, accounts', tStorage') ⇒
+         txParams = SOME (success, returnData, accounts', tStorage', emitted_logs) ⇒
        success ∧ returnData = [] ∧ IS_SOME drv ⇒
        ∀st res st'. eval_expr cx (THE drv) st = (res,st') ⇒
          preserves_immutables_dom cx st st') ⇒
@@ -1740,11 +1741,12 @@ Theorem extcall_pipeline_preserves_imm_dom[local]:
         lift_option
           (run_ext_call caller target_addr calldata value_opt accounts
              tStorage txParams) "ExtCall run failed";
-      (λ(success,returnData,accounts',tStorage').
+      (λ(success,returnData,accounts',tStorage',emitted_logs).
            do
              x <- check success "ExtCall reverted";
              x <- update_accounts (K accounts');
              x <- update_transient (K tStorage');
+             x <- append_logs emitted_logs;
              if returnData = [] ∧ IS_SOME drv then eval_expr cx (THE drv)
              else
                do
@@ -1777,7 +1779,7 @@ Proof
   \\ rpt strip_tac
   \\ first_x_assum irule \\ simp[]
   \\ qexists_tac `s.accounts` \\ qexists_tac `x''2`
-  \\ qexists_tac `s.tStorage` \\ qexists_tac `x''3`
+  \\ qexists_tac `x''4` \\ qexists_tac `s.tStorage` \\ qexists_tac `x''3`
   \\ gvs[]
 QED
 
@@ -3223,10 +3225,11 @@ QED
 
 Theorem raw_call_callback_preserves_immutables_dom[local]:
   ∀cx flags result st res st'.
-    ((λ(success,returnData,accounts',tStorage').
+    ((λ(success,returnData,accounts',tStorage',emitted_logs).
         do
           x <- update_accounts (K accounts');
           x <- update_transient (K tStorage');
+          x <- append_logs emitted_logs;
           if flags.rcf_revert_on_failure then
             do
               x <- assert success (Error (RuntimeError "raw_call reverted"));
@@ -3244,12 +3247,12 @@ Proof
   rpt strip_tac >>
   PairCases_on `result` >>
   qpat_x_assum `_ = (res,st')` mp_tac >>
-  simp[update_accounts_def, update_transient_def, bind_def, ignore_bind_def,
-      return_def, raise_def, assert_def, check_def, type_check_def,
+  simp[update_accounts_def, update_transient_def, append_logs_def,
+      bind_def, ignore_bind_def, return_def, raise_def, assert_def, check_def, type_check_def,
       AllCaseEqs()] >>
   rpt IF_CASES_TAC >>
-  simp[update_accounts_def, update_transient_def, bind_def, ignore_bind_def,
-      return_def, raise_def, assert_def, check_def, type_check_def,
+  simp[update_accounts_def, update_transient_def, append_logs_def,
+      bind_def, ignore_bind_def, return_def, raise_def, assert_def, check_def, type_check_def,
       AllCaseEqs()] >>
   rpt strip_tac >> gvs[] >>
   irule preserves_immutables_dom_eq >> gvs[]
@@ -3517,6 +3520,10 @@ Resume immutables_dom_mutual[ExtCall]:
   \\ gvs[bind_def, CaseEq"prod", CaseEq"sum"]
   \\ gvs[update_accounts_def, update_transient_def, return_def,
          check_def, type_check_def, raise_def, assert_def]
+  \\ strip_tac
+  \\ first_x_assum irule
+  \\ (conj_tac >- (qexists_tac `r` >> simp[append_logs_def, return_def]))
+  \\ simp[]
 QED
 
 Finalise immutables_dom_mutual

--- a/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
+++ b/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
@@ -734,7 +734,8 @@ Proof
   qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
   simp[Once evaluate_def, bind_def, AllCaseEqs(), return_def, raise_def,
        ignore_bind_def, push_log_def] >>
-  rpt strip_tac >> gvs[preserves_immutables_dom_refl] >>
+  rpt strip_tac >> imp_res_tac lift_option_state >>
+  gvs[preserves_immutables_dom_refl] >>
   irule preserves_immutables_dom_trans >> qexists_tac `s''` >>
   gvs[preserves_immutables_dom_eq]
 QED

--- a/semantics/prop/vyperEvalPreservesScopesScript.sml
+++ b/semantics/prop/vyperEvalPreservesScopesScript.sml
@@ -135,6 +135,7 @@ Theorem case_Log_dom[local]:
 Proof
   rpt strip_tac >> irule map_fdom_eq_preserves_dom >>
   gvs[evaluate_def, bind_def, AllCaseEqs()] >>
+  imp_res_tac lift_option_scopes >>
   imp_res_tac push_log_scopes >> gvs[]
 QED
 
@@ -928,6 +929,7 @@ Proof
       simp[Once evaluate_def, bind_def, AllCaseEqs()] >>
       rpt strip_tac >>
       imp_res_tac eval_exprs_preserves_scopes_dom >>
+      imp_res_tac lift_option_scopes >>
       imp_res_tac push_log_scopes >> gvs[]) >>
     Cases_on`st.scopes` >> Cases_on`st'.scopes` >> gvs[])
   >> conj_tac >- ( (* AnnAssign *)
@@ -1559,6 +1561,7 @@ Proof
     metis_tac[preserves_tv_trans] ) >>
   conj_tac >- (
     rw[evaluate_def, bind_apply, AllCaseEqs(), push_log_def, return_def] >>
+    imp_res_tac lift_option_state >> gvs[] >>
     first_x_assum drule >>
     gvs[preserves_tv_def] ) >>
   conj_tac >- (

--- a/semantics/prop/vyperEvalPreservesScopesScript.sml
+++ b/semantics/prop/vyperEvalPreservesScopesScript.sml
@@ -1216,6 +1216,16 @@ Proof
   simp[preserves_tv_def]
 QED
 
+Theorem append_logs_preserves_tv:
+  ∀cx logs st res st'.
+    append_logs logs st = (res,st') ⇒ preserves_tv cx st st'
+Proof
+  rpt strip_tac >> irule preserves_tv_eq >>
+  imp_res_tac append_logs_scopes >>
+  imp_res_tac append_logs_immutables >>
+  simp[]
+QED
+
 Theorem preserves_tv_stk_update[local]:
   ∀cx f st st'.
     preserves_tv (cx with stk updated_by f) st st' ⇔ preserves_tv cx st st'
@@ -1965,12 +1975,19 @@ Proof
     imp_res_tac update_transient_immutables >>
     reverse BasicProvers.TOP_CASE_TAC >- (
       rw[] >> gvs[preserves_tv_def] ) >>
+    imp_res_tac append_logs_preserves_tv >>
+    gvs[append_logs_def, return_def] >>
     reverse IF_CASES_TAC >- (
       simp[bind_apply, AllCaseEqs(), return_def] >>
       rw[] >> imp_res_tac lift_sum_runtime_state >> gvs[] >>
       irule preserves_tv_trans >>
       goal_assum drule >>
-      gvs[preserves_tv_def] ) >>
+      irule preserves_tv_trans >>
+      qexists_tac `r'` >>
+      (conj_tac >- (irule preserves_tv_eq >> gvs[])) >>
+      irule append_logs_preserves_tv >>
+      qexists_tac `p4` >> qexists_tac `INL ()` >>
+      simp[append_logs_def, return_def] ) >>
     strip_tac >> gvs[] >>
     first_x_assum drule_all >>
     rw[] >>
@@ -2053,7 +2070,9 @@ Proof
     imp_res_tac update_accounts_scopes >>
     imp_res_tac update_accounts_immutables >>
     imp_res_tac update_transient_scopes >>
-    imp_res_tac update_transient_immutables >> gvs[] >>
+    imp_res_tac update_transient_immutables >>
+    imp_res_tac append_logs_scopes >>
+    imp_res_tac append_logs_immutables >> gvs[] >>
     first_x_assum drule >> rw[] >>
     gvs[preserves_tv_def]) >>
   (* RawLog *)

--- a/semantics/prop/vyperExprNoControlScript.sml
+++ b/semantics/prop/vyperExprNoControlScript.sml
@@ -275,6 +275,13 @@ Proof
   simp[push_log_def, return_def]
 QED
 
+Theorem append_logs_no_control:
+  ∀logs s exc s'.
+  append_logs logs s = (INR exc, s') ⇒ no_control_exc exc
+Proof
+  simp[append_logs_def, return_def]
+QED
+
 Theorem write_storage_slot_no_control:
   ∀cx is_t slot tv v s exc s'.
   write_storage_slot cx is_t slot tv v s = (INR exc, s') ⇒ no_control_exc exc
@@ -723,6 +730,7 @@ Proof
   >> Cases_on `flags.rcf_revert_on_failure`
   >> gvs[return_def, bind_def, COND_RATOR, AllCaseEqs()]
   >> imp_res_tac check_no_control
+  >> imp_res_tac append_logs_no_control
 QED
 
 (* ===== Main theorem ===== *)
@@ -821,6 +829,8 @@ Resume eval_expr_no_control_with_bt[ExtCall]:
        step_tac >- gvs[update_accounts_def, return_def] >> assume_tac ih)
   >> qpat_x_assum `∀s'' vs t. _` (fn ih =>
        step_tac >- gvs[update_transient_def, return_def] >> assume_tac ih)
+  >> qpat_x_assum `∀s'' vs t. _` (fn ih =>
+       step_tac >- gvs[append_logs_def, return_def] >> assume_tac ih)
   (* Handle the if-tail *)
   >> qpat_x_assum `(if _ then _ else _) _ = _` mp_tac
   >> simp[COND_RATOR] >> strip_tac
@@ -840,8 +850,9 @@ Resume eval_expr_no_control_with_bt[ExtCall]:
   >> qpat_x_assum `lift_option (run_ext_call _ _ _ _ _ _ _) _ _ = (INL v'⁶', _)` mp_tac
   >> Cases_on `v'⁶'` >> Cases_on `r` >> Cases_on `r'` >> Cases_on `r` >> strip_tac
   >> gvs[]
+  >> PairCases_on `r''` >> gvs[]
   >> rpt (disch_then drule)
-  >> simp[]
+  >> strip_tac >> last_x_assum irule >> metis_tac[]
 QED
 
 Finalise eval_expr_no_control_with_bt

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -1795,6 +1795,86 @@ Proof
   metis_tac[log_extends_trans]
 QED
 
+
+Theorem intcall_success_continuation_guarded_log_extends[local]:
+  (do prev <- get_scopes;
+      dflt_vs <- finally
+        (do x <- set_scopes [FEMPTY];
+            eval_exprs (cx with stk updated_by CONS (src_id_opt,fn))
+              (DROP (LENGTH dflts - (LENGTH args - LENGTH es)) dflts)
+         od) (set_scopes prev);
+      env <- lift_option_type
+               (bind_arguments (get_tenv cx) args (vs ++ dflt_vs))
+               "IntCall bind_arguments";
+      rtv <- lift_option_type (evaluate_type (get_tenv cx) ret)
+               "IntCall eval ret";
+      x <- if nr then
+             case cx.nonreentrant_slot of
+               NONE => raise (Error (TypeError "nonreentrant slot missing"))
+             | SOME slot => acquire_nonreentrant_lock cx.txn.target slot
+                                (mut = View \/ mut = Pure)
+           else return ();
+      cxf <- push_function (src_id_opt,fn) env cx;
+      rv <- finally
+              (try (do x <- eval_stmts cxf body; return NoneV od)
+                   handle_function)
+              (do x <- pop_function prev;
+                  if nr /\ mut <> View /\ mut <> Pure then
+                    case cx.nonreentrant_slot of
+                      NONE => return ()
+                    | SOME slot =>
+                        release_nonreentrant_lock cx.txn.target slot
+                  else return ()
+               od);
+      crv <- lift_option_type (safe_cast rtv rv) "IntCall cast ret";
+      return (Value crv)
+   od) st = (res,st') ==>
+  (!s0 r s1.
+     eval_exprs (cx with stk updated_by CONS (src_id_opt,fn))
+       (DROP (LENGTH dflts - (LENGTH args - LENGTH es)) dflts) s0 =
+       (r,s1) ==> log_extends s0 s1) ==>
+  (!sg prev sg1 dflt_vs sg2 env sg3 rtv sg4 sg5 cxf sg6.
+     get_scopes sg = (INL prev,sg1) ==>
+     finally
+       (do x <- set_scopes [FEMPTY];
+           eval_exprs (cx with stk updated_by CONS (src_id_opt,fn))
+             (DROP (LENGTH dflts - (LENGTH args - LENGTH es)) dflts)
+        od) (set_scopes prev) sg1 = (INL dflt_vs,sg2) ==>
+     lift_option_type
+       (bind_arguments (get_tenv cx) args (vs ++ dflt_vs))
+       "IntCall bind_arguments" sg2 = (INL env,sg3) ==>
+     lift_option_type (evaluate_type (get_tenv cx) ret)
+       "IntCall eval ret" sg3 = (INL rtv,sg4) ==>
+     (if nr then
+        case cx.nonreentrant_slot of
+          NONE => raise (Error (TypeError "nonreentrant slot missing"))
+        | SOME slot => acquire_nonreentrant_lock cx.txn.target slot
+                         (mut = View \/ mut = Pure)
+      else return ()) sg4 = (INL (),sg5) ==>
+     push_function (src_id_opt,fn) env cx sg5 = (INL cxf,sg6) ==>
+     !s0 r s1. eval_stmts cxf body s0 = (r,s1) ==>
+                log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `!sg prev sg1 dflt_vs sg2 env sg3 rtv sg4 sg5 cxf sg6. _`
+    (mk_asm "guarded") >>
+  drule bind_log_extends_forward >> disch_then irule >>
+  conj_tac >-
+    (rpt strip_tac >> gvs[] >>
+     drule bind_log_extends_forward >> disch_then irule >>
+     conj_tac >-
+       (rpt strip_tac >> gvs[] >>
+        asm "guarded" drule >> disch_then drule >>
+        disch_then assume_tac >>
+        drule intcall_post_defaults_guarded_log_extends >> simp[]) >>
+     rpt strip_tac >>
+     drule intcall_defaults_exact_log_extends >> simp[]) >>
+  rpt strip_tac >>
+  irule log_extends_eq_logs >>
+  gvs[vyperStateTheory.get_scopes_def, vyperStateTheory.return_def]
+QED
+
 Theorem intcall_success_continuation_log_extends[local]:
   (do prev <- get_scopes;
       dflt_vs <- finally

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -1390,6 +1390,150 @@ Proof
   irule log_extends_eq_logs >> gvs[]
 QED
 
+Theorem finally_log_extends[local]:
+  finally f g st = (res,st') ==>
+  (!r s1. f st = (r,s1) ==> log_extends st s1) ==>
+  (!s0 r s1. g s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `finally _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.finally_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  metis_tac[log_extends_trans]
+QED
+
+Theorem set_scopes_log_extends[local]:
+  set_scopes scopes st = (res,st') ==> log_extends st st'
+Proof
+  simp[vyperStateTheory.set_scopes_def, vyperStateTheory.return_def] >>
+  rpt strip_tac >> gvs[] >>
+  irule log_extends_eq_logs >> simp[]
+QED
+
+Theorem acquire_nonreentrant_lock_log_extends[local]:
+  acquire_nonreentrant_lock addr slot is_view st = (res,st') ==>
+  log_extends st st'
+Proof
+  Cases_on
+    `lookup_storage (n2w slot)
+       (vfmExecution$lookup_transient_storage addr st.tStorage) = 1w` >>
+  Cases_on `is_view` >>
+  simp[vyperInterpreterTheory.acquire_nonreentrant_lock_def,
+       vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.get_transient_storage_def,
+       vyperStateTheory.update_transient_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def] >>
+  rpt strip_tac >> gvs[] >>
+  irule log_extends_eq_logs >> simp[]
+QED
+
+Theorem release_nonreentrant_lock_log_extends[local]:
+  release_nonreentrant_lock addr slot st = (res,st') ==>
+  log_extends st st'
+Proof
+  simp[vyperInterpreterTheory.release_nonreentrant_lock_def,
+       vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.get_transient_storage_def,
+       vyperStateTheory.update_transient_def, vyperStateTheory.return_def] >>
+  rpt strip_tac >> gvs[] >>
+  irule log_extends_eq_logs >> simp[]
+QED
+
+Theorem intcall_cleanup_log_extends[local]:
+  (do pop_function prev;
+      if nr /\ ~is_view then
+        case cx.nonreentrant_slot of
+          NONE => return ()
+        | SOME slot => release_nonreentrant_lock cx.txn.target slot
+      else return ()
+   od) st = (res,st') ==>
+  log_extends st st'
+Proof
+  Cases_on `nr` >> Cases_on `is_view` >> Cases_on `cx.nonreentrant_slot` >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperInterpreterTheory.pop_function_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  imp_res_tac set_scopes_log_extends >>
+  imp_res_tac release_nonreentrant_lock_log_extends >>
+  imp_res_tac return_state >> gvs[] >>
+  TRY (first_assum MATCH_ACCEPT_TAC >> NO_TAC) >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+
+
+Theorem handle_function_log_extends[local]:
+  handle_function ex st = (res,st') ==> log_extends st st'
+Proof
+  Cases_on `ex` >>
+  simp[oneline vyperInterpreterTheory.handle_function_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def] >>
+  rpt strip_tac >> gvs[log_extends_refl]
+QED
+
+Theorem intcall_try_body_log_extends[local]:
+  (try (do eval_stmts cxf body; return NoneV od) handle_function) st =
+    (res,st') ==>
+  (!s0 r s1. eval_stmts cxf body s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `(try _ _) _ = _` mp_tac >>
+  simp[vyperStateTheory.try_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac handle_function_log_extends >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+
+Theorem intcall_defaults_log_extends[local]:
+  finally (do set_scopes [FEMPTY]; eval_exprs cxd needed_dflts od)
+          (set_scopes prev) st = (res,st') ==>
+  (!s0 r s1. eval_exprs cxd needed_dflts s0 = (r,s1) ==>
+     log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `finally _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.finally_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.bind_def, vyperStateTheory.set_scopes_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  first_x_assum drule >> strip_tac >>
+  qpat_x_assum `log_extends (st with scopes := [FEMPTY]) s''` mp_tac >>
+  simp[log_extends_def]
+QED
+
+Theorem intcall_body_finally_log_extends[local]:
+  finally (try (do eval_stmts cxf body; return NoneV od) handle_function)
+    (do pop_function prev;
+        if nr /\ ~is_view then
+          case cx.nonreentrant_slot of
+            NONE => return ()
+          | SOME slot => release_nonreentrant_lock cx.txn.target slot
+        else return ()
+     od) st = (res,st') ==>
+  (!s0 r s1. eval_stmts cxf body s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  drule finally_log_extends >> disch_then irule >>
+  conj_tac >-
+    (rpt strip_tac >> drule intcall_cleanup_log_extends >> simp[]) >>
+  rpt strip_tac >>
+  drule intcall_try_body_log_extends >> disch_then irule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+
+
+
 Theorem ext_call_tail_log_extends[local]:
   (do x <- assert success (Error (RuntimeError "ExtCall reverted"));
       x <- update_accounts (K accounts');
@@ -1943,6 +2087,7 @@ Proof
   irule log_extends_trans >> goal_assum drule >>
   first_assum MATCH_ACCEPT_TAC
 QED
+
 
 
 val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -3225,4 +3225,25 @@ Proof
   strip_tac >> rpt conj_tac >> first_assum MATCH_ACCEPT_TAC
 QED
 
+Theorem eval_expr_log_extends:
+  !cx e st res st'.
+    eval_expr cx e st = (res,st') ==> log_extends st st'
+Proof
+  metis_tac[eval_mutual_log_extends]
+QED
+
+Theorem eval_exprs_log_extends:
+  !cx es st res st'.
+    eval_exprs cx es st = (res,st') ==> log_extends st st'
+Proof
+  metis_tac[eval_mutual_log_extends]
+QED
+
+Theorem eval_stmts_log_extends:
+  !cx ss st res st'.
+    eval_stmts cx ss st = (res,st') ==> log_extends st st'
+Proof
+  metis_tac[eval_mutual_log_extends]
+QED
+
 val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -825,6 +825,122 @@ Theorem assign_targets_logs[local]:
 Proof
   metis_tac[cj 2 assign_target_logs_mutual]
 QED
+
+Theorem case_stmt_annassign_logs[local]:
+  (!tenv s0 tyv s1.
+     tenv = get_tenv cx /\
+     lift_option_type (evaluate_type tenv typ) "AnnAssign evaluate_type" s0 =
+       (INL tyv,s1) ==>
+     !st res st'. eval_expr cx e st = (res,st') ==> log_extends st st') ==>
+  !st res st'. eval_stmt cx (AnnAssign id typ e) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  TRY (imp_res_tac lift_option_type_state >> gvs[log_extends_refl] >> NO_TAC) >>
+  qpat_x_assum `!s0 tyv s1. _`
+    (qspecl_then [`st`, `tyv`, `s''`] mp_tac) >>
+  (impl_tac >- first_assum ACCEPT_TAC) >> disch_tac >>
+  qpat_x_assum `!st res st'. eval_expr _ _ _ = _ ==> _` drule >> strip_tac >>
+  imp_res_tac lift_option_type_state >> imp_res_tac materialise_state >> gvs[] >>
+  imp_res_tac new_variable_logs >> gvs[log_extends_def]
+QED
+
+Theorem case_stmt_append_logs[local]:
+  (!st res st'. eval_base_target cx bt st = (res,st') ==>
+     log_extends st st') /\
+  (!s0 loc sbs s1. eval_base_target cx bt s0 = (INL (loc,sbs),s1) ==>
+     !st res st'. eval_expr cx e st = (res,st') ==> log_extends st st') ==>
+  !st res st'. eval_stmt cx (Append bt e) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  pure_rewrite_tac[vyperStateTheory.ignore_bind_def] >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac materialise_state >> imp_res_tac assign_target_logs >>
+  imp_res_tac return_state >> gvs[] >>
+  qpat_x_assum `!st res st'. eval_base_target _ _ _ = _ ==> _` drule >>
+  strip_tac >>
+  rpt (pairarg_tac >> gvs[]) >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+      vyperStateTheory.return_def, vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac materialise_state >> imp_res_tac assign_target_logs >>
+  imp_res_tac return_state >> gvs[] >>
+  TRY (first_assum MATCH_ACCEPT_TAC >> NO_TAC) >>
+  first_x_assum drule >> strip_tac >>
+  qpat_x_assum `!st' res st''. eval_expr _ _ _ = _ ==> _` drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_eq_logs >> gvs[]
+QED
+
+Theorem case_stmt_assign_logs[local]:
+  (!st res st'. eval_target cx g st = (res,st') ==> log_extends st st') /\
+  (!s0 gv s1. eval_target cx g s0 = (INL gv,s1) ==>
+     !st res st'. eval_expr cx e st = (res,st') ==> log_extends st st') ==>
+  !st res st'. eval_stmt cx (Assign g e) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  pure_rewrite_tac[vyperStateTheory.ignore_bind_def] >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac materialise_state >> imp_res_tac assign_target_logs >>
+  imp_res_tac return_state >> gvs[] >>
+  qpat_x_assum `!st res st'. eval_target _ _ _ = _ ==> _` drule >>
+  strip_tac >>
+  TRY (first_assum MATCH_ACCEPT_TAC >> NO_TAC) >>
+  first_x_assum drule >> strip_tac >>
+  qpat_x_assum `!st res st'. eval_target _ _ _ = _ ==> _` drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_eq_logs >> gvs[]
+QED
+
+Theorem case_stmt_augassign_logs[local]:
+  (!st res st'. eval_base_target cx bt st = (res,st') ==>
+     log_extends st st') /\
+  (!s0 loc sbs s1. eval_base_target cx bt s0 = (INL (loc,sbs),s1) ==>
+     !st res st'. eval_expr cx e st = (res,st') ==> log_extends st st') ==>
+  !st res st'. eval_stmt cx (AugAssign ty bt bop e) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  pure_rewrite_tac[vyperStateTheory.ignore_bind_def] >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac get_Value_state >> imp_res_tac assign_target_logs >>
+  imp_res_tac return_state >> gvs[] >>
+  qpat_x_assum `!st res st'. eval_base_target _ _ _ = _ ==> _` drule >>
+  strip_tac >>
+  rpt (pairarg_tac >> gvs[]) >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+      vyperStateTheory.return_def, vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac get_Value_state >> imp_res_tac assign_target_logs >>
+  imp_res_tac return_state >> gvs[] >>
+  TRY (first_assum MATCH_ACCEPT_TAC >> NO_TAC) >>
+  first_x_assum drule >> strip_tac >>
+  qpat_x_assum `!st' res st''. eval_expr _ _ _ = _ ==> _` drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_eq_logs >> gvs[]
+QED
+
 Theorem case_stmt_return_some_logs[local]:
   (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
   !st res st'. eval_stmt cx (Return (SOME e)) st = (res,st') ==>

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -82,6 +82,20 @@ Proof
   metis_tac[bind_log_extends]
 QED
 
+Theorem type_check_guard_specialize[local]:
+  type_check p msg st = (INL (),st1) ==>
+  (!s0 s1. type_check p msg s0 = (INL (),s1) ==> P) ==>
+  P
+Proof
+  metis_tac[]
+QED
+
+Theorem equality_guard_specialize[local]:
+  (!x. x = a ==> P) ==> P
+Proof
+  metis_tac[]
+QED
+
 Theorem case_eval_stmts_nil_logs[local]:
   eval_stmts cx [] st = (res,st') ==> log_extends st st'
 Proof
@@ -167,8 +181,11 @@ Proof
 QED
 
 Theorem case_iterator_range_logs[local]:
-  (!s0 r s1. eval_expr cx e1 s0 = (r,s1) ==> log_extends s0 s1) /\
-  (!s0 r s1. eval_expr cx e2 s0 = (r,s1) ==> log_extends s0 s1) ==>
+  (!s0 tv s1 s2 v s3.
+     eval_expr cx e1 s0 = (INL tv,s1) /\
+     get_Value tv s2 = (INL v,s3) ==>
+     !st res st'. eval_expr cx e2 st = (res,st') ==> log_extends st st') /\
+  (!s0 r s1. eval_expr cx e1 s0 = (r,s1) ==> log_extends s0 s1) ==>
   !st res st'. eval_iterator cx (Range e1 e2) st = (res,st') ==>
     log_extends st st'
 Proof
@@ -668,6 +685,116 @@ Proof
   imp_res_tac write_storage_slot_logs >> imp_res_tac return_state >> gvs[]
 QED
 
+Theorem arrayref_assignment_normal_logs[local]:
+  (do (elem_slot,final_tv,remaining_subs) <-
+        resolve_array_element cx is_transient base_slot (ArrayTV elem_tv bd) subs;
+      case final_tv of
+        BaseTV _ => do
+          current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+          new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+          write_storage_slot cx is_transient elem_slot final_tv new_val;
+          assign_result final_tv ao current_val remaining_subs
+        od
+      | TupleTV _ => do
+          current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+          new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+          write_storage_slot cx is_transient elem_slot final_tv new_val;
+          assign_result final_tv ao current_val remaining_subs
+        od
+      | ArrayTV pop_elem_tv (Fixed _) => do
+          current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+          new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+          write_storage_slot cx is_transient elem_slot final_tv new_val;
+          assign_result final_tv ao current_val remaining_subs
+        od
+      | ArrayTV pop_elem_tv (Dynamic n) =>
+          (case ao of
+             Replace _ => do
+               current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+               new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+               write_storage_slot cx is_transient elem_slot final_tv new_val;
+               assign_result final_tv ao current_val remaining_subs
+             od
+           | Update _ _ _ => do
+               current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+               new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+               write_storage_slot cx is_transient elem_slot final_tv new_val;
+               assign_result final_tv ao current_val remaining_subs
+             od
+           | AppendOp v => do
+               storage <- get_storage_backend cx is_transient;
+               check (w2n (lookup_storage elem_slot storage) < n)
+                 "append full storage array";
+               write_storage_slot cx is_transient
+                 (elem_slot + n2w (type_slot_size pop_elem_tv *
+                                    w2n (lookup_storage elem_slot storage) + 1))
+                 pop_elem_tv v;
+               write_storage_slot cx is_transient elem_slot (BaseTV (UintT 256))
+                 (IntV (&(w2n (lookup_storage elem_slot storage) + 1)));
+               return NONE
+             od
+           | PopOp => do
+               storage <- get_storage_backend cx is_transient;
+               check (w2n (lookup_storage elem_slot storage) > 0)
+                 "pop empty storage array";
+               popped <- read_storage_slot cx is_transient
+                 (elem_slot + n2w (type_slot_size pop_elem_tv *
+                                    (w2n (lookup_storage elem_slot storage) - 1) + 1))
+                 pop_elem_tv;
+               write_storage_slot cx is_transient
+                 (elem_slot + n2w (type_slot_size pop_elem_tv *
+                                    (w2n (lookup_storage elem_slot storage) - 1) + 1))
+                 pop_elem_tv (default_value pop_elem_tv);
+               write_storage_slot cx is_transient elem_slot (BaseTV (UintT 256))
+                 (IntV (&(w2n (lookup_storage elem_slot storage) - 1)));
+               return (SOME popped)
+             od)
+      | StructTV _ => do
+          current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+          new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+          write_storage_slot cx is_transient elem_slot final_tv new_val;
+          assign_result final_tv ao current_val remaining_subs
+        od
+      | FlagTV _ => do
+          current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+          new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+          write_storage_slot cx is_transient elem_slot final_tv new_val;
+          assign_result final_tv ao current_val remaining_subs
+        od
+      | NoneTV => do
+          current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+          new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+          write_storage_slot cx is_transient elem_slot final_tv new_val;
+          assign_result final_tv ao current_val remaining_subs
+        od
+   od) st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >> pop_assum mp_tac >>
+  once_rewrite_tac [vyperStateTheory.bind_def] >>
+  qabbrev_tac `rr = resolve_array_element cx is_transient base_slot
+                    (ArrayTV elem_tv bd) subs st` >>
+  PairCases_on `rr` >> Cases_on `rr0` >>
+  qpat_x_assum `Abbrev _` mp_tac >>
+  simp[markerTheory.Abbrev_def] >> strip_tac >> gvs[] >>
+  rpt (pairarg_tac >> gvs[]) >>
+  qpat_x_assum `(_,_) = resolve_array_element _ _ _ _ _ _`
+    (assume_tac o SYM) >>
+  imp_res_tac resolve_array_element_state >> gvs[] >>
+  Cases_on `final_tv` >> gvs[] >>
+  TRY (Cases_on `b` >> gvs[]) >>
+  Cases_on `ao` >> gvs[] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac storage_assignment_tail_logs >>
+  imp_res_tac array_pop_tail_logs >>
+  imp_res_tac array_append_tail_logs >>
+  pop_assum mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       AllCaseEqs()] >> rpt strip_tac >> gvs[] >>
+  imp_res_tac vyperStorageBackendTheory.get_storage_backend_state >>
+  imp_res_tac check_state >> imp_res_tac read_storage_slot_state >> gvs[] >>
+  imp_res_tac write_storage_slot_logs >> imp_res_tac return_state >> gvs[]
+QED
+
 Theorem assign_target_toplevel_logs[local]:
   assign_target cx (BaseTargetV (TopLevelVar src id) subs) ao st = (res,st') ==>
   st'.logs = st.logs
@@ -710,39 +837,16 @@ Proof
           Cases_on `q` >>
           imp_res_tac lift_option_type_state >>
           pop_assum SUBST_ALL_TAC
-          >- (Cases_on `resolve_array_element cx b c (ArrayTV t b0)
-                         (REVERSE subs) st` >>
-              Cases_on `q` >>
-              imp_res_tac resolve_array_element_state >>
-              pop_assum SUBST_ALL_TAC
-              >- (PairCases_on `x'` >> Cases_on `x'1` >>
-                  TRY (Cases_on `b'` >> Cases_on `ao`) >>
-                  qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
-                  simp[Once vyperStateTheory.assign_target_def,
-                       vyperStateTheory.bind_def,
-                       vyperStateTheory.ignore_bind_def,
-                       vyperStateTheory.return_def,
-                       vyperStateTheory.raise_def,
-                       LET_THM, pairTheory.PAIR, AllCaseEqs()] >>
-                  rpt strip_tac >> gvs[] >>
-                  imp_res_tac storage_assignment_tail_logs >>
-                  imp_res_tac array_pop_tail_logs >>
-                  imp_res_tac array_append_tail_logs >>
-                  imp_res_tac vyperStorageBackendTheory.get_storage_backend_state >>
-                  imp_res_tac check_state >>
-                  imp_res_tac read_storage_slot_state >>
-                  imp_res_tac lift_sum_state >>
-                  imp_res_tac write_storage_slot_logs >>
-                  imp_res_tac assign_result_state >>
-                  imp_res_tac return_state >> gvs[])
-              >> (qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
-                  simp[Once vyperStateTheory.assign_target_def,
-                       vyperStateTheory.bind_def,
-                       vyperStateTheory.ignore_bind_def,
-                       vyperStateTheory.return_def,
-                       vyperStateTheory.raise_def,
-                       LET_THM, pairTheory.PAIR] >>
-                  strip_tac >> gvs[]))
+          >- (qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+              simp[Once vyperStateTheory.assign_target_def,
+                   LET_THM, pairTheory.PAIR] >>
+              strip_tac >>
+              pop_assum mp_tac >>
+              once_rewrite_tac [vyperStateTheory.bind_def] >>
+              strip_tac >>
+              gvs[Once vyperStateTheory.bind_def] >>
+              drule arrayref_assignment_normal_logs >>
+              simp[])
           >> (qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
               simp[Once vyperStateTheory.assign_target_def,
                    vyperStateTheory.bind_def, vyperStateTheory.return_def,
@@ -1148,12 +1252,10 @@ QED
 
 
 Theorem case_stmt_raise_logs[local]:
-  (!e. reason = RaiseReason e ==>
-     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
-  !st res st'. eval_stmt cx (Raise reason) st = (res,st') ==>
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Raise (RaiseReason e)) st = (res,st') ==>
     log_extends st st'
 Proof
-  rpt gen_tac >> strip_tac >> Cases_on `reason` >>
   rpt strip_tac >>
   qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
   simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
@@ -1166,13 +1268,12 @@ Proof
 QED
 
 Theorem case_stmt_assert_logs[local]:
-  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) /\
-  (!se. reason = AssertReason se ==>
-     !s0 r s1. eval_expr cx se s0 = (r,s1) ==> log_extends s0 s1) ==>
-  !st res st'. eval_stmt cx (Assert e reason) st = (res,st') ==>
+  (!s0 tv s1. eval_expr cx e s0 = (INL tv,s1) ==>
+     !st res st'. eval_expr cx se st = (res,st') ==> log_extends st st') /\
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Assert e (AssertReason se)) st = (res,st') ==>
     log_extends st st'
 Proof
-  rpt gen_tac >> strip_tac >> Cases_on `reason` >>
   rpt strip_tac >>
   qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
   simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
@@ -1190,6 +1291,38 @@ Proof
   rpt (first_x_assum drule >> strip_tac >> gvs[]) >>
   irule log_extends_trans >> goal_assum drule >>
   first_assum MATCH_ACCEPT_TAC
+QED
+
+Theorem case_stmt_assert_bare_logs[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Assert e AssertBare) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperInterpreterTheory.switch_BoolV_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >> first_x_assum drule >> strip_tac >>
+  Cases_on `tv = Value (BoolV T)` >>
+  Cases_on `tv = Value (BoolV F)` >>
+  gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
+QED
+
+Theorem case_stmt_assert_unreachable_logs[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Assert e AssertUnreachable) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperInterpreterTheory.switch_BoolV_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >> first_x_assum drule >> strip_tac >>
+  Cases_on `tv = Value (BoolV T)` >>
+  Cases_on `tv = Value (BoolV F)` >>
+  gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
 QED
 
 Theorem case_stmt_log_logs[local]:
@@ -1252,8 +1385,10 @@ Proof
 QED
 
 Theorem case_base_target_subscript_logs[local]:
-  (!s0 r s1. eval_base_target cx bt s0 = (r,s1) ==> log_extends s0 s1) /\
-  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  (!s0 loc sbs s1.
+     eval_base_target cx bt s0 = (INL (loc,sbs),s1) ==>
+     !s2 r s3. eval_expr cx e s2 = (r,s3) ==> log_extends s2 s3) /\
+  (!s0 r s1. eval_base_target cx bt s0 = (r,s1) ==> log_extends s0 s1) ==>
   !st res st'. eval_base_target cx (SubscriptTarget bt e) st = (res,st') ==>
     log_extends st st'
 Proof
@@ -1269,6 +1404,50 @@ Proof
   irule log_extends_trans >> goal_assum drule >>
   first_assum MATCH_ACCEPT_TAC
 QED
+
+Theorem case_expr_name_logs[local]:
+  eval_expr cx (Name ty id) st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >> qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.get_scopes_def, vyperStateTheory.return_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >> imp_res_tac lift_option_type_state >>
+  gvs[log_extends_refl]
+QED
+
+Theorem lookup_global_log_extends[local]:
+  lookup_global cx src id st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >> imp_res_tac lookup_global_state >>
+  gvs[log_extends_refl]
+QED
+
+Theorem lookup_flag_mem_log_extends[local]:
+  lookup_flag_mem cx nsid mid st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >> imp_res_tac lookup_flag_mem_state >>
+  gvs[log_extends_refl]
+QED
+
+Theorem case_expr_toplevel_name_logs[local]:
+  eval_expr cx (TopLevelName ty (src,id)) st = (res,st') ==>
+  log_extends st st'
+Proof
+  strip_tac >> qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  metis_tac[lookup_global_log_extends]
+QED
+
+Theorem case_expr_flag_member_logs[local]:
+  eval_expr cx (FlagMember ty nsid mid) st = (res,st') ==>
+  log_extends st st'
+Proof
+  strip_tac >> qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  metis_tac[lookup_flag_mem_log_extends]
+QED
+
 Theorem switch_BoolV_log_extends[local]:
   switch_BoolV tv f g st = (res,st') ==>
   (!s0 r s1. f s0 = (r,s1) ==> log_extends s0 s1) ==>
@@ -1312,8 +1491,9 @@ Proof
 QED
 
 Theorem case_expr_struct_lit_logs[local]:
-  (!s0 r s1. eval_exprs cx (MAP SND kes) s0 = (r,s1) ==>
-     log_extends s0 s1) ==>
+  (!ks. ks = MAP FST kes ==>
+     !s0 r s1. eval_exprs cx (MAP SND kes) s0 = (r,s1) ==>
+       log_extends s0 s1) ==>
   !st res st'. eval_expr cx (StructLit ty sid kes) st = (res,st') ==>
     log_extends st st'
 Proof
@@ -1321,7 +1501,8 @@ Proof
   qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
   simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
        vyperStateTheory.return_def, AllCaseEqs()] >>
-  rpt strip_tac >> gvs[] >> first_x_assum drule >> simp[]
+  rpt strip_tac >> gvs[] >> imp_res_tac equality_guard_specialize >>
+  first_x_assum drule >> simp[]
 QED
 
 Theorem transfer_value_logs[local]:
@@ -1339,7 +1520,8 @@ Proof
 QED
 
 Theorem case_expr_send_logs[local]:
-  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  (!s0 s1. type_check (LENGTH es = 2) "Send args" s0 = (INL (),s1) ==>
+     !st res st'. eval_exprs cx es st = (res,st') ==> log_extends st st') ==>
   !st res st'. eval_expr cx (Call ty Send es drv) st = (res,st') ==>
     log_extends st st'
 Proof
@@ -1349,6 +1531,7 @@ Proof
        vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
        vyperStateTheory.raise_def, AllCaseEqs()] >>
   rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac type_check_guard_specialize >>
   imp_res_tac type_check_state >> imp_res_tac lift_option_type_state >>
   imp_res_tac transfer_value_logs >> gvs[] >>
   metis_tac[log_extends_trans, log_extends_eq_logs]
@@ -1875,6 +2058,73 @@ Proof
   gvs[vyperStateTheory.get_scopes_def, vyperStateTheory.return_def]
 QED
 
+Theorem intcall_guarded_continuation_application_probe[local]:
+  (do prev <- get_scopes;
+      dflt_vs <- finally
+        (do x <- set_scopes [FEMPTY];
+            eval_exprs (cx with stk updated_by CONS (src_id_opt,fn))
+              (DROP (LENGTH dflts - (LENGTH args - LENGTH es)) dflts)
+         od) (set_scopes prev);
+      env <- lift_option_type
+               (bind_arguments (get_tenv cx) args (vs ++ dflt_vs))
+               "IntCall bind_arguments";
+      rtv <- lift_option_type (evaluate_type (get_tenv cx) ret)
+               "IntCall eval ret";
+      x <- if nr then
+             case cx.nonreentrant_slot of
+               NONE => raise (Error (TypeError "nonreentrant slot missing"))
+             | SOME slot => acquire_nonreentrant_lock cx.txn.target slot
+                                (mut = View \/ mut = Pure)
+           else return ();
+      cxf <- push_function (src_id_opt,fn) env cx;
+      rv <- finally
+              (try (do x <- eval_stmts cxf body; return NoneV od)
+                   handle_function)
+              (do x <- pop_function prev;
+                  if nr /\ mut <> View /\ mut <> Pure then
+                    case cx.nonreentrant_slot of
+                      NONE => return ()
+                    | SOME slot =>
+                        release_nonreentrant_lock cx.txn.target slot
+                  else return ()
+               od);
+      crv <- lift_option_type (safe_cast rtv rv) "IntCall cast ret";
+      return (Value crv)
+   od) st = (res,st') ==>
+  (!s0 r s1.
+     eval_exprs (cx with stk updated_by CONS (src_id_opt,fn))
+       (DROP (LENGTH dflts - (LENGTH args - LENGTH es)) dflts) s0 =
+       (r,s1) ==> log_extends s0 s1) ==>
+  (!sg prev sg1 dflt_vs sg2 env sg3 rtv sg4 sg5 cxf sg6.
+     get_scopes sg = (INL prev,sg1) ==>
+     finally
+       (do x <- set_scopes [FEMPTY];
+           eval_exprs (cx with stk updated_by CONS (src_id_opt,fn))
+             (DROP (LENGTH dflts - (LENGTH args - LENGTH es)) dflts)
+        od) (set_scopes prev) sg1 = (INL dflt_vs,sg2) ==>
+     lift_option_type
+       (bind_arguments (get_tenv cx) args (vs ++ dflt_vs))
+       "IntCall bind_arguments" sg2 = (INL env,sg3) ==>
+     lift_option_type (evaluate_type (get_tenv cx) ret)
+       "IntCall eval ret" sg3 = (INL rtv,sg4) ==>
+     (if nr then
+        case cx.nonreentrant_slot of
+          NONE => raise (Error (TypeError "nonreentrant slot missing"))
+        | SOME slot => acquire_nonreentrant_lock cx.txn.target slot
+                         (mut = View \/ mut = Pure)
+      else return ()) sg4 = (INL (),sg5) ==>
+     push_function (src_id_opt,fn) env cx sg5 = (INL cxf,sg6) ==>
+     !s0 r s1. eval_stmts cxf body s0 = (r,s1) ==>
+                log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  drule intcall_success_continuation_guarded_log_extends >>
+  disch_then drule >>
+  disch_then drule >>
+  simp[]
+QED
+
 Theorem intcall_success_continuation_log_extends[local]:
   (do prev <- get_scopes;
       dflt_vs <- finally
@@ -2110,66 +2360,6 @@ Proof
   metis_tac[]
 QED
 
-Definition ext_call_prepare_def:
-  ext_call_prepare cx isc func_name arg_types vs =
-    do
-      type_check (vs <> []) "ExtCall no target";
-      target_addr <- lift_option_type (dest_AddressV (HD vs))
-                       "ExtCall target not address";
-      (value_opt,arg_vals) <- if (isc:bool) then return (NONE,TL vs)
-        else do
-          type_check (TL vs <> []) "ExtCall no value";
-          v <- lift_option_type (dest_NumV (HD (TL vs)))
-                 "ExtCall value not int";
-          return (SOME v,TL (TL vs))
-        od;
-      tenv <<- get_tenv cx;
-      calldata <- lift_option_type
-        (build_ext_calldata tenv func_name arg_types arg_vals)
-        "ExtCall build_calldata";
-      accounts <- get_accounts;
-      check (~NULL (lookup_account target_addr accounts).code)
-        "ExtCall target has no code";
-      tStorage <- get_transient_storage;
-      result <- lift_option
-        (run_ext_call cx.txn.target target_addr calldata value_opt accounts
-           tStorage (vyper_to_tx_params cx.txn)) "ExtCall run failed";
-      return (tenv,result)
-    od
-End
-
-Theorem ext_call_prepare_state[local]:
-  ext_call_prepare cx isc func_name arg_types vs st = (out,st') ==>
-  st' = st
-Proof
-  Cases_on `isc` >>
-  simp[ext_call_prepare_def, vyperStateTheory.bind_def,
-       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
-       vyperStateTheory.raise_def, vyperStateTheory.check_def,
-       vyperStateTheory.type_check_def, vyperStateTheory.get_accounts_def,
-       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
-  rpt strip_tac >>
-  gvs[vyperStateTheory.assert_def, vyperStateTheory.check_def,
-      vyperStateTheory.type_check_def, vyperStateTheory.raise_def,
-      vyperStateTheory.return_def] >>
-  imp_res_tac lift_option_type_state >>
-  imp_res_tac run_ext_call_lift_option_state >>
-  gvs[] >>
-  qpat_x_assum `(do _ od) _ = _` mp_tac >>
-  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
-       vyperStateTheory.return_def, vyperStateTheory.raise_def,
-       vyperStateTheory.check_def, vyperStateTheory.assert_def,
-       vyperStateTheory.get_accounts_def,
-       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
-  rpt strip_tac >>
-  gvs[vyperStateTheory.assert_def, vyperStateTheory.check_def,
-      vyperStateTheory.raise_def, vyperStateTheory.return_def] >>
-  imp_res_tac lift_option_type_state >>
-  imp_res_tac run_ext_call_lift_option_state >>
-  gvs[]
-QED
-
-
 Definition ext_call_after_args_with_def:
   ext_call_after_args_with cx isc func_name arg_types vs k =
     do
@@ -2198,6 +2388,118 @@ Definition ext_call_after_args_with_def:
     od
 End
 
+Theorem ext_call_generated_success_certificate[local]:
+  type_check (vs <> []) "ExtCall no target" s = (INL (),s) /\
+  lift_option_type (dest_AddressV (HD vs)) "ExtCall target not address"
+    s = (INL target_addr,s) /\
+  (if static then return (NONE,TL vs)
+   else do
+     type_check (TL vs <> []) "ExtCall no value";
+     v <- lift_option_type (dest_NumV (HD (TL vs)))
+            "ExtCall value not int";
+     return (SOME v,TL (TL vs))
+   od) s = (INL (value_opt,arg_vals),s) /\
+  lift_option_type
+    (build_ext_calldata (get_tenv cx) func_name arg_types arg_vals)
+    "ExtCall build_calldata" s = (INL calldata,s) /\
+  get_accounts s = (INL accounts,s) /\
+  check (~NULL (lookup_account target_addr accounts).code)
+    "ExtCall target has no code" s = (INL (),s) /\
+  get_transient_storage s = (INL tStorage,s) /\
+  lift_option
+    (run_ext_call cx.txn.target target_addr calldata value_opt accounts
+       tStorage (vyper_to_tx_params cx.txn))
+    "ExtCall run failed" s =
+      (INL (T,[],accounts',tStorage',emitted_logs),s) ==>
+  ext_call_after_args_with cx static func_name arg_types vs
+    (\tenv result. return (tenv,result)) s =
+    (INL (get_tenv cx,(T,[],accounts',tStorage',emitted_logs)),s)
+Proof
+  rpt strip_tac >>
+  simp[ext_call_after_args_with_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+      vyperStateTheory.return_def, vyperStateTheory.raise_def,
+      vyperStateTheory.check_def, vyperStateTheory.type_check_def,
+      vyperStateTheory.assert_def, vyperStateTheory.get_accounts_def,
+      vyperStateTheory.get_transient_storage_def, AllCaseEqs()]
+QED
+
+Theorem ext_call_generated_success_certificate_elim[local]:
+  ext_call_after_args_with cx static func_name arg_types vs
+    (\tenv result. return (tenv,result)) s =
+    (INL (get_tenv cx,(T,[],accounts',tStorage',emitted_logs)),s) ==>
+  ?target_addr value_opt arg_vals calldata accounts tStorage.
+    type_check (vs <> []) "ExtCall no target" s = (INL (),s) /\
+    lift_option_type (dest_AddressV (HD vs)) "ExtCall target not address" s =
+      (INL target_addr,s) /\
+    (if static then return (NONE,TL vs)
+     else do
+       type_check (TL vs <> []) "ExtCall no value";
+       v <- lift_option_type (dest_NumV (HD (TL vs)))
+              "ExtCall value not int";
+       return (SOME v,TL (TL vs))
+     od) s = (INL (value_opt,arg_vals),s) /\
+    lift_option_type
+      (build_ext_calldata (get_tenv cx) func_name arg_types arg_vals)
+      "ExtCall build_calldata" s = (INL calldata,s) /\
+    get_accounts s = (INL accounts,s) /\
+    check (~NULL (lookup_account target_addr accounts).code)
+      "ExtCall target has no code" s = (INL (),s) /\
+    get_transient_storage s = (INL tStorage,s) /\
+    lift_option
+      (run_ext_call cx.txn.target target_addr calldata value_opt accounts
+         tStorage (vyper_to_tx_params cx.txn))
+      "ExtCall run failed" s =
+        (INL (T,[],accounts',tStorage',emitted_logs),s)
+Proof
+  simp[ext_call_after_args_with_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  imp_res_tac lift_option_type_state >>
+  imp_res_tac run_ext_call_lift_option_state >>
+  pairarg_tac >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+      vyperStateTheory.return_def, vyperStateTheory.raise_def,
+      vyperStateTheory.check_def, vyperStateTheory.type_check_def,
+      vyperStateTheory.assert_def, vyperStateTheory.get_accounts_def,
+      vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  imp_res_tac lift_option_type_state >>
+  imp_res_tac run_ext_call_lift_option_state >>
+  gvs[] >>
+  metis_tac[]
+QED
+
+Theorem ext_call_generated_success_certificate_tenv[local]:
+  ext_call_after_args_with cx static func_name arg_types vs
+    (\tenv result. return (tenv,result)) s = (INL (tenv,result),s) ==>
+  tenv = get_tenv cx
+Proof
+  simp[ext_call_after_args_with_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  pairarg_tac >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+      vyperStateTheory.return_def, vyperStateTheory.raise_def,
+      vyperStateTheory.check_def, vyperStateTheory.type_check_def,
+      vyperStateTheory.assert_def, vyperStateTheory.get_accounts_def,
+      vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  metis_tac[]
+QED
+
+
 Theorem ext_call_after_args_with_log_extends_snd[local]:
   (!tenv result s0.
      log_extends s0 (SND (k tenv result s0))) ==>
@@ -2221,6 +2523,108 @@ Proof
   imp_res_tac lift_option_type_state >>
   imp_res_tac run_ext_call_lift_option_state >>
   gvs[log_extends_refl]
+QED
+
+Theorem ext_call_after_args_with_guarded_log_extends_snd[local]:
+  (!tenv result.
+     ext_call_after_args_with cx isc func_name arg_types vs
+       (\tenv result. return (tenv,result)) st =
+       (INL (tenv,result),st) ==>
+     log_extends st (SND (k tenv result st))) ==>
+  log_extends st
+    (SND (ext_call_after_args_with cx isc func_name arg_types vs k st))
+Proof
+  Cases_on `isc` >> rpt strip_tac >>
+  simp[ext_call_after_args_with_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt (CASE_TAC >> gvs[log_extends_refl]) >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       vyperStateTheory.check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt (CASE_TAC >> gvs[log_extends_refl]) >>
+  imp_res_tac lift_option_type_state >>
+  imp_res_tac run_ext_call_lift_option_state >>
+  gvs[log_extends_refl] >>
+  first_x_assum irule >>
+  simp[ext_call_after_args_with_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()]
+QED
+
+Theorem lift_sum_runtime_return_after_append_log_extends[local]:
+  log_extends st
+    (SND
+      (case lift_sum_runtime decoded
+              (st with <|logs := st.logs ++ emitted_logs;
+                         accounts := accounts'; tStorage := tStorage'|>) of
+         (INL ret_val,s'') => (INL (Value ret_val),s'')
+       | (INR err,s'') => (INR err,s'')))
+Proof
+  Cases_on `lift_sum_runtime decoded
+    (st with <|logs := st.logs ++ emitted_logs;
+               accounts := accounts'; tStorage := tStorage'|>)` >>
+  imp_res_tac lift_sum_runtime_state >>
+  Cases_on `q` >>
+  gvs[log_extends_def, rich_listTheory.IS_PREFIX_APPEND]
+QED
+
+Theorem eval_expr_after_append_log_extends[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st
+    (SND (eval_expr cx e
+      (st with <|logs := st.logs ++ emitted_logs;
+                 accounts := accounts'; tStorage := tStorage'|>)))
+Proof
+  strip_tac >>
+  Cases_on `eval_expr cx e
+    (st with <|logs := st.logs ++ emitted_logs;
+               accounts := accounts'; tStorage := tStorage'|>)` >>
+  simp[] >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >>
+  qexists_tac `st with <|logs := st.logs ++ emitted_logs;
+    accounts := accounts'; tStorage := tStorage'|>` >>
+  simp[log_extends_def, rich_listTheory.IS_PREFIX_APPEND]
+QED
+
+Theorem ext_call_after_args_finish_guarded_log_extends[local]:
+  (!tenv accounts' tStorage' emitted_logs e.
+     drv = SOME e /\
+     ext_call_after_args_with cx isc func_name arg_types vs
+       (\tenv result. return (tenv,result)) st =
+       (INL (tenv,(T,[],accounts',tStorage',emitted_logs)),st) ==>
+     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st
+    (SND (ext_call_after_args_with cx isc func_name arg_types vs
+      (\tenv result. ext_call_finish cx drv ret_type tenv result) st))
+Proof
+  strip_tac >>
+  irule ext_call_after_args_with_guarded_log_extends_snd >>
+  rpt strip_tac >>
+  PairCases_on `result` >>
+  Cases_on `result0` >> Cases_on `drv` >>
+  simp[ext_call_finish_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.update_accounts_def,
+       vyperStateTheory.update_transient_def,
+       vyperInterpreterTheory.append_logs_def,
+       vyperStateTheory.check_def, vyperStateTheory.type_check_def,
+       vyperStateTheory.assert_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_append] >>
+  Cases_on `result1 = []` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def, AllCaseEqs()] >>
+  simp[lift_sum_runtime_return_after_append_log_extends,
+       eval_expr_after_append_log_extends, log_extends_refl]
 QED
 
 Theorem ext_call_after_args_fold[local]:
@@ -2327,8 +2731,13 @@ QED
 
 Theorem case_expr_ext_call_logs[local]:
   (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) /\
-  (!e. drv = SOME e ==>
-     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  (!s0 vs s1 tenv accounts' tStorage' emitted_logs e.
+     eval_exprs cx es s0 = (INL vs,s1) /\
+     drv = SOME e /\
+     ext_call_after_args_with cx static func_name arg_types vs
+       (\tenv result. return (tenv,result)) s1 =
+       (INL (tenv,(T,[],accounts',tStorage',emitted_logs)),s1) ==>
+     !u0 r u1. eval_expr cx e u0 = (r,u1) ==> log_extends u0 u1) ==>
   !st res st'.
     eval_expr cx (Call ty (ExtCall static (func_name,arg_types,ret_type))
                          es drv) st = (res,st') ==>
@@ -2340,11 +2749,20 @@ Proof
        vyperStateTheory.bind_def, vyperStateTheory.return_def,
        vyperStateTheory.raise_def, AllCaseEqs()] >>
   rpt strip_tac >> gvs[log_extends_refl] >>
-  first_x_assum drule >> strip_tac >>
+  qpat_x_assum `!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> _`
+    drule >> strip_tac >>
   irule log_extends_trans >> goal_assum drule >>
-  drule ext_call_after_args_log_extends >>
-  disch_then drule >>
-  simp[]
+  qpat_x_assum `(do _ od) _ = _` mp_tac >>
+  pure_rewrite_tac[ext_call_finish_check_fold, ext_call_after_args_fold] >>
+  strip_tac >>
+  `log_extends s''
+     (SND (ext_call_after_args_with cx static func_name arg_types vs
+       (\tenv result. ext_call_finish cx drv ret_type tenv result) s''))` by
+    (irule ext_call_after_args_finish_guarded_log_extends >>
+     rpt strip_tac >>
+     first_x_assum irule >>
+     metis_tac[]) >>
+  gvs[]
 QED
 
 Theorem raw_call_tail_log_extends[local]:
@@ -2445,7 +2863,10 @@ Proof
 QED
 
 Theorem case_expr_type_builtin_logs[local]:
-  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  (!s0 s1.
+     type_check (type_builtin_args_length_ok tb (LENGTH es))
+       "TypeBuiltin args" s0 = (INL (),s1) ==>
+     !st res st'. eval_exprs cx es st = (res,st') ==> log_extends st st') ==>
   !st res st'. eval_expr cx (TypeBuiltin ty tb typ es) st = (res,st') ==>
     log_extends st st'
 Proof
@@ -2455,6 +2876,7 @@ Proof
        vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
        AllCaseEqs()] >>
   rpt strip_tac >> gvs[] >>
+  imp_res_tac type_check_guard_specialize >>
   imp_res_tac type_check_state >> imp_res_tac lift_sum_state >> gvs[] >>
   TRY (simp[log_extends_refl] >> NO_TAC) >>
   first_x_assum drule >> simp[]
@@ -2488,41 +2910,6 @@ Proof
   first_assum MATCH_ACCEPT_TAC
 QED
 
-Theorem eval_mutual_log_extends[local]:
-  (!cx s st res st'. eval_stmt cx s st = (res,st') ==> log_extends st st') /\
-  (!cx ss st res st'. eval_stmts cx ss st = (res,st') ==> log_extends st st') /\
-  (!cx bt st res st'. eval_base_target cx bt st = (res,st') ==>
-     log_extends st st') /\
-  (!cx e st res st'. eval_expr cx e st = (res,st') ==> log_extends st st') /\
-  (!cx es st res st'. eval_exprs cx es st = (res,st') ==> log_extends st st')
-Proof
-  MP_TAC (CONV_RULE (DEPTH_CONV BETA_CONV)
-    (SPECL
-      [``\cx s. !st res st'. eval_stmt cx s st = (res,st') ==>
-           log_extends st st'``,
-       ``\cx ss. !st res st'. eval_stmts cx ss st = (res,st') ==>
-           log_extends st st'``,
-       ``\(cx:evaluation_context) (it:iterator). T``,
-       ``\(cx:evaluation_context) (g:assignment_target). T``,
-       ``\(cx:evaluation_context) (gs:assignment_target list). T``,
-       ``\cx bt. !st res st'. eval_base_target cx bt st = (res,st') ==>
-           log_extends st st'``,
-       ``\(cx:evaluation_context) (tyv:type_value) (nm:num)
-           (body:stmt list) (vs:value list). T``,
-       ``\cx e. !st res st'. eval_expr cx e st = (res,st') ==>
-           log_extends st st'``,
-       ``\cx es. !st res st'. eval_exprs cx es st = (res,st') ==>
-           log_extends st st'``]
-      vyperInterpreterTheory.evaluate_ind)) >>
-  impl_tac >- (
-    rpt conj_tac >> TRY (simp[] >> NO_TAC) >~
-      [`_ ==> !st res st'.
-          eval_expr _ (Call _ (IntCall _) _ _) st = (res,st') ==>
-          log_extends st st'`] >-
-      suspend "IntCall" >>
-    suspend "rest") >>
-  simp[]
-QED
 
 local
   fun last_imp_ante tm =
@@ -2552,14 +2939,72 @@ local
             (MATCH_MP (PURE_REWRITE_RULE [GSYM AND_IMP_INTRO] th) ath))
 in
   val specialize_guard_then = specialize_guard_then
+  val is_guarded_eval_expr_ih =
+    is_guarded_eval_ih "vyperInterpreter$eval_expr"
   val is_guarded_eval_exprs_ih =
     is_guarded_eval_ih "vyperInterpreter$eval_exprs"
   val is_guarded_eval_stmts_ih =
     is_guarded_eval_ih "vyperInterpreter$eval_stmts"
   fun TOP_CASE_IF_PRESENT_TAC g =
     ((BasicProvers.TOP_CASE_TAC ORELSE ALL_TAC) g)
+  fun unfold_last_eval_ante_conv tm =
+    if boolSyntax.is_forall tm then
+      QUANT_CONV unfold_last_eval_ante_conv tm
+    else if boolSyntax.is_imp tm then
+      let
+        val (_,conseq) = boolSyntax.dest_imp tm
+        val (_,body) = boolSyntax.strip_forall conseq
+      in
+        if boolSyntax.is_imp body then
+          RAND_CONV unfold_last_eval_ante_conv tm
+        else
+          LAND_CONV
+            (LAND_CONV
+              (SCONV [Once vyperInterpreterTheory.evaluate_def,
+                      vyperStateTheory.bind_def,
+                      vyperStateTheory.ignore_bind_def,
+                      vyperStateTheory.return_def,
+                      vyperStateTheory.raise_def])) tm
+      end
+    else raise ERR "unfold_last_eval_ante_conv" "expected guarded implication"
+  fun commute_outer_ante_conv tm =
+    if boolSyntax.is_forall tm then
+      QUANT_CONV commute_outer_ante_conv tm
+    else if boolSyntax.is_imp tm then
+      LAND_CONV (REWR_CONV CONJ_COMM) tm
+    else raise ERR "commute_outer_ante_conv" "expected implication"
+  fun APPLY_CASE_HELPER_TAC th =
+    FIRST_PROVE
+      [MATCH_ACCEPT_TAC th,
+       rpt gen_tac >> disch_tac >> ho_match_mp_tac th >>
+       TRY (qpat_x_assum `_ /\ _` strip_assume_tac) >>
+       rpt conj_tac >> first_assum MATCH_ACCEPT_TAC]
+  fun APPLY_NORMALIZED_CASE_HELPER_TAC th =
+    APPLY_CASE_HELPER_TAC (CONV_RULE unfold_last_eval_ante_conv th)
+  val eval_case_helpers =
+    [case_iterator_array_logs, case_iterator_range_logs,
+     case_target_base_logs, case_target_tuple_logs,
+     case_eval_targets_nil_logs, case_eval_targets_cons_logs,
+     case_eval_for_nil_logs, case_eval_for_cons_logs,
+     case_eval_stmts_nil_logs, case_eval_stmts_cons_logs,
+     case_stmt_annassign_logs, case_stmt_append_logs, case_stmt_assign_logs,
+     case_stmt_augassign_logs, case_stmt_return_some_logs,
+     case_stmt_expr_logs, case_stmt_if_logs, case_stmt_for_logs,
+     case_stmt_raise_logs, case_stmt_assert_logs,
+     case_stmt_assert_bare_logs, case_stmt_assert_unreachable_logs,
+     case_stmt_log_logs,
+     case_base_target_name_logs, case_base_target_toplevel_logs,
+     case_base_target_attribute_logs, case_base_target_subscript_logs,
+     case_expr_name_logs, case_expr_toplevel_name_logs,
+     case_expr_flag_member_logs, lookup_global_log_extends,
+     lookup_flag_mem_log_extends, case_expr_subscript_logs, case_expr_pop_logs,
+     case_expr_builtin_logs, case_expr_if_logs, case_expr_struct_lit_logs,
+     case_expr_send_logs, case_expr_selfdestruct_logs, case_expr_create_logs,
+     case_expr_ext_call_logs, case_expr_raw_call_logs,
+     case_expr_raw_log_logs, case_expr_raw_revert_logs,
+     case_expr_attribute_logs, case_expr_type_builtin_logs,
+     case_eval_exprs_nil_logs, case_eval_exprs_cons_logs]
 end
-
 
 Theorem conjunction_guard_specialize_probe[local]:
   (!x y. f x = a /\ g y = b ==> P x y) ==>
@@ -2570,45 +3015,214 @@ Proof
   rpt strip_tac >>
   first_x_assum (specialize_guard_then 2 MATCH_ACCEPT_TAC)
 QED
-Resume eval_mutual_log_extends[IntCall]:
-  rpt gen_tac >> strip_tac >>
-  rewrite_tac[Once vyperInterpreterTheory.evaluate_def] >>
-  rewrite_tac[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def] >>
-  rpt gen_tac >>
-  BasicProvers.TOP_CASE_TAC >>
-  reverse BasicProvers.TOP_CASE_TAC >-
-    (rpt strip_tac >> imp_res_tac type_check_state >> gvs[log_extends_refl]) >>
-  rewrite_tac[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def] >>
-  BasicProvers.TOP_CASE_TAC >>
-  reverse BasicProvers.TOP_CASE_TAC >-
-    (rpt strip_tac >> imp_res_tac type_check_state >>
-     imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
-  rewrite_tac[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def] >>
-  BasicProvers.TOP_CASE_TAC >>
-  reverse BasicProvers.TOP_CASE_TAC >-
-    (rpt strip_tac >> imp_res_tac type_check_state >>
-     imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
-  BasicProvers.LET_ELIM_TAC >>
-  qpat_x_assum `_ = _` mp_tac >>
-  rewrite_tac[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def] >>
-  BasicProvers.TOP_CASE_TAC >>
-  reverse BasicProvers.TOP_CASE_TAC >-
-    (rpt strip_tac >> imp_res_tac type_check_state >>
-     imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
-  pop_assum mp_tac >>
-  first_x_assum $ funpow 2 drule_then drule >>
-  simp[] >> ntac 2 strip_tac >>
-  first_x_assum drule >> strip_tac >>
-  pop_assum $ mk_asm "args_ext" >>
-  BasicProvers.TOP_CASE_TAC >>
-  TRY (rename1 `eval_exprs cx es _ = (INR _,_)` >>
-       asm "args_ext" drule >> simp[] >> NO_TAC) >>
-  asm "args_ext" drule >> strip_tac >>
-  pop_assum $ mk_asm "explicit_ext" >>
-  PRED_ASSUM is_guarded_eval_exprs_ih (mk_asm "defaults_guarded") >>
-  PRED_ASSUM is_guarded_eval_stmts_ih (mk_asm "body_guarded") >>
-  all_tac
+
+val REST_ATOMIC_DISPATCH_TAC =
+  FIRST
+    ([rpt gen_tac >> disch_tac >>
+      ho_match_mp_tac
+        (CONV_RULE commute_outer_ante_conv case_stmt_assign_logs) >>
+      first_assum MATCH_ACCEPT_TAC,
+      rpt gen_tac >> strip_tac >>
+      ho_match_mp_tac case_eval_targets_cons_logs >>
+      rpt conj_tac >> first_assum MATCH_ACCEPT_TAC,
+      rpt gen_tac >> strip_tac >>
+      ho_match_mp_tac case_stmt_append_logs >>
+      rpt conj_tac >> first_assum MATCH_ACCEPT_TAC,
+      rpt gen_tac >> strip_tac >>
+      ho_match_mp_tac case_expr_ext_call_logs >>
+      conj_tac >- first_assum MATCH_ACCEPT_TAC >>
+      rpt gen_tac >> strip_tac >>
+      drule ext_call_generated_success_certificate_tenv >>
+      strip_tac >> gvs[] >>
+      drule ext_call_generated_success_certificate_elim >>
+      strip_tac >>
+      `check T "ExtCall reverted" s1 = (INL (),s1)` by
+        simp[vyperStateTheory.check_def, vyperStateTheory.type_check_def,
+             vyperStateTheory.assert_def, vyperStateTheory.return_def] >>
+      `update_accounts (K accounts') s1 =
+       (INL (),s1 with accounts := accounts')` by
+        simp[vyperStateTheory.update_accounts_def,
+             vyperStateTheory.return_def] >>
+      `update_transient (K tStorage') s1 =
+       (INL (),s1 with tStorage := tStorage')` by
+        simp[vyperStateTheory.update_transient_def,
+             vyperStateTheory.return_def] >>
+      PRED_ASSUM is_guarded_eval_expr_ih
+        (specialize_guard_then 12 MATCH_ACCEPT_TAC)] @
+     map APPLY_CASE_HELPER_TAC eval_case_helpers @
+     map APPLY_NORMALIZED_CASE_HELPER_TAC eval_case_helpers @
+     [simp[Once vyperInterpreterTheory.evaluate_def,
+           vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+           vyperStateTheory.return_def, vyperStateTheory.raise_def,
+           log_extends_refl]]) >>
+  simp[]
+
+Theorem eval_mutual_log_extends[local]:
+  (!cx s st res st'. eval_stmt cx s st = (res,st') ==> log_extends st st') /\
+  (!cx ss st res st'. eval_stmts cx ss st = (res,st') ==> log_extends st st') /\
+  (!cx bt st res st'. eval_base_target cx bt st = (res,st') ==>
+     log_extends st st') /\
+  (!cx e st res st'. eval_expr cx e st = (res,st') ==> log_extends st st') /\
+  (!cx es st res st'. eval_exprs cx es st = (res,st') ==> log_extends st st')
+Proof
+  MP_TAC (CONV_RULE (DEPTH_CONV BETA_CONV)
+    (SPECL
+      [``\cx s. !st res st'. eval_stmt cx s st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx ss. !st res st'. eval_stmts cx ss st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx it. !st res st'. eval_iterator cx it st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx g. !st res st'. eval_target cx g st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx gs. !st res st'. eval_targets cx gs st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx bt. !st res st'. eval_base_target cx bt st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx tyv nm body vs. !st res st'.
+           eval_for cx tyv nm body vs st = (res,st') ==> log_extends st st'``,
+       ``\cx e. !st res st'. eval_expr cx e st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx es. !st res st'. eval_exprs cx es st = (res,st') ==>
+           log_extends st st'``]
+      vyperInterpreterTheory.evaluate_ind)) >>
+  impl_tac >-
+    (rpt conj_tac >> TRY (simp[] >> NO_TAC) >~
+       [`_ ==> !st res st'.
+           eval_expr _ (Call _ (IntCall _) _ _) st = (res,st') ==>
+           log_extends st st'`] >-
+         (rpt gen_tac >> strip_tac >>
+          rewrite_tac[Once vyperInterpreterTheory.evaluate_def] >>
+          rewrite_tac[vyperStateTheory.bind_def,
+                      vyperStateTheory.ignore_bind_def] >>
+          rpt gen_tac >>
+          BasicProvers.TOP_CASE_TAC >>
+          reverse BasicProvers.TOP_CASE_TAC >-
+            (rpt strip_tac >> imp_res_tac type_check_state >>
+             gvs[log_extends_refl]) >>
+          rewrite_tac[vyperStateTheory.bind_def,
+                      vyperStateTheory.ignore_bind_def] >>
+          BasicProvers.TOP_CASE_TAC >>
+          reverse BasicProvers.TOP_CASE_TAC >-
+            (rpt strip_tac >> imp_res_tac type_check_state >>
+             imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
+          rewrite_tac[vyperStateTheory.bind_def,
+                      vyperStateTheory.ignore_bind_def] >>
+          BasicProvers.TOP_CASE_TAC >>
+          reverse BasicProvers.TOP_CASE_TAC >-
+            (rpt strip_tac >> imp_res_tac type_check_state >>
+             imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
+          BasicProvers.LET_ELIM_TAC >>
+          qpat_x_assum `_ = _` mp_tac >>
+          rewrite_tac[vyperStateTheory.bind_def,
+                      vyperStateTheory.ignore_bind_def] >>
+          BasicProvers.TOP_CASE_TAC >>
+          reverse BasicProvers.TOP_CASE_TAC >-
+            (rpt strip_tac >> imp_res_tac type_check_state >>
+             imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
+          pop_assum mp_tac >>
+          first_x_assum $ funpow 2 drule_then drule >>
+          simp[] >> ntac 2 strip_tac >>
+          first_x_assum drule >> strip_tac >>
+          pop_assum $ mk_asm "args_ext" >>
+          BasicProvers.TOP_CASE_TAC >>
+          TRY (rename1 `eval_exprs cx es _ = (INR _,_)` >>
+               asm "args_ext" drule >> simp[] >> NO_TAC) >>
+          asm "args_ext" drule >> strip_tac >>
+          pop_assum $ mk_asm "explicit_ext" >>
+          PRED_ASSUM is_guarded_eval_exprs_ih
+            (mk_asm "defaults_guarded") >>
+          PRED_ASSUM is_guarded_eval_stmts_ih (mk_asm "body_guarded") >>
+          asm "body_guarded" mp_tac >>
+          simp[] >> strip_tac >>
+          pop_assum $ mk_asm "body_after_explicit" >>
+          qpat_x_assum `type_check _ "IntCall args length" _ = _` mp_tac >>
+          simp[vyperStateTheory.type_check_def,
+               vyperStateTheory.assert_def] >>
+          strip_tac >>
+          `type_check (~MEM (src_id_opt,fn) cx.stk) "recursion" st =
+             (INL (),r)` by
+            (qpat_x_assum `type_check _ "recursion" st = _` mp_tac >>
+             simp[vyperStateTheory.type_check_def,
+                  vyperStateTheory.assert_def]) >>
+          `type_check
+             (LENGTH es <= LENGTH (FST (SND (SND x''))) /\
+              LENGTH (FST (SND (SND x''))) <=
+                LENGTH es + LENGTH (FST (SND (SND (SND x'')))))
+             "IntCall args length" r' = (INL (),r')` by
+            simp[vyperStateTheory.type_check_def,
+                 vyperStateTheory.assert_def] >>
+          asm "body_after_explicit"
+            (specialize_guard_then 4 (mk_asm "body_callback")) >>
+          Cases_on `q` >~
+            [`eval_exprs cx es _ = (INR _,_)`] >-
+              (simp[] >> rpt strip_tac >>
+               irule log_extends_trans >>
+               qexists `r'³'` >>
+               conj_tac >-
+                 (imp_res_tac type_check_state >>
+                  imp_res_tac lift_option_type_state >>
+                  gvs[log_extends_eq_logs]) >>
+               asm "explicit_ext" mp_tac >> simp[]) >>
+          simp[] >>
+          asm "body_callback"
+            (specialize_guard_then 1 (mk_asm "body_callback6")) >>
+          asm "defaults_guarded" mp_tac >>
+          simp[] >> strip_tac >>
+          pop_assum $ mk_asm "defaults_ext" >>
+          asm "defaults_ext"
+            (specialize_guard_then 5 (mk_asm "defaults_admin")) >>
+          `get_scopes r'⁴' = (INL r'⁴'.scopes,r'⁴')` by
+            simp[vyperStateTheory.get_scopes_def,
+                 vyperStateTheory.return_def] >>
+          `set_scopes [FEMPTY] r'⁴' =
+             (INL (),r'⁴' with scopes := [FEMPTY])` by
+            simp[vyperStateTheory.set_scopes_def,
+                 vyperStateTheory.return_def] >>
+          asm "defaults_admin"
+            (specialize_guard_then 2 (mk_asm "defaults_preserves")) >>
+          asm_x "defaults_guarded" kall_tac >>
+          asm_x "defaults_ext" kall_tac >>
+          asm_x "defaults_admin" kall_tac >>
+          asm_x "body_guarded" kall_tac >>
+          asm_x "body_after_explicit" kall_tac >>
+          asm_x "body_callback" kall_tac >>
+          simp[] >> strip_tac >>
+          pop_assum $ mk_asm "continuation_eq" >>
+          `LENGTH dflts + LENGTH es - LENGTH args =
+           LENGTH dflts - (LENGTH args - LENGTH es)` by decide_tac >>
+          pop_assum $ mk_asm "drop_eq" >>
+          asm_x "continuation_eq" mp_tac >>
+          asm "drop_eq" (once_rewrite_tac o single) >>
+          unabbrev_all_tac >>
+          strip_tac >>
+          pop_assum $ mk_asm "continuation_eq" >>
+          `log_extends r'⁴' st'` by
+            (asm_x "body_callback6" mp_tac >>
+             asm_x "defaults_preserves" mp_tac >>
+             asm_x "continuation_eq" mp_tac >>
+             POP_ASSUM_LIST (K all_tac) >>
+             rpt strip_tac >>
+             drule intcall_guarded_continuation_application_probe >>
+             disch_then drule >>
+             disch_then irule >>
+             rpt strip_tac >>
+             gvs[vyperStateTheory.bind_def,
+                 vyperStateTheory.ignore_bind_def] >>
+             PRED_ASSUM is_guarded_eval_stmts_ih
+               (specialize_guard_then 7 MATCH_ACCEPT_TAC)) >>
+          irule log_extends_trans >>
+          qexists `r'³'` >>
+          conj_tac >-
+            (imp_res_tac type_check_state >>
+             imp_res_tac lift_option_type_state >>
+             gvs[log_extends_eq_logs]) >>
+          irule log_extends_trans >>
+          qexists `r'⁴'` >>
+          conj_tac >- asm "explicit_ext" MATCH_ACCEPT_TAC >>
+          first_assum MATCH_ACCEPT_TAC) >>
+     REST_ATOMIC_DISPATCH_TAC) >>
+  strip_tac >> rpt conj_tac >> first_assum MATCH_ACCEPT_TAC
 QED
-Finalise eval_mutual_log_extends
 
 val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -1511,6 +1511,62 @@ Proof
   simp[log_extends_def]
 QED
 
+
+Theorem intcall_defaults_exact_log_extends[local]:
+  finally (do x <- set_scopes [FEMPTY];
+              eval_exprs cxd needed_dflts
+           od)
+          (set_scopes prev) st = (res,st') ==>
+  (!s0 r s1. eval_exprs cxd needed_dflts s0 = (r,s1) ==>
+     log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `finally _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.finally_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.bind_def, vyperStateTheory.set_scopes_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  first_x_assum drule >> strip_tac >>
+  qpat_x_assum `log_extends (st with scopes := [FEMPTY]) s''` mp_tac >>
+  simp[log_extends_def]
+QED
+Theorem intcall_scoped_defaults_bind_log_extends[local]:
+  (do prev <- get_scopes;
+      dflt_vs <- finally
+        (do set_scopes [FEMPTY]; eval_exprs cxd needed_dflts od)
+        (set_scopes prev);
+      k prev dflt_vs
+   od) st = (res,st') ==>
+  (!s0 r s1. eval_exprs cxd needed_dflts s0 = (r,s1) ==>
+             log_extends s0 s1) ==>
+  (!prev dflt_vs s0 r s1. k prev dflt_vs s0 = (r,s1) ==>
+                          log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  drule bind_log_extends_forward >> disch_then irule >>
+  conj_tac >-
+    (rpt strip_tac >> gvs[] >>
+     drule bind_log_extends_forward >> disch_then irule >>
+     conj_tac >-
+       (rpt strip_tac >> gvs[] >> metis_tac[]) >>
+     rpt strip_tac >>
+     drule intcall_defaults_log_extends >> simp[]) >>
+  rpt strip_tac >>
+  irule log_extends_eq_logs >>
+  gvs[vyperStateTheory.get_scopes_def, vyperStateTheory.return_def]
+QED
+
+Theorem sum_result_case_log_extends[local]:
+  (case q of INL x => k x st | INR e => (INR e,st)) = (res,st') ==>
+  (!x res st'. k x st = (res,st') ==> log_extends st st') ==>
+  log_extends st st'
+Proof
+  Cases_on `q` >> simp[log_extends_refl] >> metis_tac[]
+QED
+
 Theorem intcall_body_finally_log_extends[local]:
   finally (try (do eval_stmts cxf body; return NoneV od) handle_function)
     (do pop_function prev;
@@ -1530,6 +1586,270 @@ Proof
   rpt strip_tac >>
   drule intcall_try_body_log_extends >> disch_then irule >>
   first_assum MATCH_ACCEPT_TAC
+QED
+
+Theorem intcall_cleanup_exact_log_extends[local]:
+  (do x <- pop_function prev;
+      if nr /\ mut <> View /\ mut <> Pure then
+        case cx.nonreentrant_slot of
+          NONE => return ()
+        | SOME slot => release_nonreentrant_lock cx.txn.target slot
+      else return ()
+   od) st = (res,st') ==>
+  log_extends st st'
+Proof
+  Cases_on `nr` >> Cases_on `mut` >> Cases_on `cx.nonreentrant_slot` >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperInterpreterTheory.pop_function_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  imp_res_tac set_scopes_log_extends >>
+  imp_res_tac release_nonreentrant_lock_log_extends >>
+  imp_res_tac return_state >> gvs[log_extends_refl] >>
+  TRY (first_assum MATCH_ACCEPT_TAC >> NO_TAC) >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+
+
+Theorem intcall_try_body_exact_log_extends[local]:
+  (try (do x <- eval_stmts cxf body; return NoneV od) handle_function) st =
+    (res,st') ==>
+  (!s0 r s1. eval_stmts cxf body s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `(try _ _) _ = _` mp_tac >>
+  simp[vyperStateTheory.try_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac handle_function_log_extends >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+Theorem intcall_body_finally_exact_log_extends[local]:
+  finally (try (do x <- eval_stmts cxf body; return NoneV od) handle_function)
+    (do x <- pop_function prev;
+        if nr /\ mut <> View /\ mut <> Pure then
+          case cx.nonreentrant_slot of
+            NONE => return ()
+          | SOME slot => release_nonreentrant_lock cx.txn.target slot
+        else return ()
+     od) st = (res,st') ==>
+  (!s0 r s1. eval_stmts cxf body s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  drule finally_log_extends >> disch_then irule >>
+  conj_tac >-
+    (rpt strip_tac >> drule intcall_cleanup_exact_log_extends >> simp[]) >>
+  rpt strip_tac >>
+  drule intcall_try_body_exact_log_extends >> disch_then irule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+Theorem intcall_needed_dflts_index[local]:
+  e <= a /\ a <= e + d ==> d - (a - e) = e + d - a
+Proof
+  decide_tac
+QED
+
+Theorem push_function_logs[local]:
+  push_function src_fn sc cx st = (res,st') ==>
+  st'.logs = st.logs
+Proof
+  simp[vyperInterpreterTheory.push_function_def,
+       vyperStateTheory.return_def] >>
+  rpt strip_tac >> gvs[]
+QED
+
+
+Theorem intcall_post_defaults_log_extends[local]:
+  (do env <- lift_option_type
+               (bind_arguments (get_tenv cx) args (vs ++ dflt_vs))
+               "IntCall bind_arguments";
+      rtv <- lift_option_type (evaluate_type (get_tenv cx) ret)
+               "IntCall eval ret";
+      x <- if nr then
+             case cx.nonreentrant_slot of
+               NONE => raise (Error (TypeError "nonreentrant slot missing"))
+             | SOME slot =>
+                 acquire_nonreentrant_lock cx.txn.target slot
+                   (mut = View \/ mut = Pure)
+           else return ();
+      cxf <- push_function (src_id_opt,fn) env cx;
+      rv <- finally
+              (try (do x <- eval_stmts cxf body; return NoneV od)
+                   handle_function)
+              (do x <- pop_function prev;
+                  if nr /\ mut <> View /\ mut <> Pure then
+                    case cx.nonreentrant_slot of
+                      NONE => return ()
+                    | SOME slot =>
+                        release_nonreentrant_lock cx.txn.target slot
+                  else return ()
+               od);
+      crv <- lift_option_type (safe_cast rtv rv) "IntCall cast ret";
+      return (Value crv)
+   od) st = (res,st') ==>
+  (!s0 r s1.
+     eval_stmts (cx with stk updated_by CONS (src_id_opt,fn)) body s0 =
+       (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `(do _ od) _ = _` mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperInterpreterTheory.push_function_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac lift_option_type_state >>
+  gvs[log_extends_refl] >>
+  `log_extends s'' s'⁴'` by
+    (qpat_x_assum `(if nr then _ else _) _ = _` mp_tac >>
+     Cases_on `nr` >> Cases_on `cx.nonreentrant_slot` >>
+     simp[vyperStateTheory.return_def, vyperStateTheory.raise_def] >>
+     rpt strip_tac >>
+     imp_res_tac acquire_nonreentrant_lock_log_extends >>
+     gvs[log_extends_refl]) >>
+  `log_extends (s'⁴' with scopes := [env]) s'⁵'` by
+    (qpat_x_assum `finally _ _ _ = _` mp_tac >>
+     strip_tac >>
+     drule intcall_body_finally_exact_log_extends >>
+     simp[]) >>
+  irule log_extends_trans >>
+  qexists `s'⁴'` >> simp[] >>
+  irule log_extends_trans >>
+  qexists `s'⁴' with scopes := [env]` >>
+  simp[log_extends_eq_logs]
+QED
+
+Theorem intcall_post_defaults_guarded_log_extends[local]:
+  (do env <- lift_option_type
+               (bind_arguments (get_tenv cx) args (vs ++ dflt_vs))
+               "IntCall bind_arguments";
+      rtv <- lift_option_type (evaluate_type (get_tenv cx) ret)
+               "IntCall eval ret";
+      x <- if nr then
+             case cx.nonreentrant_slot of
+               NONE => raise (Error (TypeError "nonreentrant slot missing"))
+             | SOME slot =>
+                 acquire_nonreentrant_lock cx.txn.target slot
+                   (mut = View \/ mut = Pure)
+           else return ();
+      cxf <- push_function (src_id_opt,fn) env cx;
+      rv <- finally
+              (try (do x <- eval_stmts cxf body; return NoneV od)
+                   handle_function)
+              (do x <- pop_function prev;
+                  if nr /\ mut <> View /\ mut <> Pure then
+                    case cx.nonreentrant_slot of
+                      NONE => return ()
+                    | SOME slot =>
+                        release_nonreentrant_lock cx.txn.target slot
+                  else return ()
+               od);
+      crv <- lift_option_type (safe_cast rtv rv) "IntCall cast ret";
+      return (Value crv)
+   od) sg2 = (res,st') ==>
+  (!env sg3 rtv sg4 sg5 cxf sg6.
+     lift_option_type
+       (bind_arguments (get_tenv cx) args (vs ++ dflt_vs))
+       "IntCall bind_arguments" sg2 = (INL env,sg3) ==>
+     lift_option_type (evaluate_type (get_tenv cx) ret)
+       "IntCall eval ret" sg3 = (INL rtv,sg4) ==>
+     (if nr then
+        case cx.nonreentrant_slot of
+          NONE => raise (Error (TypeError "nonreentrant slot missing"))
+        | SOME slot => acquire_nonreentrant_lock cx.txn.target slot
+                         (mut = View \/ mut = Pure)
+      else return ()) sg4 = (INL (),sg5) ==>
+     push_function (src_id_opt,fn) env cx sg5 = (INL cxf,sg6) ==>
+     !s0 r s1. eval_stmts cxf body s0 = (r,s1) ==>
+                log_extends s0 s1) ==>
+  log_extends sg2 st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `(do _ od) _ = _` mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac lift_option_type_state >>
+  gvs[log_extends_refl] >>
+  `log_extends s'' s'⁴'` by
+    (qpat_x_assum `(if nr then _ else _) _ = _` mp_tac >>
+     Cases_on `nr` >> Cases_on `cx.nonreentrant_slot` >>
+     simp[vyperStateTheory.return_def, vyperStateTheory.raise_def] >>
+     rpt strip_tac >>
+     imp_res_tac acquire_nonreentrant_lock_log_extends >>
+     gvs[log_extends_refl]) >>
+  `log_extends s'⁴' s'⁵'` by
+    (irule log_extends_eq_logs >>
+     imp_res_tac push_function_logs >> sym_tac >>
+     first_assum MATCH_ACCEPT_TAC) >>
+  TRY (irule log_extends_trans >> goal_assum drule >>
+       first_assum MATCH_ACCEPT_TAC >> NO_TAC) >>
+  `log_extends s'⁵' s'⁶'` by
+    (qpat_x_assum `finally _ _ _ = _` mp_tac >>
+     strip_tac >>
+     drule intcall_body_finally_exact_log_extends >> simp[]) >>
+  metis_tac[log_extends_trans]
+QED
+
+Theorem intcall_success_continuation_log_extends[local]:
+  (do prev <- get_scopes;
+      dflt_vs <- finally
+        (do x <- set_scopes [FEMPTY];
+            eval_exprs (cx with stk updated_by CONS (src_id_opt,fn))
+              (DROP (LENGTH dflts - (LENGTH args - LENGTH es)) dflts)
+         od) (set_scopes prev);
+      env <- lift_option_type
+               (bind_arguments (get_tenv cx) args (vs ++ dflt_vs))
+               "IntCall bind_arguments";
+      rtv <- lift_option_type (evaluate_type (get_tenv cx) ret)
+               "IntCall eval ret";
+      x <- if nr then
+             case cx.nonreentrant_slot of
+               NONE => raise (Error (TypeError "nonreentrant slot missing"))
+             | SOME slot => acquire_nonreentrant_lock cx.txn.target slot
+                                (mut = View \/ mut = Pure)
+           else return ();
+      cxf <- push_function (src_id_opt,fn) env cx;
+      rv <- finally
+              (try (do x <- eval_stmts cxf body; return NoneV od)
+                   handle_function)
+              (do x <- pop_function prev;
+                  if nr /\ mut <> View /\ mut <> Pure then
+                    case cx.nonreentrant_slot of
+                      NONE => return ()
+                    | SOME slot =>
+                        release_nonreentrant_lock cx.txn.target slot
+                  else return ()
+               od);
+      crv <- lift_option_type (safe_cast rtv rv) "IntCall cast ret";
+      return (Value crv)
+   od) st = (res,st') ==>
+  (!s0 r s1.
+     eval_exprs (cx with stk updated_by CONS (src_id_opt,fn))
+       (DROP (LENGTH dflts - (LENGTH args - LENGTH es)) dflts) s0 =
+       (r,s1) ==> log_extends s0 s1) ==>
+  (!s0 r s1.
+     eval_stmts (cx with stk updated_by CONS (src_id_opt,fn)) body s0 =
+       (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  drule bind_log_extends_forward >> disch_then irule >>
+  conj_tac >-
+    (rpt strip_tac >> gvs[] >>
+     drule bind_log_extends_forward >> disch_then irule >>
+     conj_tac >-
+       (rpt strip_tac >> gvs[] >>
+        drule intcall_post_defaults_log_extends >> simp[]) >>
+     rpt strip_tac >>
+     drule intcall_defaults_exact_log_extends >> simp[]) >>
+  rpt strip_tac >>
+  irule log_extends_eq_logs >>
+  gvs[vyperStateTheory.get_scopes_def, vyperStateTheory.return_def]
 QED
 
 
@@ -2088,6 +2408,110 @@ Proof
   first_assum MATCH_ACCEPT_TAC
 QED
 
+Theorem eval_mutual_log_extends[local]:
+  (!cx s st res st'. eval_stmt cx s st = (res,st') ==> log_extends st st') /\
+  (!cx ss st res st'. eval_stmts cx ss st = (res,st') ==> log_extends st st') /\
+  (!cx bt st res st'. eval_base_target cx bt st = (res,st') ==>
+     log_extends st st') /\
+  (!cx e st res st'. eval_expr cx e st = (res,st') ==> log_extends st st') /\
+  (!cx es st res st'. eval_exprs cx es st = (res,st') ==> log_extends st st')
+Proof
+  MP_TAC (CONV_RULE (DEPTH_CONV BETA_CONV)
+    (SPECL
+      [``\cx s. !st res st'. eval_stmt cx s st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx ss. !st res st'. eval_stmts cx ss st = (res,st') ==>
+           log_extends st st'``,
+       ``\(cx:evaluation_context) (it:iterator). T``,
+       ``\(cx:evaluation_context) (g:assignment_target). T``,
+       ``\(cx:evaluation_context) (gs:assignment_target list). T``,
+       ``\cx bt. !st res st'. eval_base_target cx bt st = (res,st') ==>
+           log_extends st st'``,
+       ``\(cx:evaluation_context) (tyv:type_value) (nm:num)
+           (body:stmt list) (vs:value list). T``,
+       ``\cx e. !st res st'. eval_expr cx e st = (res,st') ==>
+           log_extends st st'``,
+       ``\cx es. !st res st'. eval_exprs cx es st = (res,st') ==>
+           log_extends st st'``]
+      vyperInterpreterTheory.evaluate_ind)) >>
+  impl_tac >- (
+    rpt conj_tac >> TRY (simp[] >> NO_TAC) >~
+      [`_ ==> !st res st'.
+          eval_expr _ (Call _ (IntCall _) _ _) st = (res,st') ==>
+          log_extends st st'`] >-
+      suspend "IntCall" >>
+    suspend "rest") >>
+  simp[]
+QED
 
+local
+  fun last_imp_ante tm =
+    let
+      val (_,body) = boolSyntax.strip_forall tm
+      val (ante,conseq) = boolSyntax.dest_imp body
+      val (_,next) = boolSyntax.strip_forall conseq
+    in
+      if boolSyntax.is_imp next then
+        let val (depth,last) = last_imp_ante conseq in (depth + 1,last) end
+      else (1,ante)
+    end
+
+  fun is_guarded_eval_ih name tm =
+    let
+      val (depth,ante) = last_imp_ante tm
+      val (lhs,_) = boolSyntax.dest_eq ante
+      val (head,_) = boolSyntax.dest_strip_comb lhs
+    in
+      depth > 1 andalso head = name
+    end handle _ => false
+in
+  val is_guarded_eval_exprs_ih =
+    is_guarded_eval_ih "vyperInterpreter$eval_exprs"
+  val is_guarded_eval_stmts_ih =
+    is_guarded_eval_ih "vyperInterpreter$eval_stmts"
+  fun TOP_CASE_IF_PRESENT_TAC g =
+    ((BasicProvers.TOP_CASE_TAC ORELSE ALL_TAC) g)
+end
+
+Resume eval_mutual_log_extends[IntCall]:
+  rpt gen_tac >> strip_tac >>
+  rewrite_tac[Once vyperInterpreterTheory.evaluate_def] >>
+  rewrite_tac[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def] >>
+  rpt gen_tac >>
+  BasicProvers.TOP_CASE_TAC >>
+  reverse BasicProvers.TOP_CASE_TAC >-
+    (rpt strip_tac >> imp_res_tac type_check_state >> gvs[log_extends_refl]) >>
+  rewrite_tac[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def] >>
+  BasicProvers.TOP_CASE_TAC >>
+  reverse BasicProvers.TOP_CASE_TAC >-
+    (rpt strip_tac >> imp_res_tac type_check_state >>
+     imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
+  rewrite_tac[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def] >>
+  BasicProvers.TOP_CASE_TAC >>
+  reverse BasicProvers.TOP_CASE_TAC >-
+    (rpt strip_tac >> imp_res_tac type_check_state >>
+     imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
+  BasicProvers.LET_ELIM_TAC >>
+  qpat_x_assum `_ = _` mp_tac >>
+  rewrite_tac[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def] >>
+  BasicProvers.TOP_CASE_TAC >>
+  reverse BasicProvers.TOP_CASE_TAC >-
+    (rpt strip_tac >> imp_res_tac type_check_state >>
+     imp_res_tac lift_option_type_state >> gvs[log_extends_refl]) >>
+  pop_assum mp_tac >>
+  first_x_assum $ funpow 2 drule_then drule >>
+  simp[] >> ntac 2 strip_tac >>
+  first_x_assum drule >> strip_tac >>
+  pop_assum $ mk_asm "args_ext" >>
+  BasicProvers.TOP_CASE_TAC >>
+  TRY (rename1 `eval_exprs cx es _ = (INR _,_)` >>
+       asm "args_ext" drule >> simp[] >> NO_TAC) >>
+  asm "args_ext" drule >> strip_tac >>
+  pop_assum $ mk_asm "explicit_ext" >>
+  PRED_ASSUM is_guarded_eval_exprs_ih (mk_asm "defaults_guarded") >>
+  PRED_ASSUM is_guarded_eval_stmts_ih (mk_asm "body_guarded") >>
+  all_tac
+QED
+Finalise eval_mutual_log_extends
 
 val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -71,6 +71,17 @@ Proof
   metis_tac[log_extends_trans]
 QED
 
+Theorem bind_log_extends_forward[local]:
+  bind f g st = (res,st') ==>
+  (!r st1. f st = (r,st1) ==> log_extends st st1) ==>
+  (!x st1 r st2.
+     f st = (INL x,st1) /\ g x st1 = (r,st2) ==>
+     log_extends st1 st2) ==>
+  log_extends st st'
+Proof
+  metis_tac[bind_log_extends]
+QED
+
 Theorem case_eval_stmts_nil_logs[local]:
   eval_stmts cx [] st = (res,st') ==> log_extends st st'
 Proof

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -1324,6 +1324,72 @@ Proof
   rpt strip_tac >> gvs[] >> first_x_assum drule >> simp[]
 QED
 
+Theorem transfer_value_logs[local]:
+  transfer_value fromAddr toAddr amount st = (res,st') ==>
+  st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `transfer_value _ _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.transfer_value_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.get_accounts_def,
+       vyperStateTheory.update_accounts_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[]
+QED
+
+Theorem case_expr_send_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (Call ty Send es drv) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac type_check_state >> imp_res_tac lift_option_type_state >>
+  imp_res_tac transfer_value_logs >> gvs[] >>
+  metis_tac[log_extends_trans, log_extends_eq_logs]
+QED
+
+Theorem case_expr_selfdestruct_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (Call ty SelfDestructTarget es drv) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.get_accounts_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac type_check_state >> imp_res_tac lift_option_type_state >>
+  imp_res_tac transfer_value_logs >> gvs[] >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_eq_logs >> gvs[]
+QED
+
+Theorem case_expr_create_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'.
+    eval_expr cx (Call ty (CreateTarget kind has_salt rof) es drv) st =
+      (res,st') ==> log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac vyperCreateTheory.eval_create_preserves_non_accounts >> gvs[] >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_eq_logs >> gvs[]
+QED
+
 Theorem ext_call_tail_log_extends[local]:
   (do x <- assert success (Error (RuntimeError "ExtCall reverted"));
       x <- update_accounts (K accounts');

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -485,6 +485,67 @@ Proof
   imp_res_tac check_state >> imp_res_tac write_storage_slot_logs >>
   imp_res_tac return_state >> gvs[]
 QED
+
+Theorem arrayref_assignment_suffix_logs[local]:
+  (do (elem_slot,final_tv,remaining_subs) <-
+        resolve_array_element cx is_transient base_slot (ArrayTV elem_tv bd) subs;
+      case (ao,final_tv) of
+        (PopOp,ArrayTV pop_elem_tv (Dynamic n)) => do
+          storage <- get_storage_backend cx is_transient;
+          stored_len <<- w2n (lookup_storage elem_slot storage);
+          check (stored_len > 0) "pop empty storage array";
+          last_idx <<- stored_len - 1;
+          last_slot <<- elem_slot + n2w (1 + last_idx * type_slot_size pop_elem_tv);
+          popped <- read_storage_slot cx is_transient last_slot pop_elem_tv;
+          write_storage_slot cx is_transient last_slot pop_elem_tv
+            (default_value pop_elem_tv);
+          write_storage_slot cx is_transient elem_slot (BaseTV (UintT 256))
+            (IntV &last_idx);
+          return (SOME popped)
+        od
+      | (AppendOp v,ArrayTV app_elem_tv (Dynamic n)) => do
+          storage <- get_storage_backend cx is_transient;
+          stored_len <<- w2n (lookup_storage elem_slot storage);
+          check (stored_len < n) "append full storage array";
+          new_slot <<- elem_slot + n2w (1 + stored_len * type_slot_size app_elem_tv);
+          write_storage_slot cx is_transient new_slot app_elem_tv v;
+          write_storage_slot cx is_transient elem_slot (BaseTV (UintT 256))
+            (IntV &(stored_len + 1));
+          return NONE
+        od
+      | _ => do
+          current_val <- read_storage_slot cx is_transient elem_slot final_tv;
+          new_val <- lift_sum (assign_subscripts final_tv current_val remaining_subs ao);
+          write_storage_slot cx is_transient elem_slot final_tv new_val;
+          assign_result final_tv ao current_val remaining_subs
+        od
+   od) st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >> pop_assum mp_tac >>
+  once_rewrite_tac [vyperStateTheory.bind_def] >>
+  qabbrev_tac `rr = resolve_array_element cx is_transient base_slot
+                    (ArrayTV elem_tv bd) subs st` >>
+  PairCases_on `rr` >> Cases_on `rr0` >>
+  qpat_x_assum `Abbrev _` mp_tac >>
+  simp[markerTheory.Abbrev_def] >> strip_tac >> gvs[] >>
+  rpt (pairarg_tac >> gvs[]) >>
+  qpat_x_assum `(_,_) = resolve_array_element _ _ _ _ _ _`
+    (assume_tac o SYM) >>
+  imp_res_tac resolve_array_element_state >> gvs[] >>
+  Cases_on `final_tv` >> gvs[] >>
+  TRY (Cases_on `b` >> gvs[]) >>
+  Cases_on `ao` >> gvs[] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac storage_assignment_tail_logs >>
+  imp_res_tac array_pop_tail_logs >>
+  imp_res_tac array_append_tail_logs >>
+  pop_assum mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       AllCaseEqs()] >> rpt strip_tac >> gvs[] >>
+  imp_res_tac vyperStorageBackendTheory.get_storage_backend_state >>
+  imp_res_tac check_state >> imp_res_tac read_storage_slot_state >> gvs[] >>
+  imp_res_tac write_storage_slot_logs >> imp_res_tac return_state >> gvs[]
+QED
 Theorem case_stmt_return_some_logs[local]:
   (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
   !st res st'. eval_stmt cx (Return (SOME e)) st = (res,st') ==>

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -421,6 +421,36 @@ Proof
   imp_res_tac read_storage_slot_state >> imp_res_tac return_state >> gvs[]
 QED
 
+Theorem subscript_terminal_normalized_logs[local]:
+  (do v2 <- get_Value tv2;
+      arr_tv <- lift_option_type
+        (evaluate_type (get_tenv cx) (expr_type e1))
+        "Subscript array type";
+      check_array_bounds cx tv1 v2;
+      r <- lift_sum
+        (evaluate_subscript (get_tenv cx) arr_tv tv1 v2);
+      case r of
+        INL v => return v
+      | INR (is_transient,slot,tv) => do
+          v <- read_storage_slot cx is_transient slot tv;
+          return (Value v)
+        od
+   od) st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >> pop_assum mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_Value_state >> imp_res_tac lift_option_type_state >>
+  imp_res_tac check_array_bounds_state >> imp_res_tac lift_sum_state >> gvs[] >>
+  Cases_on `r` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def, AllCaseEqs()] >>
+  PairCases_on `y` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac read_storage_slot_state >> imp_res_tac return_state >> gvs[]
+QED
+
 Theorem new_variable_logs[local]:
   new_variable id tv v st = (res,st') ==> st'.logs = st.logs
 Proof

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -1509,14 +1509,13 @@ Theorem transfer_value_logs[local]:
   transfer_value fromAddr toAddr amount st = (res,st') ==>
   st'.logs = st.logs
 Proof
-  rpt strip_tac >>
-  qpat_x_assum `transfer_value _ _ _ _ = _` mp_tac >>
-  simp[vyperInterpreterTheory.transfer_value_def, vyperStateTheory.bind_def,
-       vyperStateTheory.ignore_bind_def, vyperStateTheory.get_accounts_def,
-       vyperStateTheory.update_accounts_def, vyperStateTheory.check_def,
-       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
-       vyperStateTheory.return_def, vyperStateTheory.raise_def, AllCaseEqs()] >>
-  rpt strip_tac >> gvs[]
+  rw[vyperInterpreterTheory.transfer_value_def, vyperStateTheory.bind_def,
+     vyperStateTheory.ignore_bind_def, vyperStateTheory.get_accounts_def,
+     vyperStateTheory.update_accounts_def, vyperStateTheory.check_def,
+     vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+     vyperStateTheory.return_def, vyperStateTheory.raise_def] >>
+  gvs[AllCaseEqs(), vyperStateTheory.return_def,
+      vyperStateTheory.raise_def]
 QED
 
 Theorem case_expr_send_logs[local]:

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -941,6 +941,73 @@ Proof
   irule log_extends_eq_logs >> gvs[]
 QED
 
+
+Theorem case_expr_pop_logs[local]:
+  (!st res st'. eval_base_target cx bt st = (res,st') ==>
+     log_extends st st') ==>
+  !st res st'. eval_expr cx (Pop ty bt) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  qpat_x_assum `!st res st'. eval_base_target _ _ _ = _ ==> _` drule >>
+  strip_tac >>
+  rpt (pairarg_tac >> gvs[]) >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+      vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac assign_target_logs >> imp_res_tac lift_option_type_state >>
+  imp_res_tac return_state >> gvs[] >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule log_extends_eq_logs >> gvs[]
+QED
+
+Theorem case_expr_builtin_logs[local]:
+  (!s0 x s1.
+     type_check (builtin_args_length_ok bt (LENGTH es)) "Builtin args" s0 =
+       (INL x,s1) /\ bt <> Len ==>
+     !st res st'. eval_exprs cx es st = (res,st') ==> log_extends st st') /\
+  (!s0 x s1.
+     type_check (builtin_args_length_ok bt (LENGTH es)) "Builtin args" s0 =
+       (INL x,s1) /\ bt = Len ==>
+     !st res st'. eval_expr cx (HD es) st = (res,st') ==> log_extends st st') ==>
+  !st res st'. eval_expr cx (Builtin ty bt es) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  pure_rewrite_tac[vyperStateTheory.ignore_bind_def] >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def, vyperStateTheory.lift_sum_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  Cases_on `bt = Len` >> gvs[] >>
+  TRY (gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+           vyperStateTheory.raise_def, AllCaseEqs()] >>
+       imp_res_tac toplevel_array_length_state >> gvs[] >>
+       first_x_assum (qspec_then `st` mp_tac) >>
+       simp[vyperStateTheory.check_def, vyperStateTheory.type_check_def,
+            vyperStateTheory.assert_def, vyperStateTheory.return_def] >> NO_TAC)
+  >> `!st res st'. eval_exprs cx es st = (res,st') ==>
+        log_extends st st'` by
+       (first_x_assum (qspec_then `st` mp_tac) >>
+        simp[vyperStateTheory.check_def, vyperStateTheory.type_check_def,
+             vyperStateTheory.assert_def, vyperStateTheory.return_def])
+  >> gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+         vyperStateTheory.raise_def, vyperStateTheory.get_accounts_def,
+         AllCaseEqs()]
+  >> BasicProvers.FULL_CASE_TAC
+  >> gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def]
+  >> first_x_assum drule >> simp[]
+QED
+
 Theorem case_stmt_return_some_logs[local]:
   (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
   !st res st'. eval_stmt cx (Return (SOME e)) st = (res,st') ==>
@@ -1255,6 +1322,470 @@ Proof
   simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
        vyperStateTheory.return_def, AllCaseEqs()] >>
   rpt strip_tac >> gvs[] >> first_x_assum drule >> simp[]
+QED
+
+Theorem ext_call_tail_log_extends[local]:
+  (do x <- assert success (Error (RuntimeError "ExtCall reverted"));
+      x <- update_accounts (K accounts');
+      x <- update_transient (K tStorage');
+      x <- append_logs emitted_logs;
+      if returnData = [] /\ IS_SOME drv then eval_expr cx (THE drv)
+      else do
+        ret_val <- lift_sum_runtime
+          (evaluate_abi_decode_return tenv ret_type returnData);
+        return (Value ret_val)
+      od
+   od) st = (res,st') ==>
+  (!e. drv = SOME e ==>
+     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  Cases_on `success` >> Cases_on `drv` >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.update_accounts_def, vyperStateTheory.update_transient_def,
+       vyperInterpreterTheory.append_logs_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_append] >>
+  Cases_on `returnData = []` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def, AllCaseEqs()] >>
+  TRY (imp_res_tac lift_sum_runtime_state >> gvs[] >>
+       simp[log_extends_def, rich_listTheory.IS_PREFIX_APPEND] >> NO_TAC) >>
+  qpat_x_assum `!s0 r s1. eval_expr cx x s0 = (r,s1) ==> _`
+    (qspecl_then [`st with <|logs := st.logs ++ emitted_logs;
+                    accounts := accounts'; tStorage := tStorage'|>`,
+                  `res`, `st'`] mp_tac) >>
+  simp[] >> strip_tac >>
+  irule log_extends_trans >> qexists_tac `st with <|logs := st.logs ++ emitted_logs;
+    accounts := accounts'; tStorage := tStorage'|>` >>
+  simp[log_extends_def, rich_listTheory.IS_PREFIX_APPEND]
+QED
+Theorem ext_call_result_tail_log_extends[local]:
+  (!e. drv = SOME e ==>
+     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) /\
+  (if returnData = [] /\ IS_SOME drv then eval_expr cx (THE drv)
+   else do
+     ret_val <- lift_sum_runtime
+       (evaluate_abi_decode_return tenv ret_type returnData);
+     return (Value ret_val)
+   od)
+    (st with <|logs := st.logs ++ emitted_logs;
+               accounts := accounts'; tStorage := tStorage'|>) = (res,st') ==>
+  log_extends st st'
+Proof
+  Cases_on `drv` >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  Cases_on `returnData = []` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def, AllCaseEqs()] >>
+  TRY (imp_res_tac lift_sum_runtime_state >> gvs[] >>
+       simp[log_extends_def, rich_listTheory.IS_PREFIX_APPEND] >> NO_TAC) >>
+  qpat_x_assum `!s0 r s1. eval_expr cx x s0 = (r,s1) ==> _`
+    (qspecl_then [`st with <|logs := st.logs ++ emitted_logs;
+                    accounts := accounts'; tStorage := tStorage'|>`,
+                  `res`, `st'`] mp_tac) >>
+  simp[] >> strip_tac >>
+  irule log_extends_trans >>
+  qexists_tac `st with <|logs := st.logs ++ emitted_logs;
+    accounts := accounts'; tStorage := tStorage'|>` >>
+  simp[log_extends_def, rich_listTheory.IS_PREFIX_APPEND]
+QED
+
+Definition ext_call_finish_def:
+  ext_call_finish cx drv ret_type tenv result =
+    (\(success,returnData,accounts',tStorage',emitted_logs).
+      do
+        x <- assert success (Error (RuntimeError "ExtCall reverted"));
+        x <- update_accounts (K accounts');
+        x <- update_transient (K tStorage');
+        x <- append_logs emitted_logs;
+        if returnData = [] /\ IS_SOME drv then eval_expr cx (THE drv)
+        else do
+          ret_val <- lift_sum_runtime
+            (evaluate_abi_decode_return tenv ret_type returnData);
+          return (Value ret_val)
+        od
+      od) result
+End
+
+Theorem ext_call_finish_fold[local]:
+  (\(success,returnData,accounts',tStorage',emitted_logs).
+    do
+      x <- assert success (Error (RuntimeError "ExtCall reverted"));
+      x <- update_accounts (K accounts');
+      x <- update_transient (K tStorage');
+      x <- append_logs emitted_logs;
+      if returnData = [] /\ IS_SOME drv then eval_expr cx (THE drv)
+      else do
+        ret_val <- lift_sum_runtime
+          (evaluate_abi_decode_return tenv ret_type returnData);
+        return (Value ret_val)
+      od
+    od) result = ext_call_finish cx drv ret_type tenv result
+Proof
+  PairCases_on `result` >> simp[ext_call_finish_def]
+QED
+
+Theorem ext_call_finish_check_fold[local]:
+  (\(success,returnData,accounts',tStorage',emitted_logs).
+    do
+      check success "ExtCall reverted";
+      update_accounts (K accounts');
+      update_transient (K tStorage');
+      append_logs emitted_logs;
+      if returnData = [] /\ IS_SOME drv then eval_expr cx (THE drv)
+      else do
+        ret_val <- lift_sum_runtime
+          (evaluate_abi_decode_return tenv ret_type returnData);
+        return (Value ret_val)
+      od
+    od) result = ext_call_finish cx drv ret_type tenv result
+Proof
+  PairCases_on `result` >>
+  simp[ext_call_finish_def, vyperStateTheory.check_def,
+       vyperStateTheory.ignore_bind_def]
+QED
+
+Theorem ext_call_finish_log_extends[local]:
+  ext_call_finish cx drv ret_type tenv result st = (res,st') ==>
+  (!e. drv = SOME e ==>
+     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  PairCases_on `result` >> simp[ext_call_finish_def] >>
+  metis_tac[ext_call_tail_log_extends]
+QED
+
+Theorem ext_call_result_log_extends[local]:
+  ((\(success,returnData,accounts',tStorage',emitted_logs).
+      do
+        x <- assert success (Error (RuntimeError "ExtCall reverted"));
+        x <- update_accounts (K accounts');
+        x <- update_transient (K tStorage');
+        x <- append_logs emitted_logs;
+        if returnData = [] /\ IS_SOME drv then eval_expr cx (THE drv)
+        else do
+          ret_val <- lift_sum_runtime
+            (evaluate_abi_decode_return tenv ret_type returnData);
+          return (Value ret_val)
+        od
+      od) result st = (res,st')) ==>
+  (!e. drv = SOME e ==>
+     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rewrite_tac[ext_call_finish_fold] >>
+  metis_tac[ext_call_finish_log_extends]
+QED
+
+Theorem run_ext_call_lift_option_state[local]:
+  lift_option
+    (run_ext_call caller target calldata value_opt accounts tStorage params)
+    msg st = (res,st') ==>
+  st' = st
+Proof
+  metis_tac[lift_option_state]
+QED
+
+Theorem bind_state_preserving_log_extends[local]:
+  (!out s1. m st = (out,s1) ==> s1 = st) /\
+  (!x r s1. k x st = (r,s1) ==> log_extends st s1) /\
+  (do x <- m; k x od) st = (res,st') ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  Cases_on `m st` >>
+  gvs[vyperStateTheory.bind_def] >>
+  Cases_on `q` >> gvs[log_extends_refl] >>
+  metis_tac[]
+QED
+
+Definition ext_call_prepare_def:
+  ext_call_prepare cx isc func_name arg_types vs =
+    do
+      type_check (vs <> []) "ExtCall no target";
+      target_addr <- lift_option_type (dest_AddressV (HD vs))
+                       "ExtCall target not address";
+      (value_opt,arg_vals) <- if (isc:bool) then return (NONE,TL vs)
+        else do
+          type_check (TL vs <> []) "ExtCall no value";
+          v <- lift_option_type (dest_NumV (HD (TL vs)))
+                 "ExtCall value not int";
+          return (SOME v,TL (TL vs))
+        od;
+      tenv <<- get_tenv cx;
+      calldata <- lift_option_type
+        (build_ext_calldata tenv func_name arg_types arg_vals)
+        "ExtCall build_calldata";
+      accounts <- get_accounts;
+      check (~NULL (lookup_account target_addr accounts).code)
+        "ExtCall target has no code";
+      tStorage <- get_transient_storage;
+      result <- lift_option
+        (run_ext_call cx.txn.target target_addr calldata value_opt accounts
+           tStorage (vyper_to_tx_params cx.txn)) "ExtCall run failed";
+      return (tenv,result)
+    od
+End
+
+Theorem ext_call_prepare_state[local]:
+  ext_call_prepare cx isc func_name arg_types vs st = (out,st') ==>
+  st' = st
+Proof
+  Cases_on `isc` >>
+  simp[ext_call_prepare_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  gvs[vyperStateTheory.assert_def, vyperStateTheory.check_def,
+      vyperStateTheory.type_check_def, vyperStateTheory.raise_def,
+      vyperStateTheory.return_def] >>
+  imp_res_tac lift_option_type_state >>
+  imp_res_tac run_ext_call_lift_option_state >>
+  gvs[] >>
+  qpat_x_assum `(do _ od) _ = _` mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       vyperStateTheory.check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  gvs[vyperStateTheory.assert_def, vyperStateTheory.check_def,
+      vyperStateTheory.raise_def, vyperStateTheory.return_def] >>
+  imp_res_tac lift_option_type_state >>
+  imp_res_tac run_ext_call_lift_option_state >>
+  gvs[]
+QED
+
+
+Definition ext_call_after_args_with_def:
+  ext_call_after_args_with cx isc func_name arg_types vs k =
+    do
+      type_check (vs <> []) "ExtCall no target";
+      target_addr <- lift_option_type (dest_AddressV (HD vs))
+                       "ExtCall target not address";
+      (value_opt,arg_vals) <- if (isc:bool) then return (NONE,TL vs)
+        else do
+          type_check (TL vs <> []) "ExtCall no value";
+          v <- lift_option_type (dest_NumV (HD (TL vs)))
+                 "ExtCall value not int";
+          return (SOME v,TL (TL vs))
+        od;
+      tenv <<- get_tenv cx;
+      calldata <- lift_option_type
+        (build_ext_calldata tenv func_name arg_types arg_vals)
+        "ExtCall build_calldata";
+      accounts <- get_accounts;
+      check (~NULL (lookup_account target_addr accounts).code)
+        "ExtCall target has no code";
+      tStorage <- get_transient_storage;
+      result <- lift_option
+        (run_ext_call cx.txn.target target_addr calldata value_opt accounts
+           tStorage (vyper_to_tx_params cx.txn)) "ExtCall run failed";
+      k tenv result
+    od
+End
+
+Theorem ext_call_after_args_with_log_extends_snd[local]:
+  (!tenv result s0.
+     log_extends s0 (SND (k tenv result s0))) ==>
+  !st. log_extends st
+    (SND (ext_call_after_args_with cx isc func_name arg_types vs k st))
+Proof
+  Cases_on `isc` >> rpt strip_tac >>
+  simp[ext_call_after_args_with_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt (CASE_TAC >> gvs[log_extends_refl]) >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       vyperStateTheory.check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt (CASE_TAC >> gvs[log_extends_refl]) >>
+  imp_res_tac lift_option_type_state >>
+  imp_res_tac run_ext_call_lift_option_state >>
+  gvs[log_extends_refl]
+QED
+
+Theorem ext_call_after_args_fold[local]:
+  (do type_check (vs <> []) "ExtCall no target";
+      target_addr <- lift_option_type (dest_AddressV (HD vs))
+                       "ExtCall target not address";
+      (value_opt,arg_vals) <- if (isc:bool) then return (NONE,TL vs)
+        else do
+          type_check (TL vs <> []) "ExtCall no value";
+          v <- lift_option_type (dest_NumV (HD (TL vs)))
+                 "ExtCall value not int";
+          return (SOME v,TL (TL vs))
+        od;
+      calldata <- lift_option_type
+        (build_ext_calldata (get_tenv cx) func_name arg_types arg_vals)
+        "ExtCall build_calldata";
+      accounts <- get_accounts;
+      check (~NULL (lookup_account target_addr accounts).code)
+        "ExtCall target has no code";
+      tStorage <- get_transient_storage;
+      result <- lift_option
+        (run_ext_call cx.txn.target target_addr calldata value_opt accounts
+           tStorage (vyper_to_tx_params cx.txn)) "ExtCall run failed";
+      (\(success,returnData,accounts',tStorage',emitted_logs).
+        do
+          check success "ExtCall reverted";
+          update_accounts (K accounts');
+          update_transient (K tStorage');
+          append_logs emitted_logs;
+          if returnData = [] /\ IS_SOME drv then eval_expr cx (THE drv)
+          else do
+            ret_val <- lift_sum_runtime
+              (evaluate_abi_decode_return (get_tenv cx) ret_type returnData);
+            return (Value ret_val)
+          od
+        od) result
+   od) =
+  ext_call_after_args_with cx isc func_name arg_types vs
+    (\tenv result. ext_call_finish cx drv ret_type tenv result)
+Proof
+  simp[ext_call_after_args_with_def, ext_call_finish_def,
+       vyperStateTheory.check_def, vyperStateTheory.ignore_bind_def]
+QED
+
+Theorem ext_call_after_args_log_extends[local]:
+  (do type_check (vs <> []) "ExtCall no target";
+      target_addr <- lift_option_type (dest_AddressV (HD vs))
+                       "ExtCall target not address";
+      (value_opt,arg_vals) <- if (isc:bool) then return (NONE,TL vs)
+        else do
+          type_check (TL vs <> []) "ExtCall no value";
+          v <- lift_option_type (dest_NumV (HD (TL vs)))
+                 "ExtCall value not int";
+          return (SOME v,TL (TL vs))
+        od;
+      calldata <- lift_option_type
+        (build_ext_calldata (get_tenv cx) func_name arg_types arg_vals)
+        "ExtCall build_calldata";
+      accounts <- get_accounts;
+      check (~NULL (lookup_account target_addr accounts).code)
+        "ExtCall target has no code";
+      tStorage <- get_transient_storage;
+      result <- lift_option
+        (run_ext_call cx.txn.target target_addr calldata value_opt accounts
+           tStorage (vyper_to_tx_params cx.txn)) "ExtCall run failed";
+      (\(success,returnData,accounts',tStorage',emitted_logs).
+        do
+          check success "ExtCall reverted";
+          update_accounts (K accounts');
+          update_transient (K tStorage');
+          append_logs emitted_logs;
+          if returnData = [] /\ IS_SOME drv then eval_expr cx (THE drv)
+          else do
+            ret_val <- lift_sum_runtime
+              (evaluate_abi_decode_return (get_tenv cx) ret_type returnData);
+            return (Value ret_val)
+          od
+        od) result
+   od) st = (res,st') ==>
+  (!e. drv = SOME e ==>
+     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  `!tenv result s0.
+     log_extends s0
+       (SND (ext_call_finish cx drv ret_type tenv result s0))` by
+    (rpt gen_tac >>
+     Cases_on `ext_call_finish cx drv ret_type tenv result s0` >>
+     simp[] >>
+     drule ext_call_finish_log_extends >>
+     disch_then irule >>
+     first_assum ACCEPT_TAC) >>
+  qpat_x_assum `(do _ od) _ = _` mp_tac >>
+  pure_rewrite_tac[ext_call_finish_check_fold, ext_call_after_args_fold] >>
+  strip_tac >>
+  `log_extends st
+     (SND (ext_call_after_args_with cx isc func_name arg_types vs
+       (\tenv result. ext_call_finish cx drv ret_type tenv result) st))` by
+    (irule ext_call_after_args_with_log_extends_snd >> simp[]) >>
+  gvs[]
+QED
+
+
+Theorem case_expr_ext_call_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) /\
+  (!e. drv = SOME e ==>
+     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'.
+    eval_expr cx (Call ty (ExtCall static (func_name,arg_types,ret_type))
+                         es drv) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def,
+       vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  drule ext_call_after_args_log_extends >>
+  disch_then drule >>
+  simp[]
+QED
+
+Theorem raw_call_tail_log_extends[local]:
+  (do x <- update_accounts (K accounts');
+      x <- update_transient (K tStorage');
+      x <- append_logs emitted_logs;
+      if flags.rcf_revert_on_failure then do
+        x <- check success "raw_call reverted";
+        if flags.rcf_max_outsize = 0 then return (Value NoneV)
+        else return (Value (BytesV (TAKE flags.rcf_max_outsize returnData)))
+      od else if flags.rcf_max_outsize = 0 then return (Value (BoolV success))
+      else return (Value (ArrayV (TupleV
+        [BoolV success; BytesV (TAKE flags.rcf_max_outsize returnData)])))
+   od) st = (res,st') ==> log_extends st st'
+Proof
+  Cases_on `flags.rcf_revert_on_failure` >> Cases_on `success` >>
+  Cases_on `flags.rcf_max_outsize = 0` >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.update_accounts_def, vyperStateTheory.update_transient_def,
+       vyperInterpreterTheory.append_logs_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       log_extends_def, rich_listTheory.IS_PREFIX_APPEND] >>
+  rpt strip_tac >> gvs[rich_listTheory.IS_PREFIX_APPEND]
+QED
+
+Theorem case_expr_raw_call_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (Call ty (RawCallTarget flags) es drv) st =
+    (res,st') ==> log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  pure_rewrite_tac[vyperStateTheory.ignore_bind_def] >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.check_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       vyperStateTheory.get_accounts_def,
+       vyperStateTheory.get_transient_storage_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  imp_res_tac lift_option_type_state >> imp_res_tac lift_option_state >> gvs[] >>
+  rpt (pairarg_tac >> gvs[]) >>
+  imp_res_tac raw_call_tail_log_extends >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  irule raw_call_tail_log_extends >>
+  simp[vyperStateTheory.check_def] >>
+  qexistsl [`accounts'`, `emitted_logs`, `flags`, `res`, `returnData`,
+            `success`, `tStorage'`] >>
+  first_assum ACCEPT_TAC
 QED
 
 Theorem case_expr_raw_log_logs[local]:

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -442,6 +442,49 @@ Proof
   imp_res_tac assign_result_state >> gvs[]
 QED
 
+
+Theorem array_pop_tail_logs[local]:
+  (do storage <- get_storage_backend cx is_transient;
+      stored_len <<- w2n (lookup_storage elem_slot storage);
+      check (stored_len > 0) "pop empty storage array";
+      last_idx <<- stored_len - 1;
+      last_slot <<- elem_slot + n2w (1 + last_idx * type_slot_size pop_elem_tv);
+      popped <- read_storage_slot cx is_transient last_slot pop_elem_tv;
+      write_storage_slot cx is_transient last_slot pop_elem_tv
+        (default_value pop_elem_tv);
+      write_storage_slot cx is_transient elem_slot (BaseTV (UintT 256))
+        (IntV &last_idx);
+      return (SOME popped)
+   od) st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >> pop_assum mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac vyperStorageBackendTheory.get_storage_backend_state >>
+  imp_res_tac check_state >> imp_res_tac read_storage_slot_state >> gvs[] >>
+  imp_res_tac write_storage_slot_logs >> imp_res_tac return_state >> gvs[]
+QED
+
+Theorem array_append_tail_logs[local]:
+  (do storage <- get_storage_backend cx is_transient;
+      stored_len <<- w2n (lookup_storage elem_slot storage);
+      check (stored_len < n) "append full storage array";
+      new_slot <<- elem_slot + n2w (1 + stored_len * type_slot_size app_elem_tv);
+      write_storage_slot cx is_transient new_slot app_elem_tv v;
+      write_storage_slot cx is_transient elem_slot (BaseTV (UintT 256))
+        (IntV &(stored_len + 1));
+      return NONE
+   od) st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >> pop_assum mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac vyperStorageBackendTheory.get_storage_backend_state >>
+  imp_res_tac check_state >> imp_res_tac write_storage_slot_logs >>
+  imp_res_tac return_state >> gvs[]
+QED
 Theorem case_stmt_return_some_logs[local]:
   (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
   !st res st'. eval_stmt cx (Return (SOME e)) st = (res,st') ==>

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -479,6 +479,58 @@ Proof
   imp_res_tac subscript_terminal_normalized_logs >>
   sym_tac >> first_assum ACCEPT_TAC
 QED
+
+Theorem subscript_after_e1_logs_forward[local]:
+  (do tv2 <- eval_expr cx e2;
+      v2 <- get_Value tv2;
+      arr_tv <- lift_option_type
+        (evaluate_type (get_tenv cx) (expr_type e1))
+        "Subscript array type";
+      check_array_bounds cx tv1 v2;
+      r <- lift_sum
+        (evaluate_subscript (get_tenv cx) arr_tv tv1 v2);
+      case r of
+        INL v => return v
+      | INR (is_transient,slot,tv) => do
+          v <- read_storage_slot cx is_transient slot tv;
+          return (Value v)
+        od
+   od) st = (res,st') ==>
+  (!s0 r s1. eval_expr cx e2 s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  drule bind_log_extends_forward >>
+  disch_then irule >>
+  conj_tac >- metis_tac[] >>
+  rpt strip_tac >> gvs[] >>
+  irule log_extends_eq_logs >>
+  imp_res_tac subscript_terminal_normalized_logs >>
+  sym_tac >> first_assum ACCEPT_TAC
+QED
+
+Theorem case_expr_subscript_logs[local]:
+  (!s0 tv1 s1. eval_expr cx e1 s0 = (INL tv1,s1) ==>
+     !s2 r s3. eval_expr cx e2 s2 = (r,s3) ==> log_extends s2 s3) /\
+  (!s0 r s1. eval_expr cx e1 s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'.
+    eval_expr cx (Subscript ty e1 e2) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ (Subscript _ _ _) _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.evaluate_def] >>
+  strip_tac >>
+  drule bind_log_extends_forward >>
+  disch_then irule >>
+  conj_tac
+  >- metis_tac[] >>
+  rpt strip_tac >> gvs[] >>
+  drule subscript_after_e1_logs_forward >>
+  disch_then irule >>
+  qpat_x_assum `!s0 tv1 s1. eval_expr _ e1 s0 = (INL tv1,s1) ==> _` drule >>
+  simp[]
+QED
 Theorem new_variable_logs[local]:
   new_variable id tv v st = (res,st') ==> st'.logs = st.logs
 Proof
@@ -614,6 +666,164 @@ Proof
   imp_res_tac vyperStorageBackendTheory.get_storage_backend_state >>
   imp_res_tac check_state >> imp_res_tac read_storage_slot_state >> gvs[] >>
   imp_res_tac write_storage_slot_logs >> imp_res_tac return_state >> gvs[]
+QED
+
+Theorem assign_target_toplevel_logs[local]:
+  assign_target cx (BaseTargetV (TopLevelVar src id) subs) ao st = (res,st') ==>
+  st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  Cases_on `lookup_global cx src (string_to_num id) st` >>
+  Cases_on `q` >>
+  imp_res_tac lookup_global_state >>
+  pop_assum SUBST_ALL_TAC
+  >- (Cases_on `x`
+      >- (qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+          simp[Once vyperStateTheory.assign_target_def,
+               vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+               vyperStateTheory.return_def, vyperStateTheory.raise_def,
+               LET_THM, pairTheory.PAIR, AllCaseEqs()] >>
+          rpt strip_tac >> gvs[] >>
+          imp_res_tac lift_option_type_state >> imp_res_tac lift_sum_state >>
+          imp_res_tac set_global_logs >> imp_res_tac assign_result_state >> gvs[])
+      >- (qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+          simp[Once vyperStateTheory.assign_target_def,
+               vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+               vyperStateTheory.return_def, vyperStateTheory.raise_def,
+               LET_THM, pairTheory.PAIR, AllCaseEqs()] >>
+          rpt strip_tac >> gvs[] >>
+          rpt (pairarg_tac >> gvs[]) >>
+          pop_assum mp_tac >>
+          simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+               AllCaseEqs()] >>
+          rpt strip_tac >> gvs[] >> rpt (pairarg_tac >> gvs[]) >>
+          pop_assum mp_tac >>
+          simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+               AllCaseEqs()] >>
+          rpt strip_tac >> gvs[] >>
+          imp_res_tac lift_option_type_state >>
+          imp_res_tac read_storage_slot_state >> imp_res_tac lift_sum_state >>
+          imp_res_tac write_storage_slot_logs >>
+          imp_res_tac assign_result_state >> gvs[])
+      >> (Cases_on `lift_option_type (get_module_code cx src)
+                       "assign_target get_module_code" st` >>
+          Cases_on `q` >>
+          imp_res_tac lift_option_type_state >>
+          pop_assum SUBST_ALL_TAC
+          >- (Cases_on `resolve_array_element cx b c (ArrayTV t b0)
+                         (REVERSE subs) st` >>
+              Cases_on `q` >>
+              imp_res_tac resolve_array_element_state >>
+              pop_assum SUBST_ALL_TAC
+              >- (PairCases_on `x'` >> Cases_on `x'1` >>
+                  TRY (Cases_on `b'` >> Cases_on `ao`) >>
+                  qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+                  simp[Once vyperStateTheory.assign_target_def,
+                       vyperStateTheory.bind_def,
+                       vyperStateTheory.ignore_bind_def,
+                       vyperStateTheory.return_def,
+                       vyperStateTheory.raise_def,
+                       LET_THM, pairTheory.PAIR, AllCaseEqs()] >>
+                  rpt strip_tac >> gvs[] >>
+                  imp_res_tac storage_assignment_tail_logs >>
+                  imp_res_tac array_pop_tail_logs >>
+                  imp_res_tac array_append_tail_logs >>
+                  imp_res_tac vyperStorageBackendTheory.get_storage_backend_state >>
+                  imp_res_tac check_state >>
+                  imp_res_tac read_storage_slot_state >>
+                  imp_res_tac lift_sum_state >>
+                  imp_res_tac write_storage_slot_logs >>
+                  imp_res_tac assign_result_state >>
+                  imp_res_tac return_state >> gvs[])
+              >> (qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+                  simp[Once vyperStateTheory.assign_target_def,
+                       vyperStateTheory.bind_def,
+                       vyperStateTheory.ignore_bind_def,
+                       vyperStateTheory.return_def,
+                       vyperStateTheory.raise_def,
+                       LET_THM, pairTheory.PAIR] >>
+                  strip_tac >> gvs[]))
+          >> (qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+              simp[Once vyperStateTheory.assign_target_def,
+                   vyperStateTheory.bind_def, vyperStateTheory.return_def,
+                   vyperStateTheory.raise_def, LET_THM, pairTheory.PAIR] >>
+              strip_tac >> gvs[])))
+  >> (qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+      simp[Once vyperStateTheory.assign_target_def,
+           vyperStateTheory.bind_def, vyperStateTheory.return_def,
+           vyperStateTheory.raise_def, LET_THM, pairTheory.PAIR] >>
+      strip_tac >> gvs[])
+QED
+
+Theorem assign_target_logs_mutual[local]:
+  (!cx gv ao st res st'.
+     assign_target cx gv ao st = (res,st') ==> st'.logs = st.logs) /\
+  (!cx gvs vs st res st'.
+     assign_targets cx gvs vs st = (res,st') ==> st'.logs = st.logs)
+Proof
+  ho_match_mp_tac vyperStateTheory.assign_target_ind >> rpt conj_tac >> rpt gen_tac
+  (* ScopedVar *)
+  >- (rpt strip_tac >>
+      gvs[vyperStateTheory.assign_target_def, vyperStateTheory.bind_def,
+          vyperStateTheory.get_scopes_def, vyperStateTheory.return_def,
+          vyperStateTheory.lift_option_def] >>
+      Cases_on `find_containing_scope (string_to_num id) st.scopes` >>
+      gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def] >>
+      PairCases_on `x` >>
+      Cases_on `assign_subscripts x2.type x2.value (REVERSE is) ao` >>
+      gvs[vyperStateTheory.return_def, vyperStateTheory.raise_def] >>
+      gvs[vyperStateTheory.assign_target_def, vyperStateTheory.bind_def,
+          vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+          vyperStateTheory.raise_def, vyperStateTheory.lift_option_def,
+          vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+          vyperStateTheory.lift_sum_def, vyperStateTheory.set_scopes_def,
+          AllCaseEqs()] >>
+      imp_res_tac lift_sum_state >> imp_res_tac assign_result_state >> gvs[])
+  (* TopLevelVar *)
+  >- (rpt strip_tac >> imp_res_tac assign_target_toplevel_logs)
+  (* ImmutableVar *)
+  >- (rpt strip_tac >>
+      qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+      simp[Once vyperStateTheory.assign_target_def,
+           vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+           vyperStateTheory.return_def, vyperStateTheory.raise_def,
+           AllCaseEqs()] >>
+      rpt strip_tac >> gvs[] >>
+      imp_res_tac get_immutables_state >> imp_res_tac lift_option_type_state >>
+      imp_res_tac lift_sum_state >> gvs[] >>
+      imp_res_tac set_immutable_logs >> imp_res_tac assign_result_state >> gvs[])
+  (* TupleTargetV success *)
+  >- (rpt strip_tac >>
+      qpat_x_assum `assign_target _ _ _ _ = _` mp_tac >>
+      simp[Once vyperStateTheory.assign_target_def,
+           vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+           vyperStateTheory.return_def, vyperStateTheory.raise_def,
+           AllCaseEqs()] >>
+      rpt strip_tac >> gvs[] >>
+      imp_res_tac type_check_state >> gvs[] >>
+      first_x_assum drule >> imp_res_tac return_state >> gvs[])
+  (* Constructor mismatch, base, cons, and fallback cases. *)
+  >> rpt strip_tac
+  >> pop_assum mp_tac
+  >> simp[Once vyperStateTheory.assign_target_def,
+          vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+          vyperStateTheory.return_def, vyperStateTheory.raise_def,
+          AllCaseEqs()]
+  >> rpt strip_tac >> gvs[]
+  >> TRY (first_x_assum drule >> gvs[] >> NO_TAC)
+  >> imp_res_tac return_state >> gvs[]
+QED
+
+Theorem assign_target_logs[local]:
+  assign_target cx gv ao st = (res,st') ==> st'.logs = st.logs
+Proof
+  metis_tac[cj 1 assign_target_logs_mutual]
+QED
+
+Theorem assign_targets_logs[local]:
+  assign_targets cx gvs vs st = (res,st') ==> st'.logs = st.logs
+Proof
+  metis_tac[cj 2 assign_target_logs_mutual]
 QED
 Theorem case_stmt_return_some_logs[local]:
   (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -451,6 +451,34 @@ Proof
   imp_res_tac read_storage_slot_state >> imp_res_tac return_state >> gvs[]
 QED
 
+
+Theorem subscript_after_e1_logs[local]:
+  (!s0 r s1. eval_expr cx e2 s0 = (r,s1) ==> log_extends s0 s1) /\
+  (do tv2 <- eval_expr cx e2;
+      v2 <- get_Value tv2;
+      tenv <<- get_tenv cx;
+      arr_tv <- lift_option_type (evaluate_type tenv (expr_type e1))
+                   "Subscript array type";
+      check_array_bounds cx tv1 v2;
+      r <- lift_sum (evaluate_subscript tenv arr_tv tv1 v2);
+      case r of
+        INL v => return v
+      | INR (is_transient,slot,tv) => do
+          v <- read_storage_slot cx is_transient slot tv;
+          return (Value v)
+        od
+   od) st = (res,st') ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  drule bind_log_extends_forward >>
+  disch_then irule >>
+  conj_tac >- metis_tac[] >>
+  rpt strip_tac >> gvs[] >>
+  irule log_extends_eq_logs >>
+  imp_res_tac subscript_terminal_normalized_logs >>
+  sym_tac >> first_assum ACCEPT_TAC
+QED
 Theorem new_variable_logs[local]:
   new_variable id tv v st = (res,st') ==> st'.logs = st.logs
 Proof

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -2544,7 +2544,14 @@ local
     in
       depth > 1 andalso head = name
     end handle _ => false
+
+  fun specialize_guard_then 0 ttac th = ttac th
+    | specialize_guard_then n ttac th =
+        first_assum (fn ath =>
+          specialize_guard_then (n - 1) ttac
+            (MATCH_MP (PURE_REWRITE_RULE [GSYM AND_IMP_INTRO] th) ath))
 in
+  val specialize_guard_then = specialize_guard_then
   val is_guarded_eval_exprs_ih =
     is_guarded_eval_ih "vyperInterpreter$eval_exprs"
   val is_guarded_eval_stmts_ih =
@@ -2553,6 +2560,16 @@ in
     ((BasicProvers.TOP_CASE_TAC ORELSE ALL_TAC) g)
 end
 
+
+Theorem conjunction_guard_specialize_probe[local]:
+  (!x y. f x = a /\ g y = b ==> P x y) ==>
+  f u = a ==>
+  g v = b ==>
+  P u v
+Proof
+  rpt strip_tac >>
+  first_x_assum (specialize_guard_then 2 MATCH_ACCEPT_TAC)
+QED
 Resume eval_mutual_log_extends[IntCall]:
   rpt gen_tac >> strip_tac >>
   rewrite_tac[Once vyperInterpreterTheory.evaluate_def] >>

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -426,6 +426,22 @@ Proof
       vyperStateTheory.raise_def]
 QED
 
+Theorem storage_assignment_tail_logs[local]:
+  (do current_val <- read_storage_slot cx tr slot tv;
+      new_val <- lift_sum (assign_subscripts tv current_val subs ao);
+      write_storage_slot cx tr slot tv new_val;
+      assign_result tv ao current_val subs
+   od) st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >> pop_assum mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac read_storage_slot_state >> imp_res_tac lift_sum_state >> gvs[] >>
+  imp_res_tac write_storage_slot_logs >>
+  imp_res_tac assign_result_state >> gvs[]
+QED
+
 Theorem case_stmt_return_some_logs[local]:
   (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
   !st res st'. eval_stmt cx (Return (SOME e)) st = (res,st') ==>

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -1,7 +1,7 @@
 Theory vyperLogPreservation
 
 Ancestors
-  vyperCall
+  vyperCall vyperStatePreservation
 
 Definition log_extends_def:
   log_extends (st:evaluation_state) (st':evaluation_state) <=>
@@ -70,5 +70,738 @@ Proof
   Cases_on `q` >> gvs[] >>
   metis_tac[log_extends_trans]
 QED
+
+Theorem case_eval_stmts_nil_logs[local]:
+  eval_stmts cx [] st = (res,st') ==> log_extends st st'
+Proof
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.return_def, log_extends_refl]
+QED
+
+Theorem case_eval_stmts_cons_logs[local]:
+  (!s0 x s1. eval_stmt cx s s0 = (INL x,s1) ==>
+     !s2 r s3. eval_stmts cx ss s2 = (r,s3) ==> log_extends s2 s3) /\
+  (!s0 r s1. eval_stmt cx s s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmts cx (s::ss) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmts _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  metis_tac[log_extends_trans]
+QED
+
+Theorem case_eval_targets_nil_logs[local]:
+  eval_targets cx [] st = (res,st') ==> log_extends st st'
+Proof
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.return_def, log_extends_refl]
+QED
+
+Theorem case_eval_targets_cons_logs[local]:
+  (!s0 r s1. eval_target cx g s0 = (r,s1) ==> log_extends s0 s1) /\
+  (!s0 gv s1. eval_target cx g s0 = (INL gv,s1) ==>
+     !s2 r s3. eval_targets cx gs s2 = (r,s3) ==> log_extends s2 s3) ==>
+  !st res st'. eval_targets cx (g::gs) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_targets _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  rpt (first_x_assum drule >> strip_tac >> gvs[]) >>
+  metis_tac[log_extends_trans]
+QED
+
+Theorem case_target_base_logs[local]:
+  (!s0 r s1. eval_base_target cx bt s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_target cx (BaseTarget bt) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_target _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def, AllCaseEqs()] >>
+  strip_tac >> gvs[] >>
+  Cases_on `x` >> gvs[vyperStateTheory.return_def] >>
+  first_x_assum drule >> simp[]
+QED
+
+Theorem case_target_tuple_logs[local]:
+  (!s0 r s1. eval_targets cx gs s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_target cx (TupleTarget gs) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_target _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def, AllCaseEqs(),
+       vyperStateTheory.return_def] >>
+  metis_tac[]
+QED
+Theorem case_iterator_array_logs[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_iterator cx (Array e) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_iterator _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs(), log_extends_def] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac materialise_state >>
+  imp_res_tac lift_option_type_state >> gvs[] >>
+  first_x_assum drule >> simp[] >> strip_tac >>
+  qpat_x_assum `log_extends _ _` mp_tac >>
+  simp[log_extends_def]
+QED
+
+Theorem case_iterator_range_logs[local]:
+  (!s0 r s1. eval_expr cx e1 s0 = (r,s1) ==> log_extends s0 s1) /\
+  (!s0 r s1. eval_expr cx e2 s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_iterator cx (Range e1 e2) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_iterator _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_Value_state >> imp_res_tac lift_sum_state >> gvs[] >>
+  rpt (first_x_assum drule >> strip_tac >> gvs[]) >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+
+Theorem case_eval_for_nil_logs[local]:
+  eval_for cx tyv nm body [] st = (res,st') ==> log_extends st st'
+Proof
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.return_def,
+       log_extends_refl]
+QED
+
+Theorem push_scope_with_var_log_extends[local]:
+  push_scope_with_var nm ty v st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >>
+  gvs[vyperStateTheory.push_scope_with_var_def, vyperStateTheory.return_def] >>
+  irule log_extends_eq_logs >> simp[]
+QED
+
+Theorem pop_scope_log_extends[local]:
+  pop_scope st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >>
+  gvs[vyperStateTheory.pop_scope_def, vyperStateTheory.return_def,
+      vyperStateTheory.raise_def, AllCaseEqs()] >>
+  irule log_extends_eq_logs >> simp[]
+QED
+
+Theorem try_body_log_extends[local]:
+  (!s0 x s1. push_scope_with_var nm tyv v s0 = (INL x,s1) ==>
+     !st res st'. eval_stmts cx body st = (res,st') ==>
+       log_extends st st') /\
+  push_scope_with_var nm tyv v st0 = (INL (),st1) /\
+  (try (do eval_stmts cx body; return F od) handle_loop_exception) st1 =
+    (res1,st1') ==>
+  log_extends st1 st1'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `(try _ _) _ = _` mp_tac >>
+  simp[vyperStateTheory.try_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  first_x_assum drule >> simp[] >> strip_tac >>
+  first_x_assum drule >> strip_tac >>
+  imp_res_tac handle_loop_exception_state >> gvs[]
+QED
+
+Theorem finally_pop_scope_log_extends[local]:
+  (!r s1. f st = (r,s1) ==> log_extends st s1) /\
+  finally f pop_scope st = (res,st') ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `finally _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.finally_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac pop_scope_log_extends >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum ACCEPT_TAC
+QED
+
+Theorem finally_try_body_log_extends[local]:
+  !cx body st1 res1 st1'.
+    finally (try (do x <- eval_stmts cx body; return F od) handle_loop_exception)
+            pop_scope st1 = (res1,st1') ==>
+    (!st res st'. eval_stmts cx body st = (res,st') ==>
+       log_extends st st') ==>
+    log_extends st1 st1'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `finally _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.finally_def, vyperStateTheory.try_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  first_x_assum drule >> strip_tac >>
+  imp_res_tac handle_loop_exception_state >> gvs[] >>
+  imp_res_tac pop_scope_log_extends >>
+  irule log_extends_trans >>
+  qexists_tac `s''` >> simp[]
+QED
+
+Theorem case_eval_for_cons_logs[local]:
+  (!s0 x s1 s2 broke s3.
+     push_scope_with_var nm tyv v s0 = (INL x,s1) /\
+     finally (try (do eval_stmts cx body; return F od)
+                    handle_loop_exception) pop_scope s2 = (INL broke,s3) /\
+     ~broke ==>
+     !st res st'. eval_for cx tyv nm body vs st = (res,st') ==>
+       log_extends st st') /\
+  (!s0 x s1. push_scope_with_var nm tyv v s0 = (INL x,s1) ==>
+     !st res st'. eval_stmts cx body st = (res,st') ==>
+       log_extends st st') ==>
+  !st res st'. eval_for cx tyv nm body (v::vs) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_for _ _ _ _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac push_scope_with_var_log_extends >>
+  `!sb rb sb'. eval_stmts cx body sb = (rb,sb') ==>
+               log_extends sb sb'` by
+    (rpt strip_tac >>
+     qpat_x_assum `!s0 s1. push_scope_with_var _ _ _ s0 = _ ==> _`
+       (qspecl_then [`st`, `s''`] mp_tac) >>
+     simp[] >> strip_tac >>
+     first_x_assum drule >> simp[]) >>
+  `log_extends s'' s'³'` by
+    (drule finally_try_body_log_extends >>
+     disch_then drule >> simp[]) >>
+  `log_extends st s'³'` by
+    (irule log_extends_trans >> qexists_tac `s''` >> simp[]) >>
+  Cases_on `broke` >> gvs[vyperStateTheory.return_def] >>
+  qpat_x_assum `!s0 s1 s2 s3. _`
+    (qspecl_then [`st`, `s''`, `s''`, `s'³'`] mp_tac) >>
+  simp[vyperStateTheory.ignore_bind_def] >> strip_tac >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> qexists_tac `s'³'` >> simp[]
+QED
+
+
+Theorem update_accounts_logs[local]:
+  update_accounts f st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  gvs[vyperStateTheory.update_accounts_def, vyperStateTheory.return_def]
+QED
+
+Theorem update_transient_logs[local]:
+  update_transient f st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  gvs[vyperStateTheory.update_transient_def, vyperStateTheory.return_def]
+QED
+
+Theorem set_scopes_logs[local]:
+  set_scopes env st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  gvs[vyperStateTheory.set_scopes_def, vyperStateTheory.return_def]
+QED
+
+Theorem set_address_immutables_logs[local]:
+  set_address_immutables cx imms st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  gvs[vyperStateTheory.set_address_immutables_def,
+      vyperStateTheory.return_def]
+QED
+
+Theorem set_storage_backend_logs[local]:
+  set_storage_backend cx is_transient storage st = (res,st') ==>
+    st'.logs = st.logs
+Proof
+  Cases_on `is_transient` >> rpt strip_tac >>
+  gvs[vyperStateTheory.set_storage_backend_def, vyperStateTheory.bind_def,
+      vyperStateTheory.update_transient_def,
+      vyperStateTheory.update_accounts_def,
+      vyperStateTheory.get_accounts_def, vyperStateTheory.return_def,
+      AllCaseEqs()]
+QED
+
+Theorem write_storage_slot_logs[local]:
+  write_storage_slot cx is_transient slot tv v st = (res,st') ==>
+    st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `write_storage_slot _ _ _ _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.write_storage_slot_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac vyperStorageBackendTheory.get_storage_backend_state >>
+  imp_res_tac lift_option_type_state >> gvs[] >>
+  imp_res_tac set_storage_backend_logs >> gvs[]
+QED
+
+Theorem set_immutable_logs[local]:
+  set_immutable cx src n tv v st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `set_immutable _ _ _ _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.set_immutable_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_address_immutables_state >> gvs[] >>
+  imp_res_tac set_address_immutables_logs >> gvs[]
+QED
+Theorem set_global_logs[local]:
+  set_global cx src n v st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `set_global _ _ _ _ _ = _` mp_tac >>
+  simp[Once vyperStateTheory.set_global_def, vyperStateTheory.bind_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac lift_option_type_state >> gvs[] >>
+  Cases_on `find_var_decl_by_num n ts` >>
+  gvs[vyperStateTheory.raise_def] >>
+  PairCases_on `x` >> Cases_on `x0` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.raise_def,
+      AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac lift_option_type_state >> gvs[] >>
+  imp_res_tac write_storage_slot_logs >> gvs[]
+QED
+
+
+Theorem new_variable_logs[local]:
+  new_variable id tv v st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `new_variable _ _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.new_variable_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.get_scopes_def,
+       vyperStateTheory.set_scopes_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperStateTheory.type_check_def,
+       vyperStateTheory.assert_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  Cases_on `st.scopes` >>
+  gvs[vyperStateTheory.set_scopes_def, vyperStateTheory.return_def,
+      vyperStateTheory.raise_def]
+QED
+
+Theorem case_stmt_return_some_logs[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Return (SOME e)) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_Value_state >> imp_res_tac materialise_state >>
+  imp_res_tac raise_state >> gvs[] >>
+  first_x_assum drule >> simp[]
+QED
+
+Theorem case_stmt_expr_logs[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Expr e) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_Value_state >> imp_res_tac type_check_state >> gvs[] >>
+  first_x_assum drule >> simp[]
+QED
+
+Theorem push_scope_log_extends[local]:
+  push_scope st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >>
+  gvs[vyperStateTheory.push_scope_def, vyperStateTheory.return_def] >>
+  irule log_extends_eq_logs >> simp[]
+QED
+
+Theorem finally_switch_BoolV_log_extends[local]:
+  finally (switch_BoolV tv f g) pop_scope st = (res,st') ==>
+  (!s0 r s1. f s0 = (r,s1) ==> log_extends s0 s1) ==>
+  (!s0 r s1. g s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `finally _ _ _ = _` mp_tac >>
+  simp[vyperStateTheory.finally_def, vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.bind_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, vyperInterpreterTheory.switch_BoolV_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  qpat_x_assum `(if _ then _ else _) _ = _` mp_tac >>
+  rpt IF_CASES_TAC >> gvs[vyperStateTheory.raise_def] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac pop_scope_log_extends >>
+  rpt (first_x_assum drule >> strip_tac >> gvs[]) >>
+  TRY (irule log_extends_trans >> goal_assum drule >>
+       first_assum MATCH_ACCEPT_TAC)
+QED
+
+Theorem case_stmt_if_logs[local]:
+  (!s0 tv s1 s2 x s3.
+     eval_expr cx e s0 = (INL tv,s1) /\ push_scope s2 = (INL x,s3) ==>
+     !st res st'. eval_stmts cx ss1 st = (res,st') ==> log_extends st st') /\
+  (!s0 tv s1 s2 x s3.
+     eval_expr cx e s0 = (INL tv,s1) /\ push_scope s2 = (INL x,s3) ==>
+     !st res st'. eval_stmts cx ss2 st = (res,st') ==> log_extends st st') /\
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (If e ss1 ss2) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, AllCaseEqs(),
+       vyperStateTheory.push_scope_def, vyperStateTheory.return_def] >>
+  strip_tac >> gvs[] >>
+  rename1 `eval_expr cx e st = (INL tv,s_expr)` >>
+  `log_extends st s_expr` by
+    (qpat_x_assum `!s0 r s1. eval_expr _ _ _ = _ ==> _` drule >> simp[]) >>
+  `!sb rb sb'. eval_stmts cx ss1 sb = (rb,sb') ==>
+                log_extends sb sb'` by
+    (rpt strip_tac >>
+     qpat_x_assum `!s0 tv s1 s2 s3. _ ==> !st res st'. eval_stmts _ ss1 _ = _ ==> _`
+       (qspecl_then [`st`, `tv`, `s_expr`, `s_expr`,
+                     `s_expr with scopes updated_by CONS FEMPTY`] mp_tac) >>
+     simp[vyperStateTheory.push_scope_def, vyperStateTheory.return_def]) >>
+  `!sb rb sb'. eval_stmts cx ss2 sb = (rb,sb') ==>
+                log_extends sb sb'` by
+    (rpt strip_tac >>
+     qpat_x_assum `!s0 tv s1 s2 s3. _ ==> !st res st'. eval_stmts _ ss2 _ = _ ==> _`
+       (qspecl_then [`st`, `tv`, `s_expr`, `s_expr`,
+                     `s_expr with scopes updated_by CONS FEMPTY`] mp_tac) >>
+     simp[vyperStateTheory.push_scope_def, vyperStateTheory.return_def]) >>
+  `log_extends (s_expr with scopes updated_by CONS FEMPTY) st'` by
+    (drule finally_switch_BoolV_log_extends >>
+     disch_then drule >> disch_then drule >> simp[]) >>
+  `log_extends s_expr (s_expr with scopes updated_by CONS FEMPTY)` by
+    (irule log_extends_eq_logs >> simp[]) >>
+  `log_extends s_expr st'` by
+    (irule log_extends_trans >>
+     qexists_tac `s_expr with scopes updated_by CONS FEMPTY` >> simp[]) >>
+  irule log_extends_trans >> qexists_tac `s_expr` >> simp[]
+QED
+Theorem case_stmt_for_logs[local]:
+  (!tenv s0 tyv s1 s2 vs s3 s4 x s5.
+     tenv = get_tenv cx /\
+     lift_option_type (evaluate_type tenv typ) "For evaluate_type" s0 =
+       (INL tyv,s1) /\
+     eval_iterator cx it s2 = (INL vs,s3) /\
+     check (compatible_bound (Dynamic n) (LENGTH vs)) "For too long" s4 =
+       (INL x,s5) ==>
+     !st res st'. eval_for cx tyv (string_to_num id) body vs st = (res,st') ==>
+       log_extends st st') /\
+  (!tenv s0 tyv s1.
+     tenv = get_tenv cx /\
+     lift_option_type (evaluate_type tenv typ) "For evaluate_type" s0 =
+       (INL tyv,s1) ==>
+     !st res st'. eval_iterator cx it st = (res,st') ==>
+       log_extends st st') ==>
+  !st res st'. eval_stmt cx (For id typ it n body) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, AllCaseEqs()] >>
+  strip_tac >> gvs[] >>
+  TRY (imp_res_tac lift_option_type_state >> gvs[log_extends_refl] >> NO_TAC) >>
+  first_x_assum drule_all >> strip_tac >>
+  imp_res_tac lift_option_type_state >> gvs[] >>
+  TRY (first_x_assum drule >> simp[] >> NO_TAC) >>
+  imp_res_tac check_state >> imp_res_tac type_check_state >> gvs[] >>
+  TRY (first_x_assum drule >> simp[] >> NO_TAC) >>
+  first_x_assum drule_all >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+
+
+Theorem case_stmt_raise_logs[local]:
+  (!e. reason = RaiseReason e ==>
+     !s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Raise reason) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt gen_tac >> strip_tac >> Cases_on `reason` >>
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_Value_state >> imp_res_tac lift_option_state >>
+  imp_res_tac lift_option_type_state >> imp_res_tac raise_state >> gvs[] >>
+  TRY (simp[log_extends_refl] >> NO_TAC) >>
+  first_x_assum drule >> simp[]
+QED
+
+Theorem case_stmt_assert_logs[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) /\
+  (!se. reason = AssertReason se ==>
+     !s0 r s1. eval_expr cx se s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Assert e reason) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt gen_tac >> strip_tac >> Cases_on `reason` >>
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_Value_state >> gvs[] >>
+  qpat_x_assum `switch_BoolV _ _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.switch_BoolV_def] >>
+  rpt IF_CASES_TAC >>
+  simp[vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       vyperStateTheory.bind_def, AllCaseEqs()] >>
+  strip_tac >> gvs[] >>
+  TRY (imp_res_tac get_Value_state >> imp_res_tac lift_option_state >>
+       imp_res_tac lift_option_type_state >> imp_res_tac raise_state >> gvs[]) >>
+  rpt (first_x_assum drule >> strip_tac >> gvs[]) >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+
+Theorem case_stmt_log_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_stmt cx (Log id es) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_stmt _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac lift_option_state >> gvs[] >>
+  imp_res_tac push_log_log_extends >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  simp[log_extends_append]
+QED
+
+
+Theorem case_base_target_name_logs[local]:
+  eval_base_target cx (NameTarget id) st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >>
+  qpat_x_assum `eval_base_target _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def,
+       vyperStateTheory.get_scopes_def, vyperStateTheory.return_def,
+       vyperStateTheory.type_check_def, vyperStateTheory.assert_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[log_extends_refl]
+QED
+
+Theorem case_base_target_toplevel_logs[local]:
+  eval_base_target cx (TopLevelNameTarget sid) st = (res,st') ==>
+    log_extends st st'
+Proof
+  PairCases_on `sid` >> strip_tac >>
+  qpat_x_assum `eval_base_target _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac lift_option_type_state >> gvs[] >>
+  Cases_on `is_immutable_decl (string_to_num sid1) ts` >>
+  gvs[vyperStateTheory.return_def, log_extends_refl]
+QED
+
+Theorem case_base_target_attribute_logs[local]:
+  (!s0 r s1. eval_base_target cx bt s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_base_target cx (AttributeTarget bt id) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_base_target _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  strip_tac >> gvs[] >>
+  Cases_on `x` >> gvs[vyperStateTheory.return_def] >>
+  first_x_assum drule >> simp[]
+QED
+
+Theorem case_base_target_subscript_logs[local]:
+  (!s0 r s1. eval_base_target cx bt s0 = (r,s1) ==> log_extends s0 s1) /\
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_base_target cx (SubscriptTarget bt e) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_base_target _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  PairCases_on `x` >> gvs[vyperStateTheory.bind_def,
+                           vyperStateTheory.return_def, AllCaseEqs()] >>
+  imp_res_tac get_Value_state >> gvs[] >>
+  rpt (first_x_assum drule >> strip_tac >> gvs[]) >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+Theorem switch_BoolV_log_extends[local]:
+  switch_BoolV tv f g st = (res,st') ==>
+  (!s0 r s1. f s0 = (r,s1) ==> log_extends s0 s1) ==>
+  (!s0 r s1. g s0 = (r,s1) ==> log_extends s0 s1) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `switch_BoolV _ _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.switch_BoolV_def] >>
+  rpt IF_CASES_TAC >> simp[vyperStateTheory.raise_def] >>
+  rpt strip_tac >> gvs[log_extends_refl] >>
+  first_x_assum drule >> simp[]
+QED
+
+Theorem case_expr_if_logs[local]:
+  (!s0 tv s1. eval_expr cx e1 s0 = (INL tv,s1) ==>
+     !st res st'. eval_expr cx e2 st = (res,st') ==> log_extends st st') /\
+  (!s0 tv s1. eval_expr cx e1 s0 = (INL tv,s1) ==>
+     !st res st'. eval_expr cx e3 st = (res,st') ==> log_extends st st') /\
+  (!s0 r s1. eval_expr cx e1 s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (IfExp ty e1 e2 e3) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  `!sb rb sb'. eval_expr cx e2 sb = (rb,sb') ==> log_extends sb sb'` by
+    (qpat_x_assum `!s0 tv s1. _ ==> !st res st'. eval_expr _ e2 _ = _ ==> _`
+       drule >> simp[]) >>
+  `!sb rb sb'. eval_expr cx e3 sb = (rb,sb') ==> log_extends sb sb'` by
+    (qpat_x_assum `!s0 tv s1. _ ==> !st res st'. eval_expr _ e3 _ = _ ==> _`
+       drule >> simp[]) >>
+  `log_extends s'' st'` by
+    (drule switch_BoolV_log_extends >>
+     disch_then drule >> disch_then drule >> simp[]) >>
+  `log_extends st s''` by
+    (qpat_x_assum `!s0 r s1. eval_expr _ e1 _ = _ ==> _` drule >> simp[]) >>
+  irule log_extends_trans >> qexists_tac `s''` >> simp[]
+QED
+
+Theorem case_expr_struct_lit_logs[local]:
+  (!s0 r s1. eval_exprs cx (MAP SND kes) s0 = (r,s1) ==>
+     log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (StructLit ty sid kes) st = (res,st') ==>
+    log_extends st st'
+Proof
+  PairCases_on `sid` >> rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >> first_x_assum drule >> simp[]
+QED
+
+Theorem case_expr_raw_log_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (Call ty RawLog es drv) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac type_check_state >> imp_res_tac lift_option_type_state >> gvs[] >>
+  imp_res_tac push_log_log_extends >> imp_res_tac return_state >> gvs[] >>
+  first_x_assum drule >> strip_tac >>
+  irule log_extends_trans >> goal_assum drule >>
+  simp[log_extends_append]
+QED
+
+Theorem case_expr_raw_revert_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (Call ty RawRevert es drv) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.raise_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac type_check_state >> imp_res_tac raise_state >> gvs[] >>
+  first_x_assum drule >> simp[]
+QED
+
+Theorem case_expr_attribute_logs[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (Attribute ty e id) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_Value_state >> imp_res_tac lift_sum_state >> gvs[] >>
+  first_x_assum drule >> simp[]
+QED
+
+Theorem case_expr_type_builtin_logs[local]:
+  (!s0 r s1. eval_exprs cx es s0 = (r,s1) ==> log_extends s0 s1) ==>
+  !st res st'. eval_expr cx (TypeBuiltin ty tb typ es) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_expr _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.return_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac type_check_state >> imp_res_tac lift_sum_state >> gvs[] >>
+  TRY (simp[log_extends_refl] >> NO_TAC) >>
+  first_x_assum drule >> simp[]
+QED
+
+
+Theorem case_eval_exprs_nil_logs[local]:
+  eval_exprs cx [] st = (res,st') ==> log_extends st st'
+Proof
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.return_def,
+       log_extends_refl]
+QED
+
+Theorem case_eval_exprs_cons_logs[local]:
+  (!s0 r s1. eval_expr cx e s0 = (r,s1) ==> log_extends s0 s1) /\
+  (!s0 tv s1 s2 v s3.
+     eval_expr cx e s0 = (INL tv,s1) /\
+     materialise cx tv s2 = (INL v,s3) ==>
+     !st res st'. eval_exprs cx es st = (res,st') ==> log_extends st st') ==>
+  !st res st'. eval_exprs cx (e::es) st = (res,st') ==>
+    log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `eval_exprs _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.evaluate_def, vyperStateTheory.bind_def,
+       vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac materialise_state >> gvs[] >>
+  rpt (first_x_assum drule >> strip_tac >> gvs[]) >>
+  irule log_extends_trans >> goal_assum drule >>
+  first_assum MATCH_ACCEPT_TAC
+QED
+
 
 val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -1,0 +1,74 @@
+Theory vyperLogPreservation
+
+Ancestors
+  vyperCall
+
+Definition log_extends_def:
+  log_extends (st:evaluation_state) (st':evaluation_state) <=>
+    isPREFIX st.logs st'.logs
+End
+
+Theorem log_extends_refl:
+  log_extends st st
+Proof
+  simp[log_extends_def, rich_listTheory.IS_PREFIX_REFL]
+QED
+
+Theorem log_extends_trans:
+  log_extends st st1 /\ log_extends st1 st2 ==> log_extends st st2
+Proof
+  simp[log_extends_def] >> metis_tac[rich_listTheory.IS_PREFIX_TRANS]
+QED
+
+Theorem log_extends_eq_logs:
+  st.logs = st'.logs ==> log_extends st st'
+Proof
+  simp[log_extends_def, rich_listTheory.IS_PREFIX_REFL]
+QED
+
+Theorem log_extends_append:
+  log_extends st (st with logs := st.logs ++ events)
+Proof
+  simp[log_extends_def, rich_listTheory.IS_PREFIX_APPEND]
+QED
+
+Theorem return_log_extends[local]:
+  return x st = (res,st') ==> log_extends st st'
+Proof
+  simp[vyperStateTheory.return_def, log_extends_refl]
+QED
+
+Theorem raise_log_extends[local]:
+  raise e st = (res,st') ==> log_extends st st'
+Proof
+  simp[vyperStateTheory.raise_def, log_extends_refl]
+QED
+
+Theorem push_log_log_extends[local]:
+  push_log ev st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >> gvs[push_log_logs] >> simp[log_extends_append]
+QED
+
+Theorem append_logs_log_extends[local]:
+  append_logs events st = (res,st') ==> log_extends st st'
+Proof
+  strip_tac >> gvs[append_logs_logs] >> simp[log_extends_append]
+QED
+
+Theorem bind_log_extends[local]:
+  (!r st1. f st = (r,st1) ==> log_extends st st1) /\
+  (!x st1 r st2.
+     f st = (INL x,st1) /\ g x st1 = (r,st2) ==>
+     log_extends st1 st2) /\
+  bind f g st = (res,st') ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  Cases_on `f st` >>
+  gvs[vyperStateTheory.bind_def] >>
+  Cases_on `q` >> gvs[] >>
+  metis_tac[log_extends_trans]
+QED
+
+val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -3246,4 +3246,53 @@ Proof
   metis_tac[eval_mutual_log_extends]
 QED
 
+
+Definition machine_log_extends_def:
+  machine_log_extends (am:abstract_machine) (am':abstract_machine) <=>
+    isPREFIX am.logs am'.logs
+End
+
+Theorem machine_log_extends_refl:
+  machine_log_extends am am
+Proof
+  simp[machine_log_extends_def, rich_listTheory.IS_PREFIX_REFL]
+QED
+
+Theorem machine_log_extends_trans:
+  machine_log_extends am am1 /\ machine_log_extends am1 am2 ==>
+  machine_log_extends am am2
+Proof
+  simp[machine_log_extends_def] >>
+  metis_tac[rich_listTheory.IS_PREFIX_TRANS]
+QED
+
+Theorem machine_log_extends_eq_logs:
+  am.logs = am'.logs ==> machine_log_extends am am'
+Proof
+  simp[machine_log_extends_def, rich_listTheory.IS_PREFIX_REFL]
+QED
+
+Theorem abstract_machine_from_state_logs[simp]:
+  (abstract_machine_from_state srcs exps layouts st).logs = st.logs
+Proof
+  simp[vyperInterpreterTheory.abstract_machine_from_state_def]
+QED
+
+Theorem merge_constants_logs[local]:
+  (merge_constants addr src_id_opt cenv am).logs = am.logs
+Proof
+  simp[vyperInterpreterTheory.merge_constants_def]
+QED
+
+Theorem evaluate_all_constants_logs:
+  evaluate_all_constants cx am addr mods = SOME am' ==> am'.logs = am.logs
+Proof
+  qid_spec_tac `am` >> Induct_on `mods` >-
+    simp[vyperInterpreterTheory.evaluate_all_constants_def] >>
+  gen_tac >> PairCases_on `h` >> gen_tac >>
+  simp[vyperInterpreterTheory.evaluate_all_constants_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  first_x_assum drule >>
+  simp[merge_constants_logs]
+QED
 val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -3295,4 +3295,152 @@ Proof
   first_x_assum drule >>
   simp[merge_constants_logs]
 QED
+
+Theorem acquire_nonreentrant_lock_logs[local]:
+  acquire_nonreentrant_lock addr slot is_view st = (res,st') ==>
+  st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `acquire_nonreentrant_lock _ _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.acquire_nonreentrant_lock_def,
+       vyperStateTheory.bind_def, vyperStateTheory.get_transient_storage_def,
+       vyperStateTheory.update_transient_def, vyperStateTheory.return_def,
+       vyperStateTheory.raise_def, AllCaseEqs()] >>
+  rpt strip_tac >>
+  Cases_on `lookup_storage (n2w slot)
+              (vfmExecution$lookup_transient_storage addr st.tStorage) = 1w` >>
+  Cases_on `is_view` >>
+  gvs[vyperStateTheory.update_transient_def, vyperStateTheory.return_def,
+      vyperStateTheory.raise_def]
+QED
+
+Theorem release_nonreentrant_lock_logs[local]:
+  release_nonreentrant_lock addr slot st = (res,st') ==>
+  st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `release_nonreentrant_lock _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.release_nonreentrant_lock_def,
+       vyperStateTheory.bind_def, vyperStateTheory.get_transient_storage_def,
+       vyperStateTheory.update_transient_def, vyperStateTheory.return_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[]
+QED
+
+Theorem send_call_value_logs[local]:
+  send_call_value mut cx st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `send_call_value _ _ _ = _` mp_tac >>
+  simp[vyperInterpreterTheory.send_call_value_def, vyperStateTheory.bind_def,
+       vyperStateTheory.ignore_bind_def, vyperStateTheory.check_def,
+       vyperStateTheory.return_def, vyperStateTheory.raise_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >>
+  Cases_on `cx.txn.value = 0` >> Cases_on `mut = Payable` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+      vyperStateTheory.check_def, vyperStateTheory.assert_def,
+      vyperStateTheory.return_def, vyperStateTheory.raise_def] >>
+  imp_res_tac transfer_value_logs >> gvs[]
+QED
+
+
+Theorem entry_lock_action_logs[local]:
+  (if nr then
+     case cx.nonreentrant_slot of
+       NONE => raise (Error (TypeError "nonreentrant slot missing"))
+     | SOME slot =>
+         acquire_nonreentrant_lock cx.txn.target slot is_view
+   else return ()) st = (res,st') ==>
+  st'.logs = st.logs
+Proof
+  Cases_on `nr` >> Cases_on `cx.nonreentrant_slot` >>
+  simp[vyperStateTheory.return_def, vyperStateTheory.raise_def] >>
+  metis_tac[acquire_nonreentrant_lock_logs]
+QED
+
+Theorem exit_unlock_action_logs[local]:
+  (if nr /\ ~is_view then
+     case cx.nonreentrant_slot of
+       NONE => return ()
+     | SOME slot => release_nonreentrant_lock cx.txn.target slot
+   else return ()) st = (res,st') ==>
+  st'.logs = st.logs
+Proof
+  Cases_on `nr` >> Cases_on `is_view` >> Cases_on `cx.nonreentrant_slot` >>
+  simp[vyperStateTheory.return_def] >>
+  metis_tac[release_nonreentrant_lock_logs]
+QED
+
+Theorem external_unlock_action_logs[local]:
+  (if nr /\ mut <> View /\ mut <> Pure then
+     case cx.nonreentrant_slot of
+       NONE => return ()
+     | SOME slot => release_nonreentrant_lock cx.txn.target slot
+   else return ()) st = (res,st') ==>
+  st'.logs = st.logs
+Proof
+  Cases_on `nr` >> Cases_on `mut = View` >> Cases_on `mut = Pure` >>
+  Cases_on `cx.nonreentrant_slot` >>
+  gvs[vyperStateTheory.return_def] >>
+  metis_tac[release_nonreentrant_lock_logs]
+QED
+
+Theorem call_body_pipeline_log_extends[local]:
+  (do lock_action; send_call_value mut cx; eval_stmts cx body od) st =
+    (res,st') ==>
+  (!s0 r s1. lock_action s0 = (r,s1) ==> s1.logs = s0.logs) ==>
+  log_extends st st'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `(do lock_action; send_call_value _ _; eval_stmts _ _ od) _ = _`
+    mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac send_call_value_logs >>
+  imp_res_tac eval_stmts_log_extends >>
+  metis_tac[log_extends_eq_logs, log_extends_trans]
+QED
+Theorem call_external_function_success_log_extends:
+  call_external_function am cx nr mut ts all_mods args dflts vals body ret =
+    (INL v,am') ==>
+  machine_log_extends am am'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `call_external_function _ _ _ _ _ _ _ _ _ _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.call_external_function_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >>
+  Cases_on `(do
+               if nr then
+                 case cx.nonreentrant_slot of
+                   NONE => raise (Error (TypeError "nonreentrant slot missing"))
+                 | SOME slot =>
+                     acquire_nonreentrant_lock cx.txn.target slot
+                       (mut = View \/ mut = Pure)
+               else return ();
+               send_call_value mut cx;
+               eval_stmts cx body
+             od) (initial_state am_c [env])` >>
+  Cases_on `q` >> gvs[AllCaseEqs()] >>
+  Cases_on `(if nr /\ mut <> View /\ mut <> Pure then
+               case cx.nonreentrant_slot of
+                 NONE => return ()
+               | SOME slot =>
+                   release_nonreentrant_lock cx.txn.target slot
+             else return ()) r` >>
+  Cases_on `q` >> gvs[AllCaseEqs()] >>
+  TRY (Cases_on `y` >> gvs[AllCaseEqs()]) >>
+  TRY (Cases_on `evaluate_type (type_env_all_modules all_mods) ret` >>
+       gvs[AllCaseEqs()]) >>
+  TRY (Cases_on `safe_cast x v'` >> gvs[AllCaseEqs()]) >>
+  drule call_body_pipeline_log_extends >>
+  (impl_tac >-
+     (rpt strip_tac >> imp_res_tac entry_lock_action_logs)) >>
+  strip_tac >>
+  imp_res_tac external_unlock_action_logs >>
+  imp_res_tac evaluate_all_constants_logs >>
+  gvs[machine_log_extends_def, log_extends_def]
+QED
 val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -3443,4 +3443,54 @@ Proof
   imp_res_tac evaluate_all_constants_logs >>
   gvs[machine_log_extends_def, log_extends_def]
 QED
+
+Theorem call_external_success_log_extends:
+  call_external am tx = (INL v,am') ==> machine_log_extends am am'
+Proof
+  rpt strip_tac >>
+  qpat_x_assum `call_external _ _ = _` mp_tac >>
+  simp[Once vyperInterpreterTheory.call_external_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac call_external_function_success_log_extends
+QED
+
+Theorem call_external_function_error_logs_rollback:
+  call_external_function am cx nr mut ts all_mods args dflts vals body ret =
+    (INR e,am') ==>
+  am'.logs = am.logs
+Proof
+  strip_tac >> imp_res_tac call_external_function_error_rollback >> gvs[]
+QED
+
+Theorem call_external_error_logs_rollback:
+  call_external am tx = (INR e,am') ==> am'.logs = am.logs
+Proof
+  strip_tac >> imp_res_tac call_external_error_rollback >> gvs[]
+QED
+
+Theorem call_external_log_extends:
+  call_external am tx = (res,am') ==> machine_log_extends am am'
+Proof
+  Cases_on `res` >> strip_tac >-
+    (imp_res_tac call_external_success_log_extends) >>
+  imp_res_tac call_external_error_logs_rollback >>
+  simp[machine_log_extends_eq_logs]
+QED
+
+Theorem call_external_transaction_log_extends_empty:
+  call_external_transaction am tx = (res,am') ==>
+  isPREFIX [] am'.logs
+Proof
+  simp[]
+QED
+
+Theorem call_external_transaction_success_fresh:
+  call_external_transaction am tx = (INL v,am') ==>
+  call_external (clear_machine_logs am) tx = (INL v,am') /\
+  machine_log_extends (clear_machine_logs am) am'
+Proof
+  simp[vyperInterpreterTheory.call_external_transaction_def] >>
+  metis_tac[call_external_log_extends]
+QED
+
 val _ = export_theory();

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -3225,6 +3225,13 @@ Proof
   strip_tac >> rpt conj_tac >> first_assum MATCH_ACCEPT_TAC
 QED
 
+Theorem eval_stmt_log_extends:
+  !cx s st res st'.
+    eval_stmt cx s st = (res,st') ==> log_extends st st'
+Proof
+  metis_tac[eval_mutual_log_extends]
+QED
+
 Theorem eval_expr_log_extends:
   !cx e st res st'.
     eval_expr cx e st = (res,st') ==> log_extends st st'

--- a/semantics/prop/vyperLogPreservationScript.sml
+++ b/semantics/prop/vyperLogPreservationScript.sml
@@ -381,6 +381,35 @@ Proof
 QED
 
 
+Theorem subscript_terminal_logs[local]:
+  (do v2 <- get_Value tv2;
+      tenv <<- get_tenv cx;
+      arr_tv <- lift_option_type (evaluate_type tenv (expr_type e1))
+                   "Subscript array type";
+      check_array_bounds cx tv1 v2;
+      r <- lift_sum (evaluate_subscript tenv arr_tv tv1 v2);
+      case r of
+        INL v => return v
+      | INR (is_transient,slot,tv) => do
+          v <- read_storage_slot cx is_transient slot tv;
+          return (Value v)
+        od
+   od) st = (res,st') ==> st'.logs = st.logs
+Proof
+  rpt strip_tac >> pop_assum mp_tac >>
+  simp[vyperStateTheory.bind_def, vyperStateTheory.ignore_bind_def,
+       AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac get_Value_state >> imp_res_tac lift_option_type_state >>
+  imp_res_tac check_array_bounds_state >> imp_res_tac lift_sum_state >> gvs[] >>
+  Cases_on `r` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def, AllCaseEqs()] >>
+  PairCases_on `y` >>
+  gvs[vyperStateTheory.bind_def, vyperStateTheory.return_def, AllCaseEqs()] >>
+  rpt strip_tac >> gvs[] >>
+  imp_res_tac read_storage_slot_state >> imp_res_tac return_state >> gvs[]
+QED
+
 Theorem new_variable_logs[local]:
   new_variable id tv v st = (res,st') ==> st'.logs = st.logs
 Proof

--- a/semantics/prop/vyperScopePreservationScript.sml
+++ b/semantics/prop/vyperScopePreservationScript.sml
@@ -192,6 +192,12 @@ Proof
   rw[push_log_def, return_def] >> simp[]
 QED
 
+Theorem append_logs_scopes:
+  ∀logs st res st'. append_logs logs st = (res, st') ⇒ st'.scopes = st.scopes
+Proof
+  rw[append_logs_def, return_def] >> simp[]
+QED
+
 Theorem transfer_value_scopes:
   !f t a st res st'. transfer_value f t a st = (res, st') ==> st'.scopes = st.scopes
 Proof

--- a/semantics/prop/vyperSemanticsHolScript.sml
+++ b/semantics/prop/vyperSemanticsHolScript.sml
@@ -1,6 +1,6 @@
 Theory vyperSemanticsHol
 Ancestors
-  vyperCall
+  vyperLogPreservation
   vyperEvalBinop
   vyperEvalPreservesImmutablesDom
   vyperEvalPreservesNameTarget

--- a/semantics/prop/vyperStatePreservationScript.sml
+++ b/semantics/prop/vyperStatePreservationScript.sml
@@ -221,6 +221,25 @@ Proof
   rw[push_log_def, return_def] >> gvs[]
 QED
 
+Theorem append_logs_immutables:
+  ∀logs st res st'.
+    append_logs logs st = (res, st') ⇒ st'.immutables = st.immutables
+Proof
+  rw[append_logs_def, return_def] >> gvs[]
+QED
+
+Theorem append_logs_accounts:
+  ∀logs st res st'. append_logs logs st = (res, st') ⇒ st'.accounts = st.accounts
+Proof
+  rw[append_logs_def, return_def] >> gvs[]
+QED
+
+Theorem append_logs_tStorage:
+  ∀logs st res st'. append_logs logs st = (res, st') ⇒ st'.tStorage = st.tStorage
+Proof
+  rw[append_logs_def, return_def] >> gvs[]
+QED
+
 Theorem acquire_nonreentrant_lock_immutables:
   !addr slot is_view st res st'.
     acquire_nonreentrant_lock addr slot is_view st = (res, st') ==>

--- a/semantics/prop/vyperTypeContractGetterScript.sml
+++ b/semantics/prop/vyperTypeContractGetterScript.sml
@@ -1549,7 +1549,7 @@ Proof
   rpt strip_tac >>
   irule Subscript_NoneTV_HashMapRef_no_TypeError >>
   qexistsl [`slot`, `cx`, `is_transient`, `kt`, `entry.value`,
-            `<|immutables := am.immutables; logs := []; scopes := [scope];
+            `<|immutables := am.immutables; logs := am.logs; scopes := [scope];
                accounts := am.accounts; tStorage := am.tStorage|>`, `st2`, `vt`] >>
   simp[]
 QED
@@ -2402,7 +2402,7 @@ Proof
        get_scopes_def, lookup_scopes_val_def, bind_def, lift_option_def,
        lift_option_type_def, return_def, raise_def] >>
   Cases_on `check_array_bounds cx (Value (ArrayV av)) (IntV i)
-              <|immutables := am.immutables; logs := []; scopes := [scope];
+              <|immutables := am.immutables; logs := am.logs; scopes := [scope];
                 accounts := am.accounts; tStorage := am.tStorage|>` >>
   rename1 `check_array_bounds _ _ _ _ = (bounds_res,bounds_st)` >>
   Cases_on `bounds_res` >> simp[bind_def, return_def, raise_def]
@@ -2466,7 +2466,7 @@ Proof
        get_scopes_def, lookup_scopes_val_def, bind_def, lift_option_def,
        lift_option_type_def, return_def, raise_def] >>
   Cases_on `check_array_bounds cx (ArrayRef is_transient slot (ArrayTV inner_tv inner_bd) bd) (IntV i)
-              <|immutables := am.immutables; logs := []; scopes := [scope];
+              <|immutables := am.immutables; logs := am.logs; scopes := [scope];
                 accounts := am.accounts; tStorage := am.tStorage|>` >>
   rename1 `check_array_bounds _ _ _ _ = (bounds_res,bounds_st)` >>
   Cases_on `bounds_res`
@@ -2660,7 +2660,7 @@ Proof
        lift_option_type_def, return_def, raise_def] >>
   rpt strip_tac >> gvs[]
   >- (Cases_on `check_array_bounds cx (Value (ArrayV av)) (IntV i)
-                    <|immutables := am.immutables; logs := []; scopes := [scope];
+                    <|immutables := am.immutables; logs := am.logs; scopes := [scope];
                       accounts := am.accounts; tStorage := am.tStorage|>` >>
       Cases_on `q` >>
       gvs[bind_def, ignore_bind_def, return_def, raise_def,
@@ -2668,7 +2668,7 @@ Proof
       Cases_on `array_index NoneTV av i` >>
       gvs[bind_def, return_def, raise_def]) >>
   Cases_on `check_array_bounds cx (ArrayRef is_transient slot elem_tv bd) (IntV i)
-                    <|immutables := am.immutables; logs := []; scopes := [scope];
+                    <|immutables := am.immutables; logs := am.logs; scopes := [scope];
                       accounts := am.accounts; tStorage := am.tStorage|>` >>
   Cases_on `q` >>
   gvs[bind_def, ignore_bind_def, return_def, raise_def, lift_sum_def] >>
@@ -2825,7 +2825,7 @@ Proof
        lift_option_type_def, return_def, raise_def] >>
   rpt strip_tac >> gvs[]
   >- (Cases_on `check_array_bounds cx (Value (ArrayV av)) (IntV i)
-                    <|immutables := am.immutables; logs := []; scopes := [scope];
+                    <|immutables := am.immutables; logs := am.logs; scopes := [scope];
                       accounts := am.accounts; tStorage := am.tStorage|>` >>
       Cases_on `q` >>
       gvs[bind_def, ignore_bind_def, return_def, raise_def, lift_sum_def] >>
@@ -2839,7 +2839,7 @@ Proof
           gvs[evaluate_subscript_def, AllCaseEqs()]) >>
       gvs[evaluate_subscript_def, AllCaseEqs()]) >>
   Cases_on `check_array_bounds cx (ArrayRef is_transient slot (ArrayTV inner_tv inner_bd) bd) (IntV i)
-                    <|immutables := am.immutables; logs := []; scopes := [scope];
+                    <|immutables := am.immutables; logs := am.logs; scopes := [scope];
                       accounts := am.accounts; tStorage := am.tStorage|>` >>
   Cases_on `q` >>
   gvs[bind_def, ignore_bind_def, return_def, raise_def, lift_sum_def] >>

--- a/semantics/prop/vyperTypeEvalSoundnessScript.sml
+++ b/semantics/prop/vyperTypeEvalSoundnessScript.sml
@@ -813,6 +813,7 @@ Proof
   TRY (imp_res_tac no_control_exc_no_loop_control >> NO_TAC) >>
   TRY (imp_res_tac check_no_control >> gvs[no_control_exc_def] >> NO_TAC) >>
   TRY (imp_res_tac type_check_no_control >> gvs[no_control_exc_def] >> NO_TAC) >>
+  TRY (imp_res_tac lift_option_no_control >> gvs[no_control_exc_def] >> NO_TAC) >>
   TRY (imp_res_tac lift_option_type_no_control >> gvs[no_control_exc_def] >> NO_TAC) >>
   TRY (imp_res_tac lift_sum_no_control >> gvs[no_control_exc_def] >> NO_TAC) >>
   TRY (imp_res_tac push_scope_no_control >> gvs[no_control_exc_def] >> NO_TAC) >>
@@ -2164,8 +2165,10 @@ Resume eval_all_type_sound_mutual[Log]:
   Cases_on `exprs_res` >> gvs[no_type_error_result_def]
   >- (
     strip_tac >> gvs[state_well_typed_def, accounts_well_typed_def] >>
-    irule env_consistent_preserved_by_frame >>
-    qexists_tac `st1` >> simp[preserves_tv_eq]) >>
+    Cases_on `encode_source_event (get_tenv cx) cx.sources cx.txn.target id x` >>
+    gvs[lift_option_def, return_def, raise_def] >>
+    drule_all env_consistent_logs_append >>
+    simp[return_exception_typed_def]) >>
   strip_tac >> gvs[] >>
   drule eval_exprs_exception_return_typed >> simp[]
 QED

--- a/semantics/prop/vyperTypeEvalSoundnessScript.sml
+++ b/semantics/prop/vyperTypeEvalSoundnessScript.sml
@@ -9445,6 +9445,9 @@ Resume eval_all_type_sound_mutual[Expr_Call_ExtCall_result_static]:
     drule_all run_ext_call_accounts_well_typed >>
     simp[]) >>
   `runtime_consistent env cx args_st` by simp[runtime_consistent_def] >>
+  `runtime_consistent env cx
+     (args_st with logs := args_st.logs ++ pr4)` by
+    metis_tac[runtime_consistent_logs_append] >>
   `get_tenv cx = env.type_defs` by metis_tac[env_consistent_get_tenv] >>
   qpat_x_assum `get_tenv cx = env.type_defs` (fn th => rewrite_tac[th]) >>
   strip_tac >>
@@ -9454,24 +9457,31 @@ Resume eval_all_type_sound_mutual[Expr_Call_ExtCall_result_static]:
    | INL tv => expr_result_typed env (Call ret_type (ExtCall T (func_name,arg_types,ret_type)) es drv) tv
    | INR v1 => T` suffices_by simp[no_type_error_result_def] >>
   qspecl_then [`env`, `cx`, `es`, `T`, `func_name`, `arg_types`, `ret_type`,
-               `drv`, `pr1`, `args_st`, `pr2`, `pr3`, `res`, `st'`]
+               `drv`, `pr1`, `args_st with logs := args_st.logs ++ pr4`,
+               `pr2`, `pr3`, `res`, `st'`]
     mp_tac extcall_after_state_update_tail_sound_cond_driver_ih >>
   disch_then irule >>
   conj_tac >- first_assum ACCEPT_TAC >>
   conj_tac >- first_assum ACCEPT_TAC >>
   conj_tac >- first_assum ACCEPT_TAC >>
-  conj_tac >- first_assum ACCEPT_TAC >>
+  conj_tac >- (pop_assum mp_tac >>
+                simp[append_logs_def, return_def]) >>
   conj_tac >- (
     rpt strip_tac >>
     `call_evaluation_safe cx (int_calls_expr (THE drv))` by
       (qpat_x_assum `IS_SOME drv` mp_tac >>
        Cases_on `drv` >> simp[] >>
        drule extcall_call_evaluation_safe_driver >> simp[]) >>
-    qpat_x_assum `!env' st'' res' st'''. _`
-      (qspecl_then [`env0`, `st0`, `res0`, `st0'`] mp_tac) >>
-    impl_tac >- (rpt conj_tac >> first_assum ACCEPT_TAC) >>
+    `append_logs pr4
+       (args_st with <|accounts := pr2; tStorage := pr3|>) =
+       (INL (), args_st with
+          <|accounts := pr2; tStorage := pr3;
+            logs := args_st.logs ++ pr4|>)` by
+      simp[append_logs_def, return_def] >>
+    first_x_assum drule_all >>
     strip_tac >>
-    metis_tac[]) >>
+    qpat_x_assum `well_typed_expr env0 (THE drv) ==> _` mp_tac >>
+    simp[]) >>
   rpt conj_tac >>
   first_assum ACCEPT_TAC
 QED
@@ -9644,6 +9654,21 @@ Resume eval_all_type_sound_mutual[Expr_Call_ExtCall_nonstatic_success]:
     drule_all run_ext_call_accounts_well_typed >>
     simp[]) >>
   `runtime_consistent env cx args_st` by simp[runtime_consistent_def] >>
+  `runtime_consistent env cx
+     (args_st with logs := args_st.logs ++ pr4)` by (
+    qspecl_then [`env`, `cx`, `args_st`, `pr4`]
+      mp_tac runtime_consistent_logs_append >>
+    simp[]) >>
+  `runtime_consistent env cx
+     (args_st with <|accounts := pr2; tStorage := pr3|>)` by
+    metis_tac[update_accounts_transient_runtime_consistent] >>
+  `runtime_consistent env cx
+     ((args_st with <|accounts := pr2; tStorage := pr3|>) with
+        logs := args_st.logs ++ pr4)` by (
+    qspecl_then [`env`, `cx`,
+                 `args_st with <|accounts := pr2; tStorage := pr3|>`, `pr4`]
+      mp_tac runtime_consistent_logs_append >>
+    simp[]) >>
   `!err.
      (do
         assert T err;
@@ -9661,27 +9686,47 @@ Resume eval_all_type_sound_mutual[Expr_Call_ExtCall_nonstatic_success]:
   Cases_on `pr1 = [] /\ IS_SOME drv`
   >- (
     qpat_x_assum `pr1 = [] /\ IS_SOME drv` strip_assume_tac >>
-    qpat_x_assum `(if _ then _ else _) _ = _` mp_tac >>
+    qpat_x_assum `_ = (res,st')` mp_tac >>
     qpat_assum `pr1 = []` (fn th => rewrite_tac[th]) >>
     qpat_assum `IS_SOME drv` (fn th => rewrite_tac[th]) >>
-    rewrite_tac[boolTheory.COND_CLAUSES] >> strip_tac >>
+    pure_rewrite_tac[append_logs_def, return_def,
+                     pairTheory.pair_case_thm, sumTheory.sum_case_def,
+                     boolTheory.COND_CLAUSES] >>
+    strip_tac >>
     `well_typed_expr env (THE drv)` by metis_tac[well_typed_opt_THE] >>
     `call_evaluation_safe cx (int_calls_expr (THE drv))` by
       (qpat_x_assum `IS_SOME drv` mp_tac >>
        Cases_on `drv` >> simp[] >>
        drule extcall_call_evaluation_safe_driver >> simp[]) >>
-    qpat_x_assum `!s1 t1 s2 value_opt arg_vals t2 s3 calldata t3 s4 s5 s6 t4 accounts tStorage env0 st0 res0 st1. _`
+    qpat_x_assum `!s1 t1 s2 value_opt arg_vals t2 s3 calldata t3 s4 s5 s6 t4
+                     accounts tStorage emitted_logs s7 t5 env0 st0 res0 st1. _`
       (qspecl_then [`args_st`, `args_st`, `args_st`, `SOME amount`,
                     `TL (TL x)`, `args_st`, `args_st`, `x'`, `args_st`,
                     `args_st`, `args_st`, `args_st`, `args_st`, `pr2`, `pr3`,
-                    `env`, `args_st with <|accounts := pr2; tStorage := pr3|>`,
+                    `pr4`, `args_st with <|accounts := pr2; tStorage := pr3|>`,
+                    `(args_st with <|accounts := pr2; tStorage := pr3|>) with
+                       logs := args_st.logs ++ pr4`,
+                    `env`, `(args_st with <|accounts := pr2; tStorage := pr3|>) with
+                              logs := args_st.logs ++ pr4`,
                     `res`, `st'`] mp_tac) >>
     impl_tac >- (
       conj_tac >-
         simp[type_check_def, assert_def, bind_def, ignore_bind_def,
-             return_def, raise_def] >>
-      drule_all update_accounts_transient_runtime_consistent >>
-      simp[runtime_consistent_def]) >>
+             return_def, raise_def, append_logs_def] >>
+      conj_tac >- (
+        qpat_assum `runtime_consistent env cx
+          (args_st with <|logs := args_st.logs ++ pr4;
+                         accounts := pr2; tStorage := pr3|>)` mp_tac >>
+        pure_rewrite_tac[runtime_consistent_def] >>
+        strip_tac >> first_assum ACCEPT_TAC) >>
+      conj_tac >- (
+        qpat_assum `runtime_consistent env cx
+          (args_st with <|logs := args_st.logs ++ pr4;
+                         accounts := pr2; tStorage := pr3|>)` mp_tac >>
+        pure_rewrite_tac[runtime_consistent_def] >>
+        strip_tac >> first_assum ACCEPT_TAC) >>
+      qpat_x_assum `_ = (res,st')` mp_tac >>
+      simp[]) >>
     strip_tac >>
     qpat_x_assum `well_typed_expr env (THE drv) ==> _` mp_tac >>
     simp[] >> strip_tac >>
@@ -9689,7 +9734,8 @@ Resume eval_all_type_sound_mutual[Expr_Call_ExtCall_nonstatic_success]:
     Cases_on `res` >> gvs[expr_result_typed_def, expr_runtime_typed_def, expr_type_def] >>
     metis_tac[well_typed_expr_not_hashmap_place]) >>
   qspecl_then [`env`, `cx`, `es`, `func_name`, `arg_types`, `ret_type`,
-               `drv`, `args_st`, `pr1`, `pr2`, `pr3`, `res`, `st'`]
+               `drv`, `args_st with logs := args_st.logs ++ pr4`,
+               `pr1`, `pr2`, `pr3`, `res`, `st'`]
     mp_tac extcall_nonstatic_success_tail_sound_cond_driver_ih >>
   impl_tac >- (
     conj_tac >- first_assum ACCEPT_TAC >>
@@ -9699,7 +9745,9 @@ Resume eval_all_type_sound_mutual[Expr_Call_ExtCall_nonstatic_success]:
     conj_tac >- first_assum ACCEPT_TAC >>
     conj_tac >- metis_tac[] >>
     conj_tac >- (strip_tac >> metis_tac[]) >>
-    qpat_x_assum `(if _ then _ else _) _ = _` mp_tac >>
+    qpat_x_assum `_ = (res,st')` mp_tac >>
+    pure_rewrite_tac[append_logs_def, return_def,
+                     pairTheory.pair_case_thm, sumTheory.sum_case_def] >>
     simp[]) >>
   simp[]
 QED
@@ -9792,10 +9840,17 @@ Resume eval_all_type_sound_mutual[Expr_Call_RawCallTarget]:
       strip_tac >> gvs[update_accounts_def, update_transient_def, bind_def, return_def] >>
       `runtime_consistent env cx (args_st with <|accounts := x2; tStorage := x3|>)` by
         metis_tac[update_accounts_transient_runtime_consistent, runtime_consistent_def] >>
+      `runtime_consistent env cx
+         ((args_st with <|accounts := x2; tStorage := x3|>) with
+            logs := args_st.logs ++ x4)` by (
+        qspecl_then [`env`, `cx`,
+                     `args_st with <|accounts := x2; tStorage := x3|>`, `x4`]
+          mp_tac runtime_consistent_logs_append >>
+        simp[]) >>
       Cases_on `x0` >> Cases_on `flags.rcf_revert_on_failure` >>
       Cases_on `flags.rcf_max_outsize = 0` >>
       gvs[check_def, assert_def, bind_def, return_def, raise_def,
-          runtime_consistent_def, no_type_error_result_def,
+          append_logs_def, runtime_consistent_def, no_type_error_result_def,
           expr_result_typed_def, expr_runtime_typed_def, expr_type_def,
           toplevel_value_typed_def, value_has_type_def, raw_call_return_type_def,
           evaluate_type_def, is_HashMapRef_def] >>

--- a/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
+++ b/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
@@ -1544,6 +1544,8 @@ Resume eval_all_storage_preservation_mutual[Log]:
   rename1 `eval_exprs cx es st = (exprs_res,st1)` >>
   first_x_assum drule_all >> strip_tac >>
   Cases_on `exprs_res` >> gvs[bind_def, return_def, push_log_def] >>
+  Cases_on `encode_source_event (get_tenv cx) cx.sources cx.txn.target id x` >>
+  gvs[lift_option_def, raise_def, return_def, push_log_def] >>
   rpt strip_tac >>
   pop_assum (SUBST1_TAC o SYM) >>
   metis_tac[contract_storage_well_formed_logs]

--- a/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
+++ b/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
@@ -1794,11 +1794,16 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_RawCallTarget]:
          (args_st with <|accounts := x2; tStorage := x3|>)` by
         metis_tac[protected_storage_calls_preserve_run_ext_call,
                   runtime_storage_consistent_storage] >>
+      `contract_storage_well_formed cx
+         ((args_st with <|accounts := x2; tStorage := x3|>) with
+            logs := args_st.logs ++ x4)` by
+        metis_tac[contract_storage_well_formed_logs] >>
       strip_tac >>
       gvs[update_accounts_def, update_transient_def, bind_def, return_def] >>
       Cases_on `x0` >> Cases_on `flags.rcf_revert_on_failure` >>
       Cases_on `flags.rcf_max_outsize = 0` >>
-      gvs[check_def, assert_def, bind_def, return_def, raise_def]) >>
+      gvs[check_def, assert_def, bind_def, return_def, raise_def,
+          append_logs_def]) >>
     rpt strip_tac >> gvs[]) >>
   rpt strip_tac >> gvs[Once well_typed_expr_def]
 QED
@@ -3175,6 +3180,22 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_ExtCall]:
                  (args_st with <| accounts := result2; tStorage := result3 |>)` by
                 metis_tac[runtime_storage_consistent_intro,
                           runtime_storage_consistent_layout] >>
+              `runtime_consistent env cx
+                 ((args_st with <|accounts := result2; tStorage := result3|>) with
+                    logs := args_st.logs ++ result4)` by (
+                qspecl_then [`env`, `cx`,
+                  `args_st with <|accounts := result2; tStorage := result3|>`,
+                  `result4`] mp_tac runtime_consistent_logs_append >>
+                simp[]) >>
+              `contract_storage_well_formed cx
+                 ((args_st with <|accounts := result2; tStorage := result3|>) with
+                    logs := args_st.logs ++ result4)` by
+                metis_tac[contract_storage_well_formed_logs] >>
+              `runtime_storage_consistent env cx
+                 ((args_st with <|accounts := result2; tStorage := result3|>) with
+                    logs := args_st.logs ++ result4)` by
+                metis_tac[runtime_storage_consistent_intro,
+                          runtime_storage_consistent_layout] >>
               Cases_on `result1 = [] /\ IS_SOME drv` >> gvs[]
               >- (Cases_on `drv` >> gvs[Once well_typed_expr_def] >> strip_tac >>
                   `call_evaluation_safe cx (int_calls_expr x)` by (
@@ -3182,12 +3203,19 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_ExtCall]:
                       (int_calls_expr (Call _ (ExtCall T _) es (SOME x)))` mp_tac >>
                     pure_rewrite_tac[int_calls_expr_def] >>
                     metis_tac[call_evaluation_safe_append_right]) >>
-                  qpat_x_assum `!env' st'' res' st'''. _`
+                  qpat_x_assum `!s0 t0 env' st'' res' st'''. _`
                     (qspecl_then
-                      [`env`,
-                       `args_st with <| accounts := result2; tStorage := result3 |>`,
+                      [`args_st with <|accounts := result2; tStorage := result3|>`,
+                       `(args_st with <|accounts := result2; tStorage := result3|>) with
+                          logs := args_st.logs ++ result4`,
+                       `env`,
+                       `(args_st with <|accounts := result2; tStorage := result3|>) with
+                          logs := args_st.logs ++ result4`,
                        `res`, `st'`] mp_tac) >>
-                  simp[] >> metis_tac[]) >>
+                  simp[append_logs_def, return_def] >>
+                  qpat_x_assum `_ = (res,st')` mp_tac >>
+                  simp[append_logs_def, return_def] >>
+                  metis_tac[]) >>
               strip_tac >> Cases_on `drv` >> gvs[] >>
               qpat_x_assum `(do _ od) _ = (res,st')` mp_tac >>
               simp[lift_sum_runtime_def, bind_def, return_def, raise_def] >>
@@ -3196,6 +3224,8 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_ExtCall]:
               Cases_on
                 `evaluate_abi_decode_return env.type_defs decode_ty result1` >>
               gvs[return_def, raise_def] >> strip_tac >> gvs[] >>
+              qpat_x_assum `_ = (res,st')` mp_tac >>
+              simp[append_logs_def, return_def] >>
               metis_tac[runtime_storage_consistent_storage]) >>
           qpat_x_assum
             `if F then _ else MAP expr_type es =
@@ -3286,9 +3316,12 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_ExtCall]:
               (qspecl_then
                 [`args_st`, `SOME amount`, `TL (TL vs)`, `args_st`,
                  `args_st`, `calldata`, `args_st`, `args_st`, `args_st`,
-                 `args_st`, `args_st`, `result2`, `result3`,
+                 `args_st`, `args_st`, `result2`, `result3`, `result4`,
+                 `args_st with <|accounts := result2; tStorage := result3|>`,
+                 `(args_st with <|accounts := result2; tStorage := result3|>) with
+                    logs := args_st.logs ++ result4`,
                  `env0`, `st0`, `res0`, `st0'`] mp_tac) >>
-            simp[assert_def, bind_def, return_def, raise_def] >>
+            simp[assert_def, bind_def, return_def, raise_def, append_logs_def] >>
             (impl_tac >- EVAL_TAC) >> strip_tac >> metis_tac[]) >>
           qpat_x_assum `!s' value_opt arg_vals. _` kall_tac >>
           unabbrev_all_tac >>
@@ -3307,6 +3340,22 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_ExtCall]:
              (args_st with <| accounts := result2; tStorage := result3 |>)` by
             metis_tac[runtime_storage_consistent_intro,
                       runtime_storage_consistent_layout] >>
+          `runtime_consistent env cx
+             ((args_st with <|accounts := result2; tStorage := result3|>) with
+                logs := args_st.logs ++ result4)` by (
+            qspecl_then [`env`, `cx`,
+              `args_st with <|accounts := result2; tStorage := result3|>`,
+              `result4`] mp_tac runtime_consistent_logs_append >>
+            simp[]) >>
+          `contract_storage_well_formed cx
+             ((args_st with <|accounts := result2; tStorage := result3|>) with
+                logs := args_st.logs ++ result4)` by
+            metis_tac[contract_storage_well_formed_logs] >>
+          `runtime_storage_consistent env cx
+             ((args_st with <|accounts := result2; tStorage := result3|>) with
+                logs := args_st.logs ++ result4)` by
+            metis_tac[runtime_storage_consistent_intro,
+                      runtime_storage_consistent_layout] >>
           Cases_on `result1 = [] /\ IS_SOME drv` >> gvs[]
           >- (Cases_on `drv` >> gvs[Once well_typed_expr_def] >> strip_tac >>
               `call_evaluation_safe cx (int_calls_expr x)` by (
@@ -3317,9 +3366,13 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_ExtCall]:
               qpat_x_assum `!env0 st0 res0 st0'. _`
                 (qspecl_then
                   [`env`,
-                   `args_st with <| accounts := result2; tStorage := result3 |>`,
+                   `(args_st with <|accounts := result2; tStorage := result3|>) with
+                      logs := args_st.logs ++ result4`,
                    `res`, `st'`] mp_tac) >>
-              simp[] >> metis_tac[]) >>
+              simp[append_logs_def, return_def] >>
+              qpat_x_assum `_ = (res,st')` mp_tac >>
+              simp[append_logs_def, return_def] >>
+              metis_tac[]) >>
           strip_tac >> Cases_on `drv` >> gvs[] >>
           qpat_x_assum `(do _ od) _ = (res,st')` mp_tac >>
           simp[lift_sum_runtime_def, bind_def, return_def, raise_def] >>
@@ -3328,6 +3381,8 @@ Resume eval_all_storage_preservation_mutual[Expr_Call_ExtCall]:
           Cases_on
             `evaluate_abi_decode_return env.type_defs decode_ty result1` >>
           gvs[return_def, raise_def] >> strip_tac >> gvs[] >>
+          qpat_x_assum `_ = (res,st')` mp_tac >>
+          simp[append_logs_def, return_def] >>
           metis_tac[runtime_storage_consistent_storage]) >>
       qpat_x_assum `!s'' vs t. _` kall_tac >>
       gvs[] >>

--- a/semantics/prop/vyperTypeExtCallSoundnessScript.sml
+++ b/semantics/prop/vyperTypeExtCallSoundnessScript.sml
@@ -70,9 +70,10 @@ Theorem extract_call_result_success_exposes_bad_accounts:
                       rollback updated_by (\rb. rb with accounts := bad_accounts) in
     accounts_well_typed good_accounts /\
     ~accounts_well_typed bad_accounts /\
-    ?retData tStorage'.
+    ?retData tStorage' emitted_logs.
       extract_call_result good_accounts empty_transient_storage
-        (INR NONE, final_state) = SOME (T, retData, bad_accounts, tStorage')
+        (INR NONE, final_state) =
+        SOME (T, retData, bad_accounts, tStorage', emitted_logs)
 Proof
   EVAL_TAC >> conj_tac
   >- (gen_tac >>
@@ -83,6 +84,7 @@ Proof
       first_x_assum (qspec_then `1w:address` mp_tac) >> EVAL_TAC) >>
   qexists_tac `[]` >>
   qexists_tac `empty_transient_storage` >>
+  qexists_tac `[]` >>
   EVAL_TAC
 QED
 
@@ -122,13 +124,13 @@ QED
 
 Theorem extract_call_result_accounts_well_typed:
   !orig_accounts orig_tStorage result final_state
-   success retData accounts' tStorage'.
+   success retData accounts' tStorage' emitted_logs.
     accounts_well_typed orig_accounts /\
     (case result of
      | INR NONE => accounts_well_typed final_state.rollback.accounts
      | _ => T) /\
     extract_call_result orig_accounts orig_tStorage (result, final_state) =
-      SOME (success, retData, accounts', tStorage') ==>
+      SOME (success, retData, accounts', tStorage', emitted_logs) ==>
     accounts_well_typed accounts'
 Proof
   rw[extract_call_result_def] >>
@@ -137,10 +139,10 @@ QED
 
 Theorem run_ext_call_accounts_well_typed:
   !caller callee calldata value_opt accounts tStorage txParams
-   success retData accounts' tStorage'.
+   success retData accounts' tStorage' emitted_logs.
     accounts_well_typed accounts /\
     run_ext_call caller callee calldata value_opt accounts tStorage txParams =
-      SOME (success, retData, accounts', tStorage') ==>
+      SOME (success, retData, accounts', tStorage', emitted_logs) ==>
     accounts_well_typed accounts'
 Proof
   rw[run_ext_call_def] >>
@@ -303,6 +305,26 @@ Proof
   qspecl_then [`env.type_defs`, `ret_type`, `returnData`, `x`, `ret_tv`]
     mp_tac evaluate_abi_decode_return_well_typed >>
   simp[toplevel_value_typed_def]
+QED
+
+Theorem runtime_consistent_logs_append:
+  !env cx st ls.
+    runtime_consistent env cx st ==>
+    runtime_consistent env cx (st with logs := st.logs ++ ls)
+Proof
+  rw[runtime_consistent_def, env_consistent_def, env_scopes_consistent_def,
+     env_immutables_consistent_def, state_well_typed_def] >>
+  metis_tac[]
+QED
+
+Theorem append_logs_runtime_consistent:
+  !env cx logs st res st'.
+    runtime_consistent env cx st /\
+    append_logs logs st = (res,st') ==>
+    runtime_consistent env cx st'
+Proof
+  rw[append_logs_def, return_def] >>
+  metis_tac[runtime_consistent_logs_append]
 QED
 
 Theorem extcall_after_state_update_tail_sound:
@@ -803,6 +825,9 @@ Proof
   Cases_on `evaluate_type env.type_defs ret_type` >> gvs[] >>
   `get_tenv cx = env.type_defs` by metis_tac[env_consistent_get_tenv] >>
   gvs[] >>
+  `runtime_consistent env cx
+     (args_st with logs := args_st.logs ++ x'4)` by
+    metis_tac[runtime_consistent_logs_append] >>
   `state_well_typed st' /\ env_consistent env cx st' /\
    accounts_well_typed st'.accounts /\ no_type_error_result res /\
    case res of
@@ -810,7 +835,10 @@ Proof
    | INR _ => T` by (
     irule extcall_after_state_update_tail_sound >>
     simp[] >>
-    metis_tac[]) >>
+    conj_tac >- first_assum ACCEPT_TAC >>
+    qexistsl [`x'2`, `args_st with logs := args_st.logs ++ x'4`,
+              `x'1`, `x'3`] >>
+    gvs[append_logs_def, return_def]) >>
   simp[]
 QED
 
@@ -885,29 +913,42 @@ Proof
   Cases_on `result` >> gvs[] >>
   Cases_on `r` >> gvs[] >>
   Cases_on `r''` >> gvs[] >>
+  Cases_on `r` >> gvs[] >>
   Cases_on `q` >>
   gvs[assert_def, bind_def, return_def, raise_def,
       update_accounts_def, update_transient_def] >>
-  rename1 `run_ext_call _ _ _ _ _ _ _ = SOME (T, returnData, accounts', tStorage')` >>
+  rename1 `run_ext_call _ _ _ _ _ _ _ =
+             SOME (T, returnData, accounts', tStorage', emitted_logs)` >>
   `accounts_well_typed accounts'` by (
     drule_all run_ext_call_accounts_well_typed >>
     simp[]) >>
   `runtime_consistent env cx args_st` by simp[runtime_consistent_def] >>
+  `runtime_consistent env cx
+     (args_st with logs := args_st.logs ++ emitted_logs)` by
+    metis_tac[runtime_consistent_logs_append] >>
   qpat_x_assum `well_formed_type env.type_defs ret_type` mp_tac >>
   simp[well_formed_type_def] >> strip_tac >>
   Cases_on `evaluate_type env.type_defs ret_type` >> gvs[] >>
   rename1 `evaluate_type env.type_defs ret_type = SOME ret_tv` >>
   `get_tenv cx = env.type_defs` by metis_tac[env_consistent_get_tenv] >>
   gvs[] >>
-  qspecl_then [`env`, `cx`, `es`, `T`, `func_name`, `arg_types`, `ret_type`,
-               `ret_tv`, `drv`, `returnData`, `args_st`, `accounts'`, `tStorage'`,
-               `res`, `st'`]
-    mp_tac extcall_after_state_update_tail_sound >>
-  simp[] >>
-  (impl_tac >- (
+  `!env0 st0 res0 st0'.
+      env_consistent env0 cx st0 /\ state_well_typed st0 /\
+      accounts_well_typed st0.accounts /\
+      eval_expr cx (THE drv) st0 = (res0,st0') ==>
+      well_typed_expr env0 (THE drv) ==>
+      state_well_typed st0' /\ env_consistent env0 cx st0' /\
+      accounts_well_typed st0'.accounts /\ no_type_error_result res0 /\
+      case res0 of INL tv => expr_result_typed env0 (THE drv) tv | INR _ => T` by (
     rpt strip_tac >>
     asm "drv_ih" (qspecl_then [`env0`, `st0`, `res0`, `st0'`] mp_tac) >>
-    simp[])) >>
+    simp[]) >>
+  qspecl_then [`env`, `cx`, `es`, `T`, `func_name`, `arg_types`, `ret_type`,
+               `ret_tv`, `drv`, `returnData`,
+               `args_st with logs := args_st.logs ++ emitted_logs`,
+               `accounts'`, `tStorage'`, `res`, `st'`]
+    mp_tac extcall_after_state_update_tail_sound >>
+  gvs[append_logs_def, return_def] >>
   strip_tac >>
   metis_tac[no_type_error_result_def]
 QED
@@ -969,12 +1010,19 @@ Proof
     drule_all run_ext_call_accounts_well_typed >>
     simp[]) >>
   `runtime_consistent env cx args_st` by simp[runtime_consistent_def] >>
+  `runtime_consistent env cx
+     (args_st with logs := args_st.logs ++ x'4)` by
+    metis_tac[runtime_consistent_logs_append] >>
   irule extcall_success_continuation_state_well_typed >>
-  qexistsl [`x'2`, `args_st`, `cx`, `drv`, `env`, `res`, `ret_type`, `x'1`, `x'3`] >>
+  qexistsl [`x'2`, `args_st with logs := args_st.logs ++ x'4`,
+            `cx`, `drv`, `env`, `res`, `ret_type`, `x'1`, `x'3`] >>
   simp[assert_def, bind_def, return_def,
-       update_accounts_def, update_transient_def] >>
-  strip_tac >>
-  qpat_x_assum `!env0 st0 res0 st0'. _` ACCEPT_TAC
+       update_accounts_def, update_transient_def]
+  >> gvs[append_logs_def, return_def] >>
+  rpt strip_tac >>
+  qpat_x_assum `!env0 st0 res0 st0'. _`
+    (qspecl_then [`env0`, `st0`, `res0`, `st0'`] mp_tac) >>
+  simp[]
 QED
 
 Theorem extcall_nonstatic_runtime_error_sound:
@@ -1310,6 +1358,10 @@ Proof
       Cases_on `call_result0` >> gvs[return_def, raise_def]
       >- (
         `accounts_well_typed call_result2` by (drule_all run_ext_call_accounts_well_typed >> simp[]) >>
+        `runtime_consistent env cx args_st` by simp[runtime_consistent_def] >>
+        `runtime_consistent env cx
+           (args_st with logs := args_st.logs ++ call_result4)` by
+          metis_tac[runtime_consistent_logs_append] >>
         strip_tac >>
         qpat_x_assum `(do _ od) args_st = (res,st')` mp_tac >>
         simp[bind_def, ignore_bind_def, return_def, assert_def,
@@ -1317,14 +1369,18 @@ Proof
         strip_tac >>
         rewrite_tac[GSYM no_type_error_result_def] >>
         irule extcall_success_continuation_sound >>
-        (conj_tac >- simp[runtime_consistent_def]) >>
+        (conj_tac >-
+          metis_tac[runtime_consistent_logs_append, runtime_consistent_def]) >>
         (conj_tac >- (rpt strip_tac >> first_x_assum drule_all >> simp[no_type_error_result_def])) >>
         (conj_tac >- (qpat_assum `functions_well_typed cx` ACCEPT_TAC)) >>
         (conj_tac >- (qpat_assum `well_formed_type env.type_defs ret_type` ACCEPT_TAC)) >>
         (conj_tac >- (qpat_assum `well_typed_opt env drv` ACCEPT_TAC)) >>
-        qexistsl [`call_result2`, `args_st`, `call_result1`, `call_result3`] >>
-        simp[runtime_consistent_def, assert_def, bind_def, ignore_bind_def,
-             return_def, update_accounts_def, update_transient_def]) >>
+        qexistsl [`call_result2`,
+                   `args_st with logs := args_st.logs ++ call_result4`,
+                   `call_result1`, `call_result3`] >>
+        gvs[runtime_consistent_def, assert_def, bind_def, ignore_bind_def,
+            return_def, append_logs_def,
+            update_accounts_def, update_transient_def]) >>
       strip_tac >> gvs[assert_def, bind_def, return_def, raise_def, get_accounts_def, get_transient_storage_def, no_type_error_result_def]) >>
     drule_all extcall_nonstatic_args_runtime_typed_dest >> strip_tac >> gvs[] >>
     `vs <> [] /\ TL vs <> []` by (Cases_on `vs` >> gvs[exprs_runtime_typed_def] >> Cases_on `t` >> gvs[exprs_runtime_typed_def]) >>
@@ -1352,6 +1408,10 @@ Proof
     Cases_on `call_result0` >> gvs[return_def, raise_def]
     >- (
       `accounts_well_typed call_result2` by (drule_all run_ext_call_accounts_well_typed >> simp[]) >>
+      `runtime_consistent env cx args_st` by simp[runtime_consistent_def] >>
+      `runtime_consistent env cx
+         (args_st with logs := args_st.logs ++ call_result4)` by
+        metis_tac[runtime_consistent_logs_append] >>
       strip_tac >>
       qpat_x_assum `(do calldata <- return calldata_nonstatic; _ od) args_st = (res,st')` mp_tac >>
       simp[bind_def, return_def, get_accounts_def, get_transient_storage_def, assert_def] >>
@@ -1359,14 +1419,17 @@ Proof
       gvs[update_accounts_def, update_transient_def, bind_def, return_def] >>
       rewrite_tac[GSYM no_type_error_result_def] >>
       irule extcall_success_continuation_sound >>
-      (conj_tac >- simp[runtime_consistent_def]) >>
+      (conj_tac >-
+        metis_tac[runtime_consistent_logs_append, runtime_consistent_def]) >>
       (conj_tac >- (rpt strip_tac >> first_x_assum drule_all >> simp[no_type_error_result_def])) >>
       (conj_tac >- (qpat_assum `functions_well_typed cx` ACCEPT_TAC)) >>
       (conj_tac >- (qpat_assum `well_formed_type env.type_defs ret_type` ACCEPT_TAC)) >>
       (conj_tac >- (qpat_assum `well_typed_opt env drv` ACCEPT_TAC)) >>
-      qexistsl [`call_result2`, `args_st`, `call_result1`, `call_result3`] >>
-      simp[runtime_consistent_def, assert_def, bind_def, return_def,
-           update_accounts_def, update_transient_def]) >>
+      qexistsl [`call_result2`,
+                 `args_st with logs := args_st.logs ++ call_result4`,
+                 `call_result1`, `call_result3`] >>
+      gvs[runtime_consistent_def, assert_def, bind_def, return_def,
+          append_logs_def, update_accounts_def, update_transient_def]) >>
     strip_tac >> gvs[assert_def, bind_def, return_def, raise_def, get_accounts_def, get_transient_storage_def, no_type_error_result_def]) >>
   strip_tac >> gvs[]
 QED
@@ -1577,15 +1640,6 @@ Proof
   metis_tac[]
 QED
 
-Theorem runtime_consistent_logs_append:
-  !env cx st ls.
-    runtime_consistent env cx st ==>
-    runtime_consistent env cx (st with logs := st.logs ++ ls)
-Proof
-  rw[runtime_consistent_def, env_consistent_def, env_scopes_consistent_def,
-     env_immutables_consistent_def, state_well_typed_def] >>
-  metis_tac[]
-QED
 
 Theorem push_log_runtime_consistent:
   !env cx l st.

--- a/semantics/prop/vyperTypeExtCallSoundnessScript.sml
+++ b/semantics/prop/vyperTypeExtCallSoundnessScript.sml
@@ -1561,6 +1561,32 @@ Proof
      env_immutables_consistent_def, state_well_typed_def] >>
   metis_tac[]
 QED
+Theorem state_well_typed_logs_append:
+  !st ls. state_well_typed st ==>
+          state_well_typed (st with logs := st.logs ++ ls)
+Proof
+  simp[state_well_typed_def]
+QED
+
+Theorem env_consistent_logs_append:
+  !env cx st ls. env_consistent env cx st ==>
+                 env_consistent env cx (st with logs := st.logs ++ ls)
+Proof
+  rw[env_consistent_def, env_scopes_consistent_def,
+     env_immutables_consistent_def] >>
+  metis_tac[]
+QED
+
+Theorem runtime_consistent_logs_append:
+  !env cx st ls.
+    runtime_consistent env cx st ==>
+    runtime_consistent env cx (st with logs := st.logs ++ ls)
+Proof
+  rw[runtime_consistent_def, env_consistent_def, env_scopes_consistent_def,
+     env_immutables_consistent_def, state_well_typed_def] >>
+  metis_tac[]
+QED
+
 Theorem push_log_runtime_consistent:
   !env cx l st.
     runtime_consistent env cx st ==>
@@ -1986,7 +2012,7 @@ Theorem raw_log_tail_sound:
                topic_vals <<- (case topics of
                   TupleV vs => vs | DynArrayV vs => vs | _ => []);
                type_check (LENGTH topic_vals <= 4) "raw_log too many topics";
-               push_log ((NONE,"raw_log"), topic_vals ++ [BytesV data]);
+               push_log (encode_raw_event_values cx.txn.target topic_vals data);
                return (Value NoneV)
              od) st)) /\
     (!s. FST ((do
@@ -1996,7 +2022,7 @@ Theorem raw_log_tail_sound:
                  topic_vals <<- (case topics of
                     TupleV vs => vs | DynArrayV vs => vs | _ => []);
                  type_check (LENGTH topic_vals <= 4) "raw_log too many topics";
-                 push_log ((NONE,"raw_log"), topic_vals ++ [BytesV data]);
+                 push_log (encode_raw_event_values cx.txn.target topic_vals data);
                  return (Value NoneV)
                od) st) <> INR (Error (TypeError s)))
 Proof
@@ -2005,9 +2031,7 @@ Proof
   Cases_on `topics` >>
   rw[bind_def, ignore_bind_def, type_check_def, check_def, assert_def,
      raise_def, return_def, lift_option_type_def, push_log_def] >>
-  TRY (qmatch_goalsub_rename_tac `runtime_consistent env cx (st with logs updated_by CONS log)` >>
-       qspecl_then [`env`, `cx`, `st`] mp_tac runtime_consistent_logs_cons >>
-       simp[]) >>
+  TRY (irule runtime_consistent_logs_append >> simp[]) >>
   qpat_x_assum `FST _ = INR (Error (TypeError s))` mp_tac >>
   rw[bind_def, ignore_bind_def, type_check_def, check_def, assert_def,
      raise_def, return_def, lift_option_type_def, push_log_def]
@@ -2028,7 +2052,7 @@ Theorem raw_log_tail_result_sound:
         topic_vals <<- (case topics of
            TupleV vs => vs | DynArrayV vs => vs | _ => []);
         type_check (LENGTH topic_vals <= 4) "raw_log too many topics";
-        push_log ((NONE,"raw_log"), topic_vals ++ [BytesV data]);
+        push_log (encode_raw_event_values cx.txn.target topic_vals data);
         return (Value NoneV)
       od) st = (res, st')) ==>
     state_well_typed st' /\ env_consistent env cx st' /\ accounts_well_typed st'.accounts /\
@@ -2077,11 +2101,11 @@ Theorem raw_log_tail_result_sound_simp:
                             | DynArrayV vs' => vs'
                             | _ => []) <= 4) "raw_log too many topics";
                       x <- push_log
-                        ((NONE,"raw_log"),
-                         (case topics' of
-                          | TupleV vs => vs
-                          | DynArrayV vs' => vs'
-                          | _ => []) ++ [BytesV data]);
+                        (encode_raw_event_values cx.txn.target
+                          (case topics' of
+                           | TupleV vs => vs
+                           | DynArrayV vs' => vs'
+                           | _ => []) data);
                       return (Value NoneV)
                     od s''
                 | (INR e,s'') => (INR e,s''))
@@ -2105,9 +2129,9 @@ Proof
      evaluate_type_def, is_HashMapRef_def] >>
   fs[type_check_def, bind_def, ignore_bind_def, assert_def, return_def,
      push_log_def] >>
-  TRY (qmatch_goalsub_rename_tac `st with logs updated_by CONS log` >>
-       qspecl_then [`env`, `cx`, `st`, `log`] mp_tac runtime_consistent_logs_cons >>
-       simp[runtime_consistent_def]) >>
+  TRY (irule runtime_consistent_logs_append >> simp[]) >>
+  TRY (irule state_well_typed_logs_append >> simp[]) >>
+  TRY (irule env_consistent_logs_append >> simp[]) >>
   gvs[runtime_consistent_def] >>
   qpat_x_assum `(case check _ _ _ of _ => _) = _` mp_tac >>
   rw[bind_def, ignore_bind_def, check_def, assert_def, raise_def, return_def,

--- a/semantics/prop/vyperTypeStoragePreservationScript.sml
+++ b/semantics/prop/vyperTypeStoragePreservationScript.sml
@@ -1502,10 +1502,10 @@ QED
    external transition returned to the protected transaction target. *)
 Definition protected_storage_calls_preserve_def:
   protected_storage_calls_preserve cx <=>
-    !callee calldata value_opt st txp success returndata accounts' tStorage'.
+    !callee calldata value_opt st txp success returndata accounts' tStorage' emitted_logs.
       run_ext_call cx.txn.target callee calldata value_opt
         st.accounts st.tStorage txp =
-        SOME (success,returndata,accounts',tStorage') /\
+        SOME (success,returndata,accounts',tStorage',emitted_logs) /\
       contract_storage_well_formed cx st ==>
       contract_storage_well_formed cx
         (st with <| accounts := accounts'; tStorage := tStorage' |>)
@@ -1515,7 +1515,7 @@ Theorem protected_storage_calls_preserve_run_ext_call:
   protected_storage_calls_preserve cx /\
   run_ext_call cx.txn.target callee calldata value_opt
     st.accounts st.tStorage txp =
-    SOME (success,returndata,accounts',tStorage') /\
+    SOME (success,returndata,accounts',tStorage',emitted_logs) /\
   contract_storage_well_formed cx st ==>
   contract_storage_well_formed cx
     (st with <| accounts := accounts'; tStorage := tStorage' |>)
@@ -1527,7 +1527,7 @@ Theorem protected_storage_calls_preserve_success:
   protected_storage_calls_preserve cx /\
   run_ext_call cx.txn.target callee calldata value_opt
     st.accounts st.tStorage txp =
-    SOME (T,returndata,accounts',tStorage') /\
+    SOME (T,returndata,accounts',tStorage',emitted_logs) /\
   contract_storage_well_formed cx st ==>
   contract_storage_well_formed cx
     (st with <| accounts := accounts'; tStorage := tStorage' |>)
@@ -1539,7 +1539,7 @@ Theorem protected_storage_calls_preserve_revert:
   protected_storage_calls_preserve cx /\
   run_ext_call cx.txn.target callee calldata value_opt
     st.accounts st.tStorage txp =
-    SOME (F,returndata,accounts',tStorage') /\
+    SOME (F,returndata,accounts',tStorage',emitted_logs) /\
   contract_storage_well_formed cx st ==>
   contract_storage_well_formed cx
     (st with <| accounts := accounts'; tStorage := tStorage' |>)
@@ -1551,7 +1551,7 @@ Theorem protected_storage_call_output_persistent_region:
   protected_storage_calls_preserve cx /\
   run_ext_call cx.txn.target callee calldata value_opt
     st.accounts st.tStorage txp =
-    SOME (success,returndata,accounts',tStorage') /\
+    SOME (success,returndata,accounts',tStorage',emitted_logs) /\
   contract_storage_well_formed cx st /\
   declared_storage_region cx mid n subs = SOME (F,slot,tv) /\
   get_storage_backend cx F
@@ -1567,7 +1567,7 @@ Theorem protected_storage_call_output_transient_region:
   protected_storage_calls_preserve cx /\
   run_ext_call cx.txn.target callee calldata value_opt
     st.accounts st.tStorage txp =
-    SOME (success,returndata,accounts',tStorage') /\
+    SOME (success,returndata,accounts',tStorage',emitted_logs) /\
   contract_storage_well_formed cx st /\
   declared_storage_region cx mid n subs = SOME (T,slot,tv) /\
   get_storage_backend cx T

--- a/semantics/vyperEventScript.sml
+++ b/semantics/vyperEventScript.sml
@@ -1,0 +1,92 @@
+(*
+ * Concrete EVM event encoding for the Vyper semantics.
+ *
+ * TOP-LEVEL:
+ *   event_info       -- checked metadata needed to encode declared events
+ *   encode_vyper_event -- encode a declared Vyper event as an EVM event
+ *   encode_raw_event -- construct an EVM event for raw_log
+ *)
+
+Theory vyperEvent
+Ancestors
+  cv cv_std vyperABI vyperValue contractABI vfmTypes
+  byte keccak
+Libs
+  cv_transLib
+
+Type event_info = “:string -> (num # type list # bool list) option”
+
+Definition is_event_bytestring_type_def:
+  is_event_bytestring_type (BaseT (BytesT (Dynamic _))) = T ∧
+  is_event_bytestring_type (BaseT (StringT _)) = T ∧
+  is_event_bytestring_type _ = F
+End
+
+(* Primitive word encoding used for indexed, statically-sized arguments. *)
+Definition event_value_to_word_def:
+  event_value_to_word (BoolV b) = (if b then 1w else 0w : bytes32) ∧
+  event_value_to_word (IntV n) = (i2w n : bytes32) ∧
+  event_value_to_word (FlagV k) = (n2w k : bytes32) ∧
+  event_value_to_word (DecimalV n) = (i2w n : bytes32) ∧
+  event_value_to_word (BytesV bs) =
+    (if LENGTH bs = 20 then word_of_bytes_be (PAD_LEFT 0w 32 bs)
+     else word_of_bytes_be (PAD_RIGHT 0w 32 bs)) ∧
+  event_value_to_word _ = 0w
+End
+
+Definition encode_event_topic_def:
+  encode_event_topic T (BytesV bs) =
+    SOME (word_of_bytes_be (Keccak_256_w64 bs)) ∧
+  encode_event_topic T (StringV s) =
+    SOME (word_of_bytes_be (Keccak_256_w64 (MAP (n2w o ORD) s))) ∧
+  encode_event_topic T _ = NONE ∧
+  encode_event_topic F v = SOME (event_value_to_word v)
+End
+
+Definition encode_indexed_event_topics_def:
+  encode_indexed_event_topics [] [] [] = SOME ([] : bytes32 list) ∧
+  encode_indexed_event_topics (T::fs) (ty::tys) (v::vs) =
+    (case encode_event_topic (is_event_bytestring_type ty) v of
+     | NONE => NONE
+     | SOME topic =>
+         OPTION_MAP (CONS topic) (encode_indexed_event_topics fs tys vs)) ∧
+  encode_indexed_event_topics (F::fs) (_::tys) (_::vs) =
+    encode_indexed_event_topics fs tys vs ∧
+  encode_indexed_event_topics _ _ _ = NONE
+End
+
+Definition non_indexed_event_args_def:
+  non_indexed_event_args [] [] [] = SOME ([] : (type # value) list) ∧
+  non_indexed_event_args (T::fs) (_::tys) (_::vs) =
+    non_indexed_event_args fs tys vs ∧
+  non_indexed_event_args (F::fs) (ty::tys) (v::vs) =
+    OPTION_MAP (CONS (ty,v)) (non_indexed_event_args fs tys vs) ∧
+  non_indexed_event_args _ _ _ = NONE
+End
+
+Definition encode_vyper_event_def:
+  encode_vyper_event event_info tenv (logger : address) event_name vals =
+    case event_info event_name of
+    | NONE => NONE
+    | SOME (event_hash, arg_types, indexed_flags) =>
+        case encode_indexed_event_topics indexed_flags arg_types vals of
+        | NONE => NONE
+        | SOME indexed_topics =>
+            case non_indexed_event_args indexed_flags arg_types vals of
+            | NONE => NONE
+            | SOME typed_vals =>
+                case vyper_to_abi_list tenv (MAP FST typed_vals)
+                                            (MAP SND typed_vals) of
+                | NONE => NONE
+                | SOME abi_vals =>
+                    SOME <| logger := logger;
+                            topics := n2w event_hash :: indexed_topics;
+                            data := enc (Tuple (vyper_to_abi_types tenv
+                                                (MAP FST typed_vals)))
+                                        (ListV abi_vals) |>
+End
+
+Definition encode_raw_event_def:
+  encode_raw_event (logger : address) topics data : event =
+    <| logger := logger; topics := topics; data := data |>
+End

--- a/semantics/vyperEventScript.sml
+++ b/semantics/vyperEventScript.sml
@@ -8,6 +8,7 @@
  *   encode_vyper_event         -- compatibility wrapper for lookup functions
  *   encode_source_event        -- resolve and encode from authoritative sources
  *   encode_raw_event           -- construct an EVM event for raw_log
+ *   encode_raw_event_values    -- construct raw_log output from Vyper values
  *)
 
 Theory vyperEvent
@@ -98,6 +99,27 @@ Definition non_indexed_event_args_def:
   non_indexed_event_args _ _ _ = NONE
 End
 
+val encode_indexed_event_topics_pre_def =
+  cv_auto_trans_pre "encode_indexed_event_topics_pre"
+                    encode_indexed_event_topics_def;
+
+Theorem encode_indexed_event_topics_pre[cv_pre]:
+  ∀flags tys vals. encode_indexed_event_topics_pre flags tys vals
+Proof
+  ho_match_mp_tac encode_indexed_event_topics_ind >> rw[] >>
+  rw[Once encode_indexed_event_topics_pre_def]
+QED
+
+val non_indexed_event_args_pre_def =
+  cv_auto_trans_pre "non_indexed_event_args_pre" non_indexed_event_args_def;
+
+Theorem non_indexed_event_args_pre[cv_pre]:
+  ∀flags tys vals. non_indexed_event_args_pre flags tys vals
+Proof
+  ho_match_mp_tac non_indexed_event_args_ind >> rw[] >>
+  rw[Once non_indexed_event_args_pre_def]
+QED
+
 Definition encode_vyper_event_metadata_def:
   encode_vyper_event_metadata tenv (logger : address)
                               (event_hash, arg_types, indexed_flags) vals =
@@ -136,4 +158,9 @@ End
 Definition encode_raw_event_def:
   encode_raw_event (logger : address) topics data : event =
     <| logger := logger; topics := topics; data := data |>
+End
+
+Definition encode_raw_event_values_def:
+  encode_raw_event_values logger topic_vals data =
+    encode_raw_event logger (MAP event_value_to_word topic_vals) data
 End

--- a/semantics/vyperEventScript.sml
+++ b/semantics/vyperEventScript.sml
@@ -14,9 +14,9 @@
 Theory vyperEvent
 Ancestors
   cv cv_std vyperABI vyperValue contractABI vfmTypes
-  byte keccak
+  byte keccak words
 Libs
-  cv_transLib
+  cv_transLib wordsLib
 
 Type event_metadata = “:num # type list # bool list”
 Type event_info = “:string -> event_metadata option”

--- a/semantics/vyperEventScript.sml
+++ b/semantics/vyperEventScript.sml
@@ -2,9 +2,12 @@
  * Concrete EVM event encoding for the Vyper semantics.
  *
  * TOP-LEVEL:
- *   event_info       -- checked metadata needed to encode declared events
- *   encode_vyper_event -- encode a declared Vyper event as an EVM event
- *   encode_raw_event -- construct an EVM event for raw_log
+ *   event_metadata             -- resolved declaration encoding information
+ *   lookup_event_metadata      -- resolve an event directly from loaded sources
+ *   encode_vyper_event_metadata -- encode already-resolved metadata
+ *   encode_vyper_event         -- compatibility wrapper for lookup functions
+ *   encode_source_event        -- resolve and encode from authoritative sources
+ *   encode_raw_event           -- construct an EVM event for raw_log
  *)
 
 Theory vyperEvent
@@ -14,7 +17,38 @@ Ancestors
 Libs
   cv_transLib
 
-Type event_info = “:string -> (num # type list # bool list) option”
+Type event_metadata = “:num # type list # bool list”
+Type event_info = “:string -> event_metadata option”
+
+Definition event_hash_def:
+  event_hash tenv ename (arg_types : type list) =
+    let abi_types = vyper_to_abi_types tenv arg_types in
+    let sig_str = function_signature ename abi_types in
+    let hash_bytes = Keccak_256_w64 (MAP (n2w o ORD) sig_str) in
+    num_of_bytes (be_bytes 32 [] hash_bytes)
+End
+
+Definition lookup_event_metadata_in_def:
+  lookup_event_metadata_in _ _ [] = NONE ∧
+  lookup_event_metadata_in tenv ename (EventDecl name args_indexed :: rest) =
+    (if name = ename then
+       let arg_types = MAP (SND o FST) args_indexed in
+       let indexed_flags = MAP SND args_indexed in
+         SOME (event_hash tenv name arg_types, arg_types, indexed_flags)
+     else lookup_event_metadata_in tenv ename rest) ∧
+  lookup_event_metadata_in tenv ename (_ :: rest) =
+    lookup_event_metadata_in tenv ename rest
+End
+
+Definition lookup_event_metadata_def:
+  lookup_event_metadata tenv sources target (src_id_opt, ename) =
+    case ALOOKUP sources target of
+    | NONE => NONE
+    | SOME mods =>
+        case ALOOKUP mods src_id_opt of
+        | NONE => NONE
+        | SOME tops => lookup_event_metadata_in tenv ename tops
+End
 
 Definition is_event_bytestring_type_def:
   is_event_bytestring_type (BaseT (BytesT (Dynamic _))) = T ∧
@@ -64,26 +98,39 @@ Definition non_indexed_event_args_def:
   non_indexed_event_args _ _ _ = NONE
 End
 
+Definition encode_vyper_event_metadata_def:
+  encode_vyper_event_metadata tenv (logger : address)
+                              (event_hash, arg_types, indexed_flags) vals =
+    case encode_indexed_event_topics indexed_flags arg_types vals of
+    | NONE => NONE
+    | SOME indexed_topics =>
+        case non_indexed_event_args indexed_flags arg_types vals of
+        | NONE => NONE
+        | SOME typed_vals =>
+            case vyper_to_abi_list tenv (MAP FST typed_vals)
+                                        (MAP SND typed_vals) of
+            | NONE => NONE
+            | SOME abi_vals =>
+                SOME <| logger := logger;
+                        topics := n2w event_hash :: indexed_topics;
+                        data := enc (Tuple (vyper_to_abi_types tenv
+                                            (MAP FST typed_vals)))
+                                    (ListV abi_vals) |>
+End
+
+(* Compatibility wrapper for compiler environments and other lookup maps. *)
 Definition encode_vyper_event_def:
-  encode_vyper_event event_info tenv (logger : address) event_name vals =
+  encode_vyper_event event_info tenv logger event_name vals =
     case event_info event_name of
     | NONE => NONE
-    | SOME (event_hash, arg_types, indexed_flags) =>
-        case encode_indexed_event_topics indexed_flags arg_types vals of
-        | NONE => NONE
-        | SOME indexed_topics =>
-            case non_indexed_event_args indexed_flags arg_types vals of
-            | NONE => NONE
-            | SOME typed_vals =>
-                case vyper_to_abi_list tenv (MAP FST typed_vals)
-                                            (MAP SND typed_vals) of
-                | NONE => NONE
-                | SOME abi_vals =>
-                    SOME <| logger := logger;
-                            topics := n2w event_hash :: indexed_topics;
-                            data := enc (Tuple (vyper_to_abi_types tenv
-                                                (MAP FST typed_vals)))
-                                        (ListV abi_vals) |>
+    | SOME metadata => encode_vyper_event_metadata tenv logger metadata vals
+End
+
+Definition encode_source_event_def:
+  encode_source_event tenv sources target event_id vals =
+    case lookup_event_metadata tenv sources target event_id of
+    | NONE => NONE
+    | SOME metadata => encode_vyper_event_metadata tenv target metadata vals
 End
 
 Definition encode_raw_event_def:

--- a/semantics/vyperEventScript.sml
+++ b/semantics/vyperEventScript.sml
@@ -41,6 +41,26 @@ Definition lookup_event_metadata_in_def:
     lookup_event_metadata_in tenv ename rest
 End
 
+Theorem lookup_event_metadata_in_some:
+  lookup_event_metadata_in tenv ename tops = SOME metadata ⇒
+  ∃args.
+    MEM (EventDecl ename args) tops ∧
+    metadata =
+      (event_hash tenv ename (MAP (SND o FST) args),
+       MAP (SND o FST) args,
+       MAP SND args)
+Proof
+  Induct_on `tops`
+  >- simp[lookup_event_metadata_in_def]
+  >> Cases_on `h`
+  >> gvs[lookup_event_metadata_in_def]
+  >> Cases_on `s = ename`
+  >> gvs[]
+  >> strip_tac
+  >> qexists `l`
+  >> simp[]
+QED
+
 Definition lookup_event_metadata_def:
   lookup_event_metadata tenv sources target (src_id_opt, ename) =
     case ALOOKUP sources target of
@@ -49,6 +69,15 @@ Definition lookup_event_metadata_def:
         case ALOOKUP mods src_id_opt of
         | NONE => NONE
         | SOME tops => lookup_event_metadata_in tenv ename tops
+End
+
+(* A name resolves to at most one event declaration shape in a module. *)
+Definition event_decl_unique_def:
+  event_decl_unique ename tops ⇔
+    ∀args args'.
+      MEM (EventDecl ename args) tops ∧
+      MEM (EventDecl ename args') tops ⇒
+      args = args'
 End
 
 Definition is_event_bytestring_type_def:

--- a/semantics/vyperInterpreterScript.sml
+++ b/semantics/vyperInterpreterScript.sml
@@ -4,14 +4,14 @@ Ancestors
   rich_list cv cv_std vfmState vfmContext vfmCompute[ignore_grammar]
   vfmExecution[ignore_grammar] vyperAST vyperABI
   vyperMisc vyperValue vyperValueOperation vyperStorage vyperContext vyperState
-  vyperCreate
+  vyperEvent vyperCreate
 Libs
   cv_transLib wordsLib monadsyntax
 
 (* writing logs *)
 
 Definition push_log_def:
-  push_log log st = return () $ st with logs updated_by CONS log
+  push_log log st = return () $ st with logs := st.logs ++ [log]
 End
 
 val () = cv_auto_trans push_log_def;
@@ -1011,10 +1011,13 @@ Definition evaluate_def:
        od)
   od ∧
   eval_stmt cx (Log id es) = do
-    (* TODO(semantic-limitation): event argument length/type checking is
-       currently delegated to frontend/type-system assumptions. *)
+    (* Checked programs guarantee that the declaration exists and that its
+       evaluated arguments can be encoded using the declared types. *)
     vs <- eval_exprs cx es;
-    push_log (id, vs)
+    event <- lift_option
+      (encode_source_event (get_tenv cx) cx.sources cx.txn.target id vs)
+      "Log encode event";
+    push_log event
   od ∧
   eval_stmt cx (AnnAssign id typ e) = do
     tenv <<- get_tenv cx;
@@ -1330,8 +1333,7 @@ Definition evaluate_def:
     topic_vals <<- (case topics of
        TupleV vs => vs | DynArrayV vs => vs | _ => []);
     type_check (LENGTH topic_vals ≤ 4) "raw_log too many topics";
-    (* Store as raw log: nsid = (NONE,"raw_log"), values = topic bytes ++ [data] *)
-    push_log ((NONE,"raw_log"), topic_vals ++ [BytesV data]);
+    push_log (encode_raw_event_values cx.txn.target topic_vals data);
     return $ Value NoneV
   od ∧
   (* raw_revert(data) — terminus *)
@@ -1535,7 +1537,7 @@ Definition initial_state_def:
   initial_state (am: abstract_machine) scs : evaluation_state =
   <| accounts := am.accounts
    ; immutables := am.immutables
-   ; logs := []
+   ; logs := am.logs
    ; scopes := scs
    ; tStorage := am.tStorage
    |>

--- a/semantics/vyperInterpreterScript.sml
+++ b/semantics/vyperInterpreterScript.sml
@@ -14,7 +14,12 @@ Definition push_log_def:
   push_log log st = return () $ st with logs := st.logs ++ [log]
 End
 
+Definition append_logs_def:
+  append_logs logs st = return () $ st with logs := st.logs ++ logs
+End
+
 val () = cv_auto_trans push_log_def;
+val () = cv_auto_trans append_logs_def;
 
 (* manipulating (internal call) function stack *)
 
@@ -731,9 +736,9 @@ Definition extract_call_result_def:
          | INR NONE =>  (* success - no exception *)
              SOME (T, ctxt.returnData,
                    final_state.rollback.accounts,
-                   final_state.rollback.tStorage)
-         | INR (SOME Reverted) =>  (* revert - return original state *)
-             SOME (F, ctxt.returnData, orig_accounts, orig_tStorage)
+                   final_state.rollback.tStorage, ctxt.logs)
+         | INR (SOME Reverted) =>  (* revert - discard callee effects *)
+             SOME (F, ctxt.returnData, orig_accounts, orig_tStorage, [])
          | _ => NONE)  (* other exception or still running *)
     | _ => NONE  (* shouldn't happen for single-context call *)
 End
@@ -877,7 +882,8 @@ End
    - tStorage: current transient storage
    - txParams: transaction parameters (preserves tx.origin, block info)
 
-   Returns SOME (success, returnData, accounts', tStorage') or NONE on error. *)
+   Returns SOME (success, returnData, accounts', tStorage', emitted_logs)
+   or NONE on error. Reverted calls return an empty emitted-log list. *)
 Definition run_ext_call_def:
   run_ext_call caller callee calldata value_opt
                accounts tStorage txParams =
@@ -1234,10 +1240,11 @@ Definition evaluate_def:
     result <- lift_option
       (run_ext_call caller target_addr calldata value_opt accounts tStorage txParams)
       "ExtCall run failed";
-    (success, returnData, accounts', tStorage') <<- result;
+    (success, returnData, accounts', tStorage', emitted_logs) <<- result;
     check success "ExtCall reverted";
     update_accounts (K accounts');
     update_transient (K tStorage');
+    append_logs emitted_logs;
     if returnData = [] ∧ IS_SOME drv then
       eval_expr cx (THE drv)
     else do
@@ -1311,9 +1318,10 @@ Definition evaluate_def:
     result <- lift_option
       (run_ext_call caller target_addr calldata value_opt accounts tStorage txParams)
       "raw_call run failed";
-    (success, returnData, accounts', tStorage') <<- result;
+    (success, returnData, accounts', tStorage', emitted_logs) <<- result;
     update_accounts (K accounts');
     update_transient (K tStorage');
+    append_logs emitted_logs;
     if flags.rcf_revert_on_failure then do
       check success "raw_call reverted";
       if flags.rcf_max_outsize = 0 then return $ Value NoneV

--- a/semantics/vyperInterpreterScript.sml
+++ b/semantics/vyperInterpreterScript.sml
@@ -1755,6 +1755,17 @@ Definition call_external_def:
        call_external_function am cx nr mut ts all_mods args dflts tx.args body ret
 End
 
+(* Explicit transaction boundary. Ordinary function entry preserves accumulated
+   logs so that nested and sequential calls can share one transaction trace;
+   callers use this wrapper when starting a fresh top-level transaction. *)
+Definition clear_machine_logs_def:
+  clear_machine_logs (am: abstract_machine) = am with logs := []
+End
+
+Definition call_external_transaction_def:
+  call_external_transaction am tx = call_external (clear_machine_logs am) tx
+End
+
 Definition load_contract_def:
   load_contract am tx mods exps =
   let addr = tx.target in

--- a/semantics/vyperSmallStepScript.sml
+++ b/semantics/vyperSmallStepScript.sml
@@ -3,7 +3,7 @@ Ancestors
   arithmetic combin pair list While
   vyperMisc vyperValue vyperContext vyperState vyperCreate vyperInterpreter vyperABI
 Libs
-  cv_transLib
+  cv_transLib wordsLib
 
 (*
   plan for cps version:

--- a/semantics/vyperSmallStepScript.sml
+++ b/semantics/vyperSmallStepScript.sml
@@ -669,10 +669,11 @@ Definition apply_vals_def:
       result <- lift_option
         (run_ext_call caller target_addr calldata value_opt accounts tStorage txParams)
         "ExtCall run failed";
-      (success, returnData, accounts', tStorage') <<- result;
+      (success, returnData, accounts', tStorage', emitted_logs) <<- result;
       check success "ExtCall reverted";
       update_accounts (K accounts');
       update_transient (K tStorage');
+      append_logs emitted_logs;
       if returnData = [] ∧ IS_SOME drv then
         return (INL (THE drv))
       else do
@@ -727,9 +728,10 @@ Definition apply_vals_def:
       result <- lift_option
         (run_ext_call caller target_addr calldata value_opt accounts tStorage txParams)
         "raw_call run failed";
-      (success, returnData, accounts', tStorage') <<- result;
+      (success, returnData, accounts', tStorage', emitted_logs) <<- result;
       update_accounts (K accounts');
       update_transient (K tStorage');
+      append_logs emitted_logs;
       if flags.rcf_revert_on_failure then do
         check success "raw_call reverted";
         if flags.rcf_max_outsize = 0 then return $ Value NoneV
@@ -1479,13 +1481,14 @@ Proof
     >- (
       disch_then kall_tac >>
       simp[Abbr`cc1`,Abbr`cc2`,Abbr`gg`,bind_def] >>
-      ntac 4 CASE_TAC >> simp[] >>
+      ntac 5 CASE_TAC >> simp[] >>
       Cases_on`q` >> simp[] >>
       Cases_on`q'` >> simp[] >>
       Cases_on`q''` >> simp[] >>
-      Cases_on`q'''` >> simp[return_def])
+      Cases_on`q'''` >> simp[] >>
+      Cases_on`q''''` >> simp[return_def])
     >> gvs[bind_def,Abbr`gg`] >> disch_then drule
-    >> ntac 3 (
+    >> ntac 4 (
       qmatch_asmsub_abbrev_tac`pair_CASE lot`
       >> Cases_on`lot` >> reverse(Cases_on`q`)
       >- ( simp[Abbr`cc1`,Abbr`cc2`,ignore_bind_def,bind_def] )

--- a/semantics/vyperSmallStepScript.sml
+++ b/semantics/vyperSmallStepScript.sml
@@ -630,7 +630,12 @@ Definition apply_vals_def:
       return $ Value v
     od st) k ∧
   apply_vals cx vs st (LogK id k) =
-    liftk cx (K Apply) (push_log (id, vs) st) k ∧
+    liftk cx (K Apply) (do
+      event <- lift_option
+        (encode_source_event (get_tenv cx) cx.sources cx.txn.target id vs)
+        "Log encode event";
+      push_log event
+    od st) k ∧
   apply_vals cx vs st (CallSendK k) =
     liftk cx ApplyTv (do
       type_check (LENGTH vs = 2) "CallSendK nargs";
@@ -744,7 +749,7 @@ Definition apply_vals_def:
       topic_vals <<- (case topics of
          TupleV tvs => tvs | DynArrayV tvs => tvs | _ => []);
       type_check (LENGTH topic_vals ≤ 4) "raw_log too many topics";
-      push_log ((NONE,"raw_log"), topic_vals ++ [BytesV data]);
+      push_log (encode_raw_event_values cx.txn.target topic_vals data);
       return $ Value NoneV
     od st
     of (INR ex, st) => AK cx (ApplyExc ex) st k
@@ -1073,7 +1078,7 @@ Proof
     rw[eval_stmt_cps_def, evaluate_def, bind_def]
     \\ CASE_TAC \\ rw[cont_def] \\ reverse CASE_TAC
     >- rw[Once OWHILE_THM, stepk_def, apply_exc_def]
-    \\ rw[Once OWHILE_THM, stepk_def, apply_vals_def, liftk1])
+    \\ rw[Once OWHILE_THM, stepk_def, apply_vals_def, bind_def, liftk1])
   \\ conj_tac >- ( (* AnnAssign id typ e *)
     rw[eval_stmt_cps_def, evaluate_def, bind_def]
     \\ CASE_TAC \\ rw[cont_def] \\ reverse CASE_TAC

--- a/semantics/vyperSmallStepScript.sml
+++ b/semantics/vyperSmallStepScript.sml
@@ -1838,5 +1838,7 @@ Proof
 QED
 
 val () = cv_auto_trans call_external_def;
+val () = cv_auto_trans clear_machine_logs_def;
+val () = cv_auto_trans call_external_transaction_def;
 
 val () = cv_auto_trans load_contract_def;

--- a/semantics/vyperStateScript.sml
+++ b/semantics/vyperStateScript.sml
@@ -1,7 +1,7 @@
 Theory vyperState
 Ancestors
   arithmetic alist combin option list finite_map pair rich_list
-  cv cv_std vfmState vfmContext vfmExecution[ignore_grammar]
+  cv cv_std vfmTypes vfmState vfmContext vfmExecution[ignore_grammar]
   vyperAST vyperMisc vyperValue vyperValueOperation
   vyperStorage vyperContext
 Libs
@@ -108,7 +108,8 @@ End
 
 val () = cv_auto_trans find_containing_scope_def;
 
-Type log = “:nsid # (value list)”;
+(* Transaction-level, externally observable EVM event. *)
+Type log = “:event”;
 
 (* Module-aware immutables: keyed by source_id *)
 (* NONE = main contract, SOME n = module with source_id n *)

--- a/vyperHolScript.sml
+++ b/vyperHolScript.sml
@@ -10,6 +10,7 @@ Ancestors
   (* syntax, frontend, semantics *)
   jsonToVyper
   vyperTestRunner
+  vyperEvent
   (* semantics properties *)
   vyperSemanticsHol
   (* compiler passes *)


### PR DESCRIPTION
Closes #439.

## Summary

Align Vyper source-level logs with Verifereum's concrete EVM event semantics.

- represent interpreter and abstract-machine logs directly as `vfmTypes$event`;
- encode declared Vyper events to concrete logger/topics/data records at emission time;
- construct `raw_log` events in the same concrete representation;
- preserve incoming logs across ordinary function entry and append emissions chronologically;
- incorporate successful Verifereum callee logs at external-call sites while discarding reverted callee logs;
- provide an explicit fresh-transaction boundary that clears accumulated logs;
- simplify lowering and E2E log correspondence to concrete event equality;
- prove source event encoding agrees with compiler lowering;
- prove semantic event metadata lookup agrees with compiler `build_event_info` under per-name declaration uniqueness;
- prove evaluator-wide log-prefix preservation for expressions, statements, internal calls, and public external entry.

## Semantic model

Logs are transaction-level EVM observations. Ordinary call/function entry does not clear them. `push_log` and external-call incorporation append in chronological order. Reverted external calls contribute no events, and propagated errors retain the existing exact rollback behavior. A caller starting a new top-level transaction uses `call_external_transaction`, which first applies `clear_machine_logs`.

Event metadata is resolved from the authoritative loaded source modules rather than duplicated in the evaluation context. The compiler continues to build its executable event-info function; agreement with direct semantic lookup is proved for the currently supported main-module compilation path.

## Main theorem surface

The PR includes results covering:

- concrete declared/raw event encoding and lowering compatibility;
- `initial_state` log preservation;
- exact `push_log` and `append_logs` behavior;
- successful/reverted external-call result logs;
- evaluator log-prefix preservation;
- external-call success extension and exact error rollback;
- fresh-transaction clearing and input-log independence;
- compiler/source event metadata agreement.

## Validation

Focused theory builds pass locally with `--tactic-timeout 5`, including:

- `vyperEventTheory`
- `vyperInterpreterTheory`
- `vyperSmallStepTheory`
- `vyperLogPreservationTheory`
- `compileVyperTheory`
- `e2eCorrectnessTheory`
- `vyperSemanticsHolTheory`

The full project build is left to CI.

## Notes

The existing cheats in `lowering/e2eCorrectnessScript.sml` predate this change; this PR introduces no new cheats.
