### PR TITLE
Fix self-transfer semantics and clarify deployment value handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Interface declarations (`InterfaceDecl`) are included in the AST, with interface
 
 The formal semantics for Vyper is defined across several theories in `semantics/`. The top-level entry-points are `load_contract` (for running a contract-deployment transaction given the Vyper source code of the contract), and `call_external` (for calling an external function of an already-deployed contract). These entry-points use the `eval_stmts` function defined in `evaluate_def` for interpreting Vyper code. These functions operate on Vyper values; see the test infrastructure below for how to wrap these calls with encoding/decoding to ABI-encoded bytes.
 
+`load_contract` is a Vyper-level deployment abstraction rather than a model of the EVM `CREATE` or `CREATE2` instructions. Its transaction supplies the target address directly, and successful deployment installs Vyper sources and exports. In contrast, Verifereum's EVM creation semantics derives the created address, updates creator and created-account nonces, executes init code, and installs runtime bytecode. Relating these two boundaries is an obligation of the Vyper-to-EVM compiler-correctness development. Vyper-level constructor value transfer is not omitted: it uses the ordinary external-function call path, retaining the updated accounts on success and rolling back to the input abstract machine on failure.
+
 The semantics is organised into layers:
 - **Values and types** — runtime values (`value`), type representations (`type_value`), and operations on values such as arithmetic, comparisons, conversions, and array manipulation.
 - **Storage** — encoding and decoding of Vyper values to/from EVM storage slots, and hashmap slot computation using Keccak256.

--- a/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
+++ b/semantics/prop/vyperEvalPreservesImmutablesDomScript.sml
@@ -66,8 +66,9 @@ Theorem transfer_value_immutables[local]:
   ∀f t a st res st'.
     transfer_value f t a st = (res, st') ⇒ st'.immutables = st.immutables
 Proof
-  rw[transfer_value_def, bind_def, ignore_bind_def, get_accounts_def, return_def,
-     check_def, type_check_def, assert_def, update_accounts_def] >> gvs[raise_def]
+  rpt strip_tac >>
+  drule vyperStatePreservationTheory.transfer_value_immutables >>
+  simp[]
 QED
 
 Theorem lookup_flag_mem_immutables[local]:

--- a/semantics/prop/vyperEvalPreservesScopesScript.sml
+++ b/semantics/prop/vyperEvalPreservesScopesScript.sml
@@ -1867,14 +1867,9 @@ Proof
          return_def] >>
     imp_res_tac type_check_state >>
     imp_res_tac lift_option_type_state >>
-    imp_res_tac transfer_value_scopes >> gvs[] >>
-    TRY (
-      qmatch_assum_rename_tac`ss1.scopes = ss2.scopes` >>
-      `ss1.immutables = ss2.immutables` by (
-        gvs[transfer_value_def, bind_apply, ignore_bind_apply,
-            check_def, assert_def, update_accounts_def,
-            get_accounts_def, return_def, AllCaseEqs()] ) ) >>
-    gvs[] >> first_x_assum drule_all >> rw[] >>
+    imp_res_tac transfer_value_scopes >>
+    imp_res_tac transfer_value_immutables >> gvs[] >>
+    first_x_assum drule_all >> rw[] >>
     gvs[preserves_tv_def] ) >>
   (* ExtCall *)
   conj_tac >- (

--- a/semantics/prop/vyperExprNoControlScript.sml
+++ b/semantics/prop/vyperExprNoControlScript.sml
@@ -212,7 +212,11 @@ Theorem transfer_value_no_control:
   ∀from to amt s exc s'.
   transfer_value from to amt s = (INR exc, s') ⇒ no_control_exc exc
 Proof
-  rpt gen_tac >> simp[transfer_value_def, bind_def, ignore_bind_def,
+  rpt gen_tac >>
+  rename1 `transfer_value fromAddr toAddr amount st = (INR exc, st') ⇒ no_control_exc exc` >>
+  Cases_on `amount = 0 ∨ fromAddr = toAddr`
+  >- simp[transfer_value_def, return_def]
+  >> simp[transfer_value_def, bind_def, ignore_bind_def,
     get_accounts_def, return_def, update_accounts_def]
   >> strip_tac >> gvs[AllCaseEqs(), return_def]
   >> imp_res_tac check_no_control

--- a/semantics/prop/vyperScopePreservationScript.sml
+++ b/semantics/prop/vyperScopePreservationScript.sml
@@ -196,7 +196,7 @@ Theorem transfer_value_scopes:
   !f t a st res st'. transfer_value f t a st = (res, st') ==> st'.scopes = st.scopes
 Proof
   rw[transfer_value_def, bind_def, ignore_bind_def, get_accounts_def, return_def, check_def, type_check_def, assert_def, update_accounts_def] >>
-  gvs[raise_def]
+  gvs[AllCaseEqs(), raise_def]
 QED
 
 Theorem lookup_flag_mem_scopes:

--- a/semantics/prop/vyperStatePreservationScript.sml
+++ b/semantics/prop/vyperStatePreservationScript.sml
@@ -212,7 +212,7 @@ Proof
   rw[transfer_value_def, bind_def, get_accounts_def, return_def,
      check_def, raise_def, update_accounts_def, ignore_bind_def,
      assert_def] >>
-  rpt (CASE_TAC >> gvs[return_def, raise_def]) >> gvs[]
+  gvs[AllCaseEqs(), return_def, raise_def]
 QED
 
 Theorem push_log_immutables:

--- a/semantics/prop/vyperTypeContractSoundnessScript.sml
+++ b/semantics/prop/vyperTypeContractSoundnessScript.sml
@@ -909,7 +909,9 @@ Proof
       combinTheory.APPLY_UPDATE_THM] >>
   rpt strip_tac >> gvs[] >>
   rpt (IF_CASES_TAC >> gvs[]) >>
-  first_x_assum (qspec_then `addr` mp_tac) >> decide_tac
+  first_x_assum (qspec_then `addr` mp_tac) >>
+  simp[vfmStateTheory.update_account_def, combinTheory.APPLY_UPDATE_THM] >>
+  rpt (IF_CASES_TAC >> gvs[]) >> decide_tac
 QED
 
 Theorem send_call_value_no_control_c53:

--- a/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
+++ b/semantics/prop/vyperTypeEvalStoragePreservationScript.sml
@@ -2504,10 +2504,12 @@ Theorem transfer_value_storage_frame[local]:
 Proof
   rpt strip_tac >>
   qpat_x_assum `transfer_value _ _ _ _ = _` mp_tac >>
+  Cases_on `amount = 0 ∨ fromAddr = toAddr`
+  >- gvs[transfer_value_def, return_def] >>
   simp[transfer_value_def, bind_apply, ignore_bind_apply,
        get_accounts_def, check_def, assert_def, update_accounts_def,
        return_def, raise_def] >>
-  rpt IF_CASES_TAC >> gvs[] >> rpt strip_tac >> gvs[] >>
+  rpt IF_CASES_TAC >> gvs[return_def] >> rpt strip_tac >> gvs[] >>
   Cases_on `b` >>
   simp[vyperStorageBackendTheory.get_storage_def,
        vfmStateTheory.update_account_def, vfmStateTheory.lookup_account_def,

--- a/semantics/prop/vyperTypeExtCallSoundnessScript.sml
+++ b/semantics/prop/vyperTypeExtCallSoundnessScript.sml
@@ -19,6 +19,18 @@ Ancestors
 Libs
   wordsLib markerLib intLib
 
+Theorem transfer_value_zero[simp]:
+  transfer_value from to 0 st = (INL (), st)
+Proof
+  simp[transfer_value_def, return_def]
+QED
+
+Theorem transfer_value_same_address[simp]:
+  transfer_value addr addr amount st = (INL (), st)
+Proof
+  simp[transfer_value_def, return_def]
+QED
+
 Theorem transfer_value_recipient_overflow_regression:
   let from = (0w:address) in
   let to = (1w:address) in

--- a/semantics/prop/vyperTypeExtCallSoundnessScript.sml
+++ b/semantics/prop/vyperTypeExtCallSoundnessScript.sml
@@ -19,6 +19,8 @@ Ancestors
 Libs
   wordsLib markerLib intLib
 
+val _ = Parse.hide "from"
+
 Theorem transfer_value_zero[simp]:
   transfer_value from to 0 st = (INL (), st)
 Proof
@@ -221,7 +223,9 @@ Proof
       combinTheory.APPLY_UPDATE_THM] >>
   rpt strip_tac >> gvs[] >>
   rpt (IF_CASES_TAC >> gvs[]) >>
-  first_x_assum (qspec_then `addr` mp_tac) >> decide_tac
+  first_x_assum (qspec_then `addr` mp_tac) >>
+  simp[vfmStateTheory.update_account_def, combinTheory.APPLY_UPDATE_THM] >>
+  rpt (IF_CASES_TAC >> gvs[]) >> decide_tac
 QED
 
 Theorem transfer_value_runtime_consistent:

--- a/semantics/vyperInterpreterScript.sml
+++ b/semantics/vyperInterpreterScript.sml
@@ -35,7 +35,8 @@ val () = cv_auto_trans pop_function_def;
 (* helper for sending ether between accounts *)
 
 Definition transfer_value_def:
-  transfer_value fromAddr toAddr amount = do
+  transfer_value fromAddr toAddr amount =
+  if amount = 0 ∨ fromAddr = toAddr then return () else do
     acc <- get_accounts;
     sender <<- lookup_account fromAddr acc;
     check (amount <= sender.balance) "transfer_value amount";
@@ -49,7 +50,7 @@ End
 
 val () = transfer_value_def
   |> SRULE [FUN_EQ_THM, bind_def, ignore_bind_def,
-            LET_RATOR, update_accounts_def, o_DEF, C_DEF]
+            LET_RATOR, COND_RATOR, update_accounts_def, o_DEF, C_DEF]
   |> cv_auto_trans;
 
 (* machinery for calls to functions in a Vyper contract, and for internal calls

--- a/semantics/vyperInterpreterScript.sml
+++ b/semantics/vyperInterpreterScript.sml
@@ -1745,6 +1745,13 @@ Definition call_external_def:
        call_external_function am cx nr mut ts all_mods args dflts tx.args body ret
 End
 
+(* Vyper-level deployment abstraction.  The target address is supplied by the
+   transaction rather than derived using EVM CREATE/CREATE2 rules, and successful
+   deployment installs Vyper sources and exports rather than init/runtime
+   bytecode.  Creator/created-account nonce updates and bytecode installation
+   therefore belong to the future correspondence with Verifereum's EVM creation
+   semantics.  Constructor value transfer, however, is performed by
+   call_external_function and retained on success (or rolled back on failure). *)
 Definition load_contract_def:
   load_contract am tx mods exps =
   let addr = tx.target in
@@ -1762,7 +1769,5 @@ Definition load_contract_def:
                 with in_deploy := T in
        case call_external_function am cx nr mut ts mods args dflts tx.args body ret
          of (INR e, _) => INR e
-       (* TODO(semantic-limitation): deployment currently omits balance updates
-          on successful constructor return. *)
           | (_, am) => INL (am with sources updated_by CONS (addr, mods))
 End


### PR DESCRIPTION
## Summary

- make Vyper-level `transfer_value` return the state unchanged for zero-value and same-address transfers
- preserve the existing balance and recipient-overflow checks for distinct nonzero transfers
- add general simplification theorems for both no-op cases
- repair the affected framing, typing, soundness, and storage-preservation proofs
- remove the stale claim that successful deployment omits balance updates
- document the boundary between Vyper-level `load_contract` and Verifereum's EVM CREATE/CREATE2 semantics

Successful constructor value transfers already flow through `call_external_function`: updated accounts are retained on success, while failure returns the original abstract machine.

## Validation

- `holbuild --tactic-timeout 5 vyperSemanticsHolTheory`
- no CHEAT warnings

Closes #464.
